### PR TITLE
Fix broken links (Not all) && Chore(docs): add script to validate links

### DIFF
--- a/agents-docs/content/docs/overview.mdx
+++ b/agents-docs/content/docs/overview.mdx
@@ -76,7 +76,7 @@ The **Visual Builder and Agents SDK are fully interoperable**: your technical an
       <Card title="Remote Agents" icon="LuGlobe" href="/typescript-sdk/external-agent-configuration">
         Define remote agents that can be used in your graph.
       </Card>
-      <Card title="MCPs" icon="LuHammer" href="/typescript-sdk/mcp-servers">
+      <Card title="MCPs" icon="LuHammer" href="/typescript-sdk/tools-and-mcp-servers">
         Use pre-built MCP servers.
       </Card>
       <Card title="Credentials" icon="LuKey" href="/typescript-sdk/credentials">
@@ -88,7 +88,7 @@ The **Visual Builder and Agents SDK are fully interoperable**: your technical an
       <Card title="Context Fetchers" icon="LuCirclePlus" href="/typescript-sdk/context-fetchers">
         Dynamically retrieve and cache external data when agents need it.
       </Card>
-      <Card title="Artifact Components" icon="TbInputSpark" href="/typescript-sdk/artifacts">
+      <Card title="Artifact Components" icon="TbInputSpark" href="/typescript-sdk/artifact-components">
         Create structured outputs from tools or agents.
       </Card>
       <Card title="Status Updates" icon="LuClock" href="/typescript-sdk/status-updates">

--- a/agents-docs/content/docs/quick-start.mdx
+++ b/agents-docs/content/docs/quick-start.mdx
@@ -12,7 +12,7 @@ cd agents
 
 ### Step 2: Configure environment variables
 
-Add your `ANTHROPIC_API_KEY` to an `.env` file at `/agents-run-api`
+Add your `ANTHROPIC_API_KEY` to an `.env` file at `/agents-run-api/`
 ```
 ANTHROPIC_API_KEY=sk-ant-xyz789
 ```
@@ -29,7 +29,7 @@ pnpm --dir ./packages/agents-core db:push
 
 ### Step 5: Run the agent framework
 ```
-pnpm run dev
+pnpm dev
 ```
 
 ### Step 6: Start building! 

--- a/agents-docs/content/docs/quick-start.mdx
+++ b/agents-docs/content/docs/quick-start.mdx
@@ -12,7 +12,7 @@ cd agents
 
 ### Step 2: Configure environment variables
 
-Add your ANTHROPIC_API_KEY to an `.env` file at `/agents-run-api`
+Add your `ANTHROPIC_API_KEY` to an `.env` file at `/agents-run-api`
 ```
 ANTHROPIC_API_KEY=sk-ant-xyz789
 ```

--- a/agents-docs/content/docs/visual-builder/credentials.mdx
+++ b/agents-docs/content/docs/visual-builder/credentials.mdx
@@ -10,3 +10,5 @@ The credentials page allows you to add credentials to your MCP servers.
 <Snippet file="multi-agent-framework/add-a-credential.mdx" />
 
 To use the credential in an MCP server, you can reference it when creating the MCP server. See the [MCP Servers](/visual-builder/mcp-servers) page for more information.
+
+---

