### PR TITLE
fix: PRD-4838 - Enable save button when removing self-reference relationships

### DIFF
--- a/agents-manage-ui/src/components/graph/sidepane/edges/edge-editor.tsx
+++ b/agents-manage-ui/src/components/graph/sidepane/edges/edge-editor.tsx
@@ -91,7 +91,7 @@ function EdgeEditor({ selectedEdge }: EdgeEditorProps) {
 	const handleCheckboxChange = (id: string, checked: boolean) => {
 		// Calculate the new relationships state
 		let newRelationships: A2AEdgeData["relationships"];
-		
+
 		if (isSelfLoop) {
 			// For self-loops, when we toggle the checkbox, we should set both directions
 			// to maintain consistency (a self-loop is inherently bidirectional)
@@ -115,11 +115,14 @@ function EdgeEditor({ selectedEdge }: EdgeEditorProps) {
 		}
 
 		// Check if all relationships are now unchecked
-		const hasAnyRelationship = 
+		const hasAnyRelationship =
 			newRelationships.transferSourceToTarget ||
 			newRelationships.transferTargetToSource ||
 			newRelationships.delegateSourceToTarget ||
 			newRelationships.delegateTargetToSource;
+
+		// Always mark as unsaved when relationships change
+		markUnsaved();
 
 		if (!hasAnyRelationship) {
 			// Remove the edge if no relationships remain
@@ -130,8 +133,6 @@ function EdgeEditor({ selectedEdge }: EdgeEditorProps) {
 				relationships: newRelationships,
 			});
 		}
-		
-		markUnsaved();
 	};
 
 	const transferOptions = isSelfLoop
@@ -140,7 +141,7 @@ function EdgeEditor({ selectedEdge }: EdgeEditorProps) {
 					id: "transferSourceToTarget",
 					label: `${sourceNode?.data.name} can transfer to itself`,
 				},
-		  ]
+			]
 		: [
 				{
 					id: "transferSourceToTarget",
@@ -150,7 +151,7 @@ function EdgeEditor({ selectedEdge }: EdgeEditorProps) {
 					id: "transferTargetToSource",
 					label: `${targetNode?.data.name} can transfer to ${sourceNode?.data.name}`,
 				},
-		  ];
+			];
 
 	const delegateOptions = isSelfLoop
 		? [
@@ -158,7 +159,7 @@ function EdgeEditor({ selectedEdge }: EdgeEditorProps) {
 					id: "delegateSourceToTarget",
 					label: `${sourceNode?.data.name} can delegate to itself`,
 				},
-		  ]
+			]
 		: [
 				{
 					id: "delegateSourceToTarget",
@@ -168,7 +169,7 @@ function EdgeEditor({ selectedEdge }: EdgeEditorProps) {
 					id: "delegateTargetToSource",
 					label: `${targetNode?.data.name} can delegate to ${sourceNode?.data.name}`,
 				},
-		  ];
+			];
 
 	return (
 		<div className="space-y-8">

--- a/agents-manage-ui/src/features/graph/state/use-graph-store.ts
+++ b/agents-manage-ui/src/features/graph/state/use-graph-store.ts
@@ -131,18 +131,37 @@ export const useGraphStore = create<GraphState>()(
 			}));
 		},
 		onNodesChange(changes) {
+			// Check if any change type would modify the graph (not just selection changes)
+			const hasModifyingChange = changes.some(
+				(change) =>
+					change.type === "remove" ||
+					change.type === "add" ||
+					change.type === "replace" ||
+					change.type === "position",
+			);
+
 			set((state) => ({
 				history: [...state.history, { nodes: state.nodes, edges: state.edges }],
 				nodes: applyNodeChanges(changes, state.nodes),
+				dirty: hasModifyingChange ? true : state.dirty,
 			}));
 		},
 		onEdgesChange(changes) {
+			// Check if any change type would modify the graph (not just selection changes)
+			const hasModifyingChange = changes.some(
+				(change) =>
+					change.type === "remove" ||
+					change.type === "add" ||
+					change.type === "replace",
+			);
+
 			set((state) => ({
 				history: [...state.history, { nodes: state.nodes, edges: state.edges }],
 			}));
 			set((state) => ({
 				history: [...state.history, { nodes: state.nodes, edges: state.edges }],
 				edges: applyEdgeChanges(changes, state.edges),
+				dirty: hasModifyingChange ? true : state.dirty,
 			}));
 		},
 		onConnect(connection) {


### PR DESCRIPTION
## Summary
Fixed an issue where removing goodbye agent relationships (self-references) did not trigger the save button in the manage-ui graph editor.

## Problem
When users removed a self-reference relationship from an agent node in the graph editor, the save button was not being enabled, preventing users from saving their changes. This was a state management bug where `markUnsaved()` was called after the edge deletion, causing the dirty state not to be set properly.

## Solution
1. **Edge Editor Fix**: Moved the `markUnsaved()` call to execute before edge deletion, ensuring the dirty state is always set when relationships change
2. **Store Enhancement**: Added proper dirty state tracking to `onNodesChange` and `onEdgesChange` handlers to detect actual modifications vs selection-only changes

## Changes
- `agents-manage-ui/src/components/graph/sidepane/edges/edge-editor.tsx`: Call `markUnsaved()` before edge deletion
- `agents-manage-ui/src/features/graph/state/use-graph-store.ts`: Track dirty state for node and edge changes

## Testing
- ✅ Unit tests pass (`pnpm test`)
- ✅ Type checking passes (`pnpm typecheck`)
- ✅ Linting passes (formatting applied with `pnpm biome check --write`)

## Issue
Fixes PRD-4838

🤖 Generated with [Claude Code](https://claude.ai/code)