### PR TITLE
test: Fix dataChat test logger mock for CI compatibility

### DIFF
--- a/agents-run-api/src/__tests__/routes/chat/dataChat.test.ts
+++ b/agents-run-api/src/__tests__/routes/chat/dataChat.test.ts
@@ -18,6 +18,23 @@ vi.mock('../../../logger.js', () => {
   };
 });
 
+// Mock the logger without .js extension as well (in case of different import styles)
+vi.mock('../../../logger', () => {
+  const mockLogger = {
+    info: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+    warn: vi.fn(),
+    child: vi.fn(),
+  };
+  // Make child return itself for chaining
+  mockLogger.child.mockReturnValue(mockLogger);
+  
+  return {
+    getLogger: () => mockLogger,
+  };
+});
+
 import { createAgent, createAgentGraph } from '@inkeep/agents-core';
 import dbClient from '../../../data/db/dbClient';
 import * as execModule from '../../../handlers/executionHandler';


### PR DESCRIPTION
## Summary

This PR fixes the failing dataChat.test.ts test in CI by adding an additional logger mock.

## Problem

The test was failing in CI with:
```
TypeError: Cannot read properties of undefined (reading 'error')
at _OpenAPIHono.errorHandler src/app.ts:157:19
```

This occurs when the app's error handler tries to call `getLogger().error` but the logger mock isn't properly applied.

## Solution

Add an additional logger mock without the `.js` extension to handle different import styles:
- `../../../logger.js` (original mock)
- `../../../logger` (additional mock)

This ensures the logger is properly mocked regardless of how it's imported in the module chain.

## Test Results

✅ All tests pass locally:
- 255 tests passing
- 4 tests skipped (from previous PR)
- 0 failures

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>