--- a/agents-docs/content/docs/visual-builder/data-components.mdx
+++ b/agents-docs/content/docs/visual-builder/data-components.mdx
@@ -12,3 +12,5 @@ description: Data components are used to add data to the graph.
 3. Click "Submit".
 
 To visually add the data component to the graph, see the [Graphs](/visual-builder/graphs#adding-data-components-to-the-graph) page for details.
+
+---

--- a/agents-docs/content/docs/visual-builder/mcp-servers.mdx
+++ b/agents-docs/content/docs/visual-builder/mcp-servers.mdx
@@ -11,3 +11,5 @@ description: MCP servers are used to add tools to the graph.
 4. Click "Create server".
 
 To visually add the MCP tool to the graph, see the [Graphs](/visual-builder/graphs#adding-tools-to-the-graph) page for details.
+
+---

--- a/agents-docs/package.json
+++ b/agents-docs/package.json
@@ -8,7 +8,8 @@
     "dev": "next dev -p 3010",
     "start": "next start",
     "postinstall": "fumadocs-mdx",
-    "generate-openapi": "node scripts/generate-openapi-docs.mjs"
+    "generate-openapi": "node scripts/generate-openapi-docs.mjs",
+    "validate-link": "node scripts/validate-link.mjs"
   },
   "dependencies": {
     "@inkeep/docskit": "^0.0.6",
@@ -51,6 +52,7 @@
     "@types/react-dom": "^19.1.6",
     "eslint": "^8",
     "eslint-config-next": "15.3.4",
+    "next-validate-link": "^1.5.2",
     "postcss": "^8.5.6",
     "tailwindcss": "^4.1.11",
     "typescript": "^5.8.3"

--- a/agents-docs/scripts/validate-link.mjs
+++ b/agents-docs/scripts/validate-link.mjs
@@ -1,0 +1,53 @@
+import { printErrors, readFiles, scanURLs, validateFiles } from 'next-validate-link';
+import { getSlugs, parseFilePath } from 'fumadocs-core/source';
+import { getTableOfContents } from 'fumadocs-core/server';
+import path from 'node:path';
+
+async function checkLinks() {
+  const docsFiles = await readFiles('content/docs/**/*.{md,mdx}');
+
+  // Build valid URLs manually from the slugs
+  const validUrls = {};
+
+  docsFiles.forEach((file) => {
+    const info = parseFilePath(path.relative('content/docs', file.path));
+    const slugs = getSlugs(info);
+    const url = `/${slugs.join('/')}`;
+    validUrls[url] = true;
+
+    const hashes = getTableOfContents(file.content).map((item) => item.url.slice(1));
+    hashes.forEach((hash) => {
+      if (hash) {
+        validUrls[`${url}#${hash}`] = true;
+      }
+    });
+  });
+
+  const scanned = await scanURLs({
+    populate: {
+      '[[...slug]]': docsFiles.map((file) => {
+        const info = parseFilePath(path.relative('content/docs', file.path));
+        return {
+          value: getSlugs(info),
+          hashes: getTableOfContents(file.content).map((item) => item.url.slice(1)),
+        };
+      }),
+    },
+  });
+
+  // Merge our manually built URLs with the scanned ones
+  if (scanned.urls) {
+    Object.assign(scanned.urls, validUrls);
+  } else {
+    scanned.urls = validUrls;
+  }
+
+  const standardErrors = await validateFiles([...docsFiles], {
+    scanned,
+    strict: true,
+  });
+
+  printErrors(standardErrors, true);
+}
+
+void checkLinks();

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -218,6 +218,9 @@ importers:
       eslint-config-next:
         specifier: 15.3.4
         version: 15.3.4(eslint@8.57.1)(typescript@5.9.2)
+      next-validate-link:
+        specifier: ^1.5.2
+        version: 1.5.2
       postcss:
         specifier: ^8.5.6
         version: 8.5.6
@@ -7202,6 +7205,9 @@ packages:
     peerDependencies:
       react: ^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc
       react-dom: ^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc
+
+  next-validate-link@1.5.2:
+    resolution: {integrity: sha512-BMGyo0qJqscSJw0gSCUy3gDrF7LEID6qkVhHtLSIdPPtOYONq0+fidWvLteUzEUqHeKz1GBI9QN3bpfT6Me42A==}
 
   next@15.4.7:
     resolution: {integrity: sha512-OcqRugwF7n7mC8OSYjvsZhhG1AYSvulor1EIUsIkbbEbf1qoE5EbH36Swj8WhF4cHqmDgkiam3z1c1W0J1Wifg==}
@@ -16524,6 +16530,17 @@ snapshots:
     dependencies:
       react: 19.1.1
       react-dom: 19.1.1(react@19.1.1)
+
+  next-validate-link@1.5.2:
+    dependencies:
+      fast-glob: 3.3.3
+      gray-matter: 4.0.3
+      picocolors: 1.1.1
+      remark: 15.0.1
+      remark-gfm: 4.0.1
+      unist-util-visit: 5.0.0
+    transitivePeerDependencies:
+      - supports-color
 
   next@15.4.7(@opentelemetry/api@1.9.0)(react-dom@19.1.1(react@19.1.1))(react@19.1.1):
     dependencies:


### PR DESCRIPTION
Does two things :

1. Fixes the broken hrefs to a few pages on the [overview](https://docs.inkeep.com/overview) page.

2. Adds line to indicate end of the doc in some files. In a few pages (like [this](https://docs.inkeep.com/visual-builder/mcp-servers) and [this](https://docs.inkeep.com/visual-builder/credentials)) there's a gap till the bottom page nav, which makes it look like there's something that's supposed to be rendered at that empty space, hopefully a line would indicated that it was indeed all there was.