### PR TITLE
feat: centralize database management at monorepo root

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,15 +6,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ```bash
 # Setup and installation
-cd agents-manage-api
-pnpm install
-
-cd agents-run-api
-pnpm install
-
-cd packages/agents-core
-pnpm install
-pnpm db:push
+pnpm install         # Install all dependencies for monorepo
 
 # Development workflow
 pnpm dev              # Start development server (port 3002)
@@ -24,14 +16,19 @@ pnpm build           # Build for production
 pnpm lint            # Run Biome linter
 pnpm format          # Format code with Biome
 
+# Database operations (run from monorepo root)
+pnpm db:generate     # Generate Drizzle migrations
+pnpm db:push         # Push schema changes to SQLite (shared database at ./local.db)
+pnpm db:migrate      # Run database migrations
+pnpm db:studio       # Open Drizzle Studio for database inspection
+pnpm db:clean        # Clean database
+pnpm db:check        # Check database schema
+pnpm db:reset-schema # Reset database schema
+
 # Running examples (from the examples directory)
 # Note: Use the globally installed inkeep CLI, not npx
 inkeep push agent-configurations/graph.graph.ts
 inkeep chat
-
-# Database operations ( run from packages/agents-core )
-pnpm db:push         # Push schema changes to SQLite
-pnpm db:studio       # Open Drizzle Studio for database inspection
 
 # Documentation development (from agents-docs directory)
 pnpm dev              # Start documentation site (port 3000)
@@ -52,6 +49,7 @@ This is the **Inkeep Agent Framework** - a multi-agent AI system with A2A (Agent
 - **Context Preservation**: Conversation state maintained across agent transitions
 
 #### Database Schema (SQLite + Drizzle ORM)
+- **Shared Database**: Single SQLite database (`./local.db`) at monorepo root shared by both APIs
 - **agents**: Individual AI agents with instructions and capabilities
 - **agent_graphs**: Collections of agents with default entry points  
 - **agent_relations**: Transfer (`complete control transfer`) and delegation (`task assignment with return`) relationships

--- a/package.json
+++ b/package.json
@@ -33,7 +33,14 @@
     "clean:turbo": "turbo clean",
     "prepare": "husky",
     "release": "changeset publish",
-    "release-dev": "changeset version --snapshot dev && changeset publish --tag dev"
+    "release-dev": "changeset version --snapshot dev && changeset publish --tag dev",
+    "db:generate": "pnpm --filter @inkeep/agents-core db:generate",
+    "db:push": "pnpm --filter @inkeep/agents-core db:push",
+    "db:migrate": "pnpm --filter @inkeep/agents-core db:migrate",
+    "db:studio": "pnpm --filter @inkeep/agents-core db:studio",
+    "db:clean": "pnpm --filter @inkeep/agents-core db:clean",
+    "db:check": "pnpm --filter @inkeep/agents-core db:check",
+    "db:reset-schema": "pnpm --filter @inkeep/agents-core db:reset-schema"
   },
   "version": "0.1.0",
   "dependencies": {

--- a/turbo.json
+++ b/turbo.json
@@ -72,12 +72,29 @@
       "inputs": ["$TURBO_DEFAULT$"],
       "outputs": []
     },
+    "db:generate": {
+      "cache": false,
+      "inputs": ["drizzle.config.ts", "src/db/schema.ts"],
+      "outputs": ["drizzle/**"]
+    },
     "db:push": {
       "cache": false,
-      "inputs": ["drizzle.config.ts", "src/data/db/schema.ts"]
+      "inputs": ["drizzle.config.ts", "src/db/schema.ts"]
+    },
+    "db:migrate": {
+      "cache": false,
+      "inputs": ["drizzle/**", "src/db/schema.ts"]
+    },
+    "db:studio": {
+      "cache": false,
+      "persistent": true
     },
     "db:clean": {
       "cache": false
+    },
+    "db:check": {
+      "cache": false,
+      "inputs": ["drizzle.config.ts", "src/db/schema.ts"]
     },
     "db:reset-schema": {
       "cache": false,


### PR DESCRIPTION
## Summary
- Centralized database management commands at the monorepo root level for better discoverability
- Created a shared SQLite database file that both APIs can use
- Updated documentation to reflect the new architecture

## Changes
- Added all `db:*` scripts to root `package.json` that proxy to `@inkeep/agents-core`
- Added missing database tasks to `turbo.json` (db:generate, db:migrate, db:studio, db:check)
- Created shared `local.db` at monorepo root (both APIs now share the same database)
- Updated CLAUDE.md documentation to reflect centralized database operations

## Benefits
- ✅ Single source of truth for database
- ✅ Easier discovery of database commands at root level
- ✅ Shared data between manage and run APIs as intended
- ✅ Cleaner monorepo structure with centralized database management

## Test plan
- [x] Verified all db commands work from root (`pnpm db:studio`, `pnpm db:check`)
- [x] Confirmed both APIs can connect to shared database
- [x] Documentation updated

🤖 Generated with [Claude Code](https://claude.ai/code)