### PR TITLE
feat: add view graph link to CLI push command output

### DIFF
--- a/agents-cli/src/__tests__/commands/push.test.ts
+++ b/agents-cli/src/__tests__/commands/push.test.ts
@@ -1,9 +1,10 @@
-import { describe, it, expect, beforeEach, vi, Mock } from 'vitest';
+import { describe, it, expect, beforeEach, vi, Mock, afterEach } from 'vitest';
 import { pushCommand } from '../../commands/push';
 import * as core from '@inkeep/agents-core';
 import inquirer from 'inquirer';
 import chalk from 'chalk';
 import { existsSync } from 'node:fs';
+import { importWithTypeScriptSupport } from '../../utils/tsx-loader';
 
 // Mock all external dependencies
 vi.mock('node:fs');
@@ -30,7 +31,7 @@ vi.mock('ora', () => ({
 }));
 vi.mock('../../api.js', () => ({
   ManagementApiClient: {
-    create: vi.fn().mockResolvedValue({}),
+    create: vi.fn(),
   },
 }));
 vi.mock('../../utils/config.js', () => ({
@@ -46,6 +47,10 @@ vi.mock('../../utils/config.js', () => ({
   }),
 }));
 
+vi.mock('../../utils/tsx-loader.js', () => ({
+  importWithTypeScriptSupport: vi.fn(),
+}));
+
 describe('Push Command - Project Validation', () => {
   let mockDbClient: any;
   let mockGetProject: Mock;
@@ -55,6 +60,9 @@ describe('Push Command - Project Validation', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    
+    // Ensure tsx-loader is not mocked for these tests
+    (importWithTypeScriptSupport as Mock).mockReset();
 
     // Setup database client mock
     mockDbClient = {};
@@ -105,7 +113,7 @@ describe('Push Command - Project Validation', () => {
     };
 
     vi.doMock('/test/path/graph.js', () => ({
-      default: mockGraph,
+      graph: mockGraph,
     }));
 
     // Run in TypeScript mode (skip tsx spawn)
@@ -155,7 +163,7 @@ describe('Push Command - Project Validation', () => {
     };
 
     vi.doMock('/test/path/graph.js', () => ({
-      default: mockGraph,
+      graph: mockGraph,
     }));
 
     process.env.TSX_RUNNING = '1';
@@ -205,7 +213,7 @@ describe('Push Command - Project Validation', () => {
     };
 
     vi.doMock('/test/path/graph.js', () => ({
-      default: mockGraph,
+      graph: mockGraph,
     }));
 
     process.env.TSX_RUNNING = '1';
@@ -268,7 +276,7 @@ describe('Push Command - Project Validation', () => {
     };
 
     vi.doMock('/test/path/graph.js', () => ({
-      default: mockGraph,
+      graph: mockGraph,
     }));
 
     process.env.TSX_RUNNING = '1';
@@ -305,7 +313,7 @@ describe('Push Command - Project Validation', () => {
     };
 
     vi.doMock('/test/path/graph.js', () => ({
-      default: mockGraph,
+      graph: mockGraph,
     }));
 
     process.env.TSX_RUNNING = '1';
@@ -315,6 +323,299 @@ describe('Push Command - Project Validation', () => {
     // Verify default database URL was used
     expect(core.createDatabaseClient).toHaveBeenCalledWith({
       url: expect.stringContaining('local.db'),
+    });
+  });
+});
+
+describe('Push Command - UI Link Generation', () => {
+  let mockDbClient: any;
+  let mockGetProject: Mock;
+  let mockCreateProject: Mock;
+  let mockExit: Mock;
+  let mockLog: Mock;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    
+    // Reset the tsx-loader mock
+    (importWithTypeScriptSupport as Mock).mockReset();
+
+    // Reset environment
+    delete process.env.DB_FILE_NAME;
+    delete process.env.TSX_RUNNING;
+
+    // Mock database client
+    mockDbClient = {
+      selectFrom: vi.fn().mockReturnThis(),
+      select: vi.fn().mockReturnThis(),
+      where: vi.fn().mockReturnThis(),
+      execute: vi.fn().mockResolvedValue([]),
+      insertInto: vi.fn().mockReturnThis(),
+      values: vi.fn().mockReturnThis(),
+      returning: vi.fn().mockReturnThis(),
+      executeTakeFirst: vi.fn().mockResolvedValue({ id: 'test-id' }),
+      onConflict: vi.fn().mockReturnThis(),
+      doUpdate: vi.fn().mockReturnThis(),
+      set: vi.fn().mockReturnThis(),
+    };
+
+    // Mock core functions
+    mockGetProject = vi.fn().mockResolvedValue({ id: 'test-project', name: 'Test Project' });
+    mockCreateProject = vi.fn().mockResolvedValue({ id: 'test-project', name: 'Test Project' });
+
+    (core.createDatabaseClient as Mock).mockReturnValue(mockDbClient);
+    (core.getProject as Mock) = mockGetProject;
+    (core.createProject as Mock) = mockCreateProject;
+
+    // Mock existsSync to return true
+    (existsSync as Mock).mockReturnValue(true);
+
+    // Mock process.exit to throw an error instead of actually exiting
+    mockExit = vi.fn((code) => {
+      throw new Error(`Process exited with code ${code}`);
+    });
+    process.exit = mockExit as any;
+
+    // Mock console methods
+    mockLog = vi.fn();
+    console.log = mockLog;
+    const mockError = vi.fn();
+    console.error = mockError;
+    console.debug = vi.fn();
+    
+    // Mock ManagementApiClient with default successful push
+    const { ManagementApiClient } = await import('../../api.js');
+    const mockApi = {
+      pushGraph: vi.fn().mockResolvedValue({
+        id: 'test-graph-id',
+        name: 'Test Graph',
+        agents: [],
+        tools: [],
+        relations: [],
+      }),
+    };
+    (ManagementApiClient.create as Mock).mockResolvedValue(mockApi);
+  });
+
+  it('should display UI link with custom manageUiUrl', async () => {
+    // Mock validation to include manageUiUrl
+    const { validateConfiguration } = await import('../../utils/config.js');
+    (validateConfiguration as Mock).mockResolvedValue({
+      tenantId: 'test-tenant',
+      projectId: 'test-project',
+      managementApiUrl: 'http://localhost:3002',
+      manageUiUrl: 'https://app.example.com',
+      sources: {
+        tenantId: 'config',
+        projectId: 'config',
+        managementApiUrl: 'config',
+      },
+    });
+
+    // Mock graph with required methods and id
+    const mockGraph = {
+      id: 'test-graph-id',  // Add graph ID
+      init: vi.fn().mockResolvedValue(undefined),
+      getStats: vi.fn().mockReturnValue({
+        agentCount: 2,
+        toolCount: 1,
+        relationCount: 1,
+      }),
+      getDefaultAgent: vi.fn().mockReturnValue(null),
+      setConfig: vi.fn(),
+    };
+
+    // Mock the tsx-loader to return our graph
+    const { importWithTypeScriptSupport } = await import('../../utils/tsx-loader.js');
+    (importWithTypeScriptSupport as Mock).mockResolvedValue({
+      graph: mockGraph,
+    });
+
+    process.env.TSX_RUNNING = '1';
+
+    try {
+      await pushCommand('/test/path/graph.js', {});
+      // Should not reach here since process.exit is called
+      expect.fail('Should have exited');
+    } catch (error: any) {
+      // Just verify it exited - we'll check the logs regardless
+      expect(error.message).toMatch(/Process exited with code/);
+    }
+
+    // Verify the UI link is displayed with correct URL
+    expect(mockLog).toHaveBeenCalledWith(
+      expect.stringContaining('View graph in UI:')
+    );
+    expect(mockLog).toHaveBeenCalledWith(
+      expect.stringContaining('https://app.example.com/test-tenant/projects/test-project/graphs/test-graph-id')
+    );
+  });
+
+  it('should display UI link with default URL when manageUiUrl is not provided', async () => {
+    // Mock validation without manageUiUrl
+    const { validateConfiguration } = await import('../../utils/config.js');
+    (validateConfiguration as Mock).mockResolvedValue({
+      tenantId: 'test-tenant',
+      projectId: 'test-project',
+      managementApiUrl: 'http://localhost:3002',
+      manageUiUrl: undefined,
+      sources: {
+        tenantId: 'config',
+        projectId: 'config',
+        managementApiUrl: 'config',
+      },
+    });
+
+    // Mock graph with required methods and id
+    const mockGraph = {
+      id: 'test-graph-id',
+      init: vi.fn().mockResolvedValue(undefined),
+      getStats: vi.fn().mockReturnValue({
+        agentCount: 2,
+        toolCount: 1,
+        relationCount: 1,
+      }),
+      getDefaultAgent: vi.fn().mockReturnValue(null),
+      setConfig: vi.fn(),
+    };
+
+    // Mock the tsx-loader to return our graph
+    const { importWithTypeScriptSupport } = await import('../../utils/tsx-loader.js');
+    (importWithTypeScriptSupport as Mock).mockResolvedValue({
+      graph: mockGraph,
+    });
+
+    process.env.TSX_RUNNING = '1';
+
+    try {
+      await pushCommand('/test/path/graph.js', {});
+      expect.fail('Should have exited');
+    } catch (error: any) {
+      expect(error.message).toMatch(/Process exited with code/);
+    }
+
+    // Verify the UI link is displayed with default URL
+    expect(mockLog).toHaveBeenCalledWith(
+      expect.stringContaining('View graph in UI:')
+    );
+    expect(mockLog).toHaveBeenCalledWith(
+      expect.stringContaining('http://localhost:3000/test-tenant/projects/test-project/graphs/test-graph-id')
+    );
+  });
+
+  it('should handle invalid manageUiUrl gracefully', async () => {
+    // Mock validation with invalid manageUiUrl
+    const { validateConfiguration } = await import('../../utils/config.js');
+    (validateConfiguration as Mock).mockResolvedValue({
+      tenantId: 'test-tenant',
+      projectId: 'test-project',
+      managementApiUrl: 'http://localhost:3002',
+      manageUiUrl: 'not-a-valid-url',
+      sources: {
+        tenantId: 'config',
+        projectId: 'config',
+        managementApiUrl: 'config',
+      },
+    });
+
+    // Mock graph with required methods and id
+    const mockGraph = {
+      id: 'test-graph-id',
+      init: vi.fn().mockResolvedValue(undefined),
+      getStats: vi.fn().mockReturnValue({
+        agentCount: 2,
+        toolCount: 1,
+        relationCount: 1,
+      }),
+      getDefaultAgent: vi.fn().mockReturnValue(null),
+      setConfig: vi.fn(),
+    };
+
+    // Mock the tsx-loader to return our graph
+    const { importWithTypeScriptSupport } = await import('../../utils/tsx-loader.js');
+    (importWithTypeScriptSupport as Mock).mockResolvedValue({
+      graph: mockGraph,
+    });
+
+    process.env.TSX_RUNNING = '1';
+
+    try {
+      await pushCommand('/test/path/graph.js', {});
+      expect.fail('Should have exited');
+    } catch (error: any) {
+      expect(error.message).toMatch(/Process exited with code/);
+    }
+    
+    // The UI link line should not be displayed
+    const viewGraphCalls = mockLog.mock.calls.filter((call: any[]) => 
+      call.some((arg: any) => typeof arg === 'string' && arg.includes('View graph in UI'))
+    );
+    expect(viewGraphCalls.length).toBe(0);
+    
+    // Debug log should have been called
+    expect(console.debug).toHaveBeenCalledWith('Could not generate UI link:', expect.any(Error));
+  });
+
+  it('should normalize trailing slashes in manageUiUrl', async () => {
+    // Mock validation with manageUiUrl having trailing slashes
+    const { validateConfiguration } = await import('../../utils/config.js');
+    (validateConfiguration as Mock).mockResolvedValue({
+      tenantId: 'test-tenant',
+      projectId: 'test-project',
+      managementApiUrl: 'http://localhost:3002',
+      manageUiUrl: 'https://app.example.com///',
+      sources: {
+        tenantId: 'config',
+        projectId: 'config',
+        managementApiUrl: 'config',
+      },
+    });
+
+    // Mock graph with required methods and id
+    const mockGraph = {
+      id: 'test-graph-id',
+      init: vi.fn().mockResolvedValue(undefined),
+      getStats: vi.fn().mockReturnValue({
+        agentCount: 2,
+        toolCount: 1,
+        relationCount: 1,
+      }),
+      getDefaultAgent: vi.fn().mockReturnValue(null),
+      setConfig: vi.fn(),
+    };
+
+    // Mock the tsx-loader to return our graph
+    const { importWithTypeScriptSupport } = await import('../../utils/tsx-loader.js');
+    (importWithTypeScriptSupport as Mock).mockResolvedValue({
+      graph: mockGraph,
+    });
+
+    process.env.TSX_RUNNING = '1';
+
+    try {
+      await pushCommand('/test/path/graph.js', {});
+      expect.fail('Should have exited');
+    } catch (error: any) {
+      expect(error.message).toMatch(/Process exited with code/);
+    }
+
+    // Verify the UI link is displayed with normalized URL (no trailing slashes)
+    expect(mockLog).toHaveBeenCalledWith(
+      expect.stringContaining('View graph in UI:')
+    );
+    expect(mockLog).toHaveBeenCalledWith(
+      expect.stringContaining('https://app.example.com/test-tenant/projects/test-project/graphs/test-graph-id')
+    );
+    // Ensure no double slashes after the domain
+    const urlCalls = mockLog.mock.calls.filter((call: any[]) => 
+      call.some((arg: any) => typeof arg === 'string' && arg.includes('https://app.example.com'))
+    );
+    urlCalls.forEach((call: any[]) => {
+      call.forEach((arg: any) => {
+        if (typeof arg === 'string' && arg.includes('https://app.example.com')) {
+          expect(arg).not.toContain('https://app.example.com//');
+        }
+      });
     });
   });
 });

--- a/agents-cli/src/commands/push.ts
+++ b/agents-cli/src/commands/push.ts
@@ -275,6 +275,12 @@ export async function pushCommand(graphPath: string, options: PushOptions) {
 
     // Provide next steps
     console.log(chalk.green('\n✨ Next steps:'));
+
+    // Add view graph link if manageUiUrl is available
+    const manageUiUrl = config.manageUiUrl || 'http://localhost:3000';
+    const viewGraphUrl = `${manageUiUrl}/${tenantId}/projects/${projectId}/graphs/${graphId}`;
+    console.log(chalk.gray(`  • View graph in UI: ${chalk.cyan(viewGraphUrl)}`));
+
     console.log(chalk.gray(`  • Test your graph: inkeep chat ${graphId}`));
     console.log(chalk.gray(`  • View all graphs: inkeep list-graphs`));
     console.log(chalk.gray(`  • Get graph details: inkeep get-graph ${graphId}`));

--- a/agents-cli/src/commands/push.ts
+++ b/agents-cli/src/commands/push.ts
@@ -7,6 +7,7 @@ import ora from 'ora';
 import { ManagementApiClient } from '../api';
 import { validateConfiguration } from '../utils/config';
 import { importWithTypeScriptSupport } from '../utils/tsx-loader';
+import { buildGraphViewUrl } from '../utils/url';
 
 export interface PushOptions {
   tenantId?: string;
@@ -277,9 +278,13 @@ export async function pushCommand(graphPath: string, options: PushOptions) {
     console.log(chalk.green('\n✨ Next steps:'));
 
     // Add view graph link if manageUiUrl is available
-    const manageUiUrl = config.manageUiUrl || 'http://localhost:3000';
-    const viewGraphUrl = `${manageUiUrl}/${tenantId}/projects/${projectId}/graphs/${graphId}`;
-    console.log(chalk.gray(`  • View graph in UI: ${chalk.cyan(viewGraphUrl)}`));
+    try {
+      const viewGraphUrl = buildGraphViewUrl(config.manageUiUrl, tenantId, projectId, graphId);
+      console.log(chalk.gray(`  • View graph in UI: ${chalk.cyan(viewGraphUrl)}`));
+    } catch (error) {
+      // If URL construction fails, just skip displaying the link
+      console.debug('Could not generate UI link:', error);
+    }
 
     console.log(chalk.gray(`  • Test your graph: inkeep chat ${graphId}`));
     console.log(chalk.gray(`  • View all graphs: inkeep list-graphs`));

--- a/agents-cli/src/config.ts
+++ b/agents-cli/src/config.ts
@@ -5,6 +5,8 @@ export interface InkeepConfig {
   projectId: string;
   managementApiUrl: string;
   executionApiUrl: string;
+  manageUiUrl?: string;
+  outputDirectory?: string;
   modelSettings?: ModelSettings;
 }
 

--- a/agents-cli/src/utils/__tests__/url.test.ts
+++ b/agents-cli/src/utils/__tests__/url.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect } from 'vitest';
+import { normalizeBaseUrl, buildGraphViewUrl } from '../url';
+
+describe('normalizeBaseUrl', () => {
+  it('should remove trailing slashes', () => {
+    expect(normalizeBaseUrl('http://localhost:3000/')).toBe('http://localhost:3000');
+    expect(normalizeBaseUrl('http://localhost:3000//')).toBe('http://localhost:3000');
+    expect(normalizeBaseUrl('http://localhost:3000///')).toBe('http://localhost:3000');
+  });
+
+  it('should preserve URLs without trailing slashes', () => {
+    expect(normalizeBaseUrl('http://localhost:3000')).toBe('http://localhost:3000');
+    expect(normalizeBaseUrl('https://example.com')).toBe('https://example.com');
+  });
+
+  it('should handle URLs with paths', () => {
+    expect(normalizeBaseUrl('http://localhost:3000/app/')).toBe('http://localhost:3000/app');
+    expect(normalizeBaseUrl('https://example.com/dashboard/')).toBe('https://example.com/dashboard');
+  });
+
+  it('should trim whitespace', () => {
+    expect(normalizeBaseUrl('  http://localhost:3000  ')).toBe('http://localhost:3000');
+    expect(normalizeBaseUrl('\thttp://localhost:3000/\n')).toBe('http://localhost:3000');
+  });
+
+  it('should validate URL format', () => {
+    expect(() => normalizeBaseUrl('localhost:3000')).toThrow('Invalid URL format');
+    expect(() => normalizeBaseUrl('not-a-url')).toThrow('Invalid URL format');
+    expect(() => normalizeBaseUrl('ftp://localhost')).toThrow('Invalid URL format');
+    expect(() => normalizeBaseUrl('')).toThrow('Invalid URL format');
+  });
+
+  it('should accept both http and https protocols', () => {
+    expect(normalizeBaseUrl('http://localhost:3000')).toBe('http://localhost:3000');
+    expect(normalizeBaseUrl('https://localhost:3000')).toBe('https://localhost:3000');
+    expect(normalizeBaseUrl('HTTP://localhost:3000')).toBe('HTTP://localhost:3000');
+    expect(normalizeBaseUrl('HTTPS://localhost:3000')).toBe('HTTPS://localhost:3000');
+  });
+});
+
+describe('buildGraphViewUrl', () => {
+  const tenantId = 'test-tenant';
+  const projectId = 'test-project';
+  const graphId = 'test-graph';
+
+  it('should build correct URL with provided base URL', () => {
+    const result = buildGraphViewUrl('http://localhost:3000', tenantId, projectId, graphId);
+    expect(result).toBe('http://localhost:3000/test-tenant/projects/test-project/graphs/test-graph');
+  });
+
+  it('should use default URL when manageUiUrl is undefined', () => {
+    const result = buildGraphViewUrl(undefined, tenantId, projectId, graphId);
+    expect(result).toBe('http://localhost:3000/test-tenant/projects/test-project/graphs/test-graph');
+  });
+
+  it('should handle trailing slashes in base URL', () => {
+    const result = buildGraphViewUrl('http://localhost:3000/', tenantId, projectId, graphId);
+    expect(result).toBe('http://localhost:3000/test-tenant/projects/test-project/graphs/test-graph');
+  });
+
+  it('should handle URLs with existing paths', () => {
+    const result = buildGraphViewUrl('https://app.example.com/dashboard/', tenantId, projectId, graphId);
+    expect(result).toBe('https://app.example.com/dashboard/test-tenant/projects/test-project/graphs/test-graph');
+  });
+
+  it('should handle special characters in IDs', () => {
+    const result = buildGraphViewUrl(
+      'http://localhost:3000',
+      'tenant-123',
+      'project_456',
+      'graph.with.dots'
+    );
+    expect(result).toBe('http://localhost:3000/tenant-123/projects/project_456/graphs/graph.with.dots');
+  });
+
+  it('should throw error for invalid base URL', () => {
+    expect(() => buildGraphViewUrl('not-a-url', tenantId, projectId, graphId)).toThrow('Invalid URL format');
+  });
+
+  it('should handle production URLs', () => {
+    const result = buildGraphViewUrl(
+      'https://manage.inkeep.com',
+      'prod-tenant',
+      'prod-project',
+      'prod-graph'
+    );
+    expect(result).toBe('https://manage.inkeep.com/prod-tenant/projects/prod-project/graphs/prod-graph');
+  });
+});

--- a/agents-cli/src/utils/config.ts
+++ b/agents-cli/src/utils/config.ts
@@ -12,6 +12,8 @@ export interface InkeepConfig {
   projectId?: string;
   managementApiUrl?: string;
   executionApiUrl?: string;
+  manageUiUrl?: string;
+  outputDirectory?: string;
   modelSettings?: ModelSettings;
 }
 
@@ -20,6 +22,8 @@ export interface ValidatedConfiguration {
   projectId: string;
   managementApiUrl: string;
   executionApiUrl: string;
+  manageUiUrl?: string;
+  outputDirectory?: string;
   modelSettings?: ModelSettings;
   sources: {
     tenantId: string;
@@ -98,6 +102,7 @@ export async function loadConfig(configPath?: string): Promise<InkeepConfig> {
   const config: InkeepConfig = {
     managementApiUrl: 'http://localhost:3002',
     executionApiUrl: 'http://localhost:3003',
+    manageUiUrl: 'http://localhost:3000',
   };
 
   // Try to load from inkeep.config.ts or specified config file
@@ -229,6 +234,7 @@ export async function validateConfiguration(
       projectId,
       managementApiUrl,
       executionApiUrl,
+      manageUiUrl: config.manageUiUrl,
       modelSettings: config.modelSettings || undefined,
       sources,
     };
@@ -247,6 +253,7 @@ export async function validateConfiguration(
       projectId: 'default',
       managementApiUrl: managementApiUrlFlag,
       executionApiUrl: executionApiUrlFlag,
+      manageUiUrl: undefined,
       modelSettings: undefined,
       sources,
     };
@@ -344,6 +351,7 @@ export async function validateConfiguration(
     projectId,
     managementApiUrl,
     executionApiUrl,
+    manageUiUrl: config.manageUiUrl,
     modelSettings: config.modelSettings || undefined,
     sources,
   };

--- a/agents-cli/src/utils/url.ts
+++ b/agents-cli/src/utils/url.ts
@@ -1,0 +1,36 @@
+/**
+ * Normalizes a base URL by removing trailing slashes and validating format
+ * @param url The URL to normalize
+ * @returns The normalized URL
+ * @throws Error if URL is invalid
+ */
+export function normalizeBaseUrl(url: string): string {
+  // Trim whitespace
+  const trimmedUrl = url.trim();
+  
+  // Basic URL validation - must start with http:// or https://
+  if (!trimmedUrl.match(/^https?:\/\//i)) {
+    throw new Error(`Invalid URL format: ${url}. Must start with http:// or https://`);
+  }
+  
+  // Remove trailing slash(es)
+  return trimmedUrl.replace(/\/+$/, '');
+}
+
+/**
+ * Constructs a graph view URL for the management UI
+ * @param manageUiUrl The base management UI URL
+ * @param tenantId The tenant ID
+ * @param projectId The project ID
+ * @param graphId The graph ID
+ * @returns The complete graph view URL
+ */
+export function buildGraphViewUrl(
+  manageUiUrl: string | undefined,
+  tenantId: string,
+  projectId: string,
+  graphId: string
+): string {
+  const baseUrl = normalizeBaseUrl(manageUiUrl || 'http://localhost:3000');
+  return `${baseUrl}/${tenantId}/projects/${projectId}/graphs/${graphId}`;
+}


### PR DESCRIPTION
## Summary
- Added a direct link to the manage-ui graph page in the CLI push command output
- Makes it easier for users to navigate to their newly pushed graph in the UI

## Changes
- Added optional `manageUiUrl` field to `InkeepConfig` interface
- Updated config validation to pass through `manageUiUrl` 
- Modified push command to generate and display the view graph link after successful push
- Defaults to `http://localhost:3000` if `manageUiUrl` not specified in config

## Example Output
After pushing a graph, users will now see:
```
✨ Next steps:
  • View graph in UI: http://localhost:3000/inkeep/my-project/graphs/my-graph-id
  • Test your graph: inkeep chat my-graph-id
  • View all graphs: inkeep list-graphs
  • Get graph details: inkeep get-graph my-graph-id
```

The link is displayed in cyan for better visibility and can be easily copied to navigate directly to the graph.

🤖 Generated with [Claude Code](https://claude.ai/code)