### PR TITLE
fix: Add project validation and redirect for non-existent projects

### DIFF
--- a/agents-manage-ui/src/app/[tenantId]/projects/[projectId]/layout.tsx
+++ b/agents-manage-ui/src/app/[tenantId]/projects/[projectId]/layout.tsx
@@ -1,0 +1,27 @@
+import { notFound } from "next/navigation";
+import type { ReactNode } from "react";
+import { fetchProject } from "@/lib/api/projects";
+
+export const dynamic = "force-dynamic";
+
+interface ProjectLayoutProps {
+	children: ReactNode;
+	params: Promise<{ tenantId: string; projectId: string }>;
+}
+
+export default async function ProjectLayout({
+	children,
+	params,
+}: ProjectLayoutProps) {
+	const { tenantId, projectId } = await params;
+
+	try {
+		// Verify project exists
+		await fetchProject(tenantId, projectId);
+	} catch (_error) {
+		// If project doesn't exist, show 404 page
+		notFound();
+	}
+
+	return <>{children}</>;
+}

--- a/agents-manage-ui/src/app/[tenantId]/projects/[projectId]/not-found.tsx
+++ b/agents-manage-ui/src/app/[tenantId]/projects/[projectId]/not-found.tsx
@@ -1,0 +1,46 @@
+"use client";
+
+import { AlertCircle } from "lucide-react";
+import { useParams, useRouter } from "next/navigation";
+import { useEffect } from "react";
+import { Button } from "@/components/ui/button";
+
+export default function ProjectNotFound() {
+	const params = useParams();
+	const router = useRouter();
+	const tenantId = params.tenantId as string;
+	const projectId = params.projectId as string;
+
+	useEffect(() => {
+		// Auto-redirect after 3 seconds
+		const timer = setTimeout(() => {
+			router.push(`/${tenantId}/projects`);
+		}, 3000);
+
+		return () => clearTimeout(timer);
+	}, [tenantId, router]);
+
+	return (
+		<div className="flex min-h-[400px] flex-col items-center justify-center p-8">
+			<div className="text-center max-w-md">
+				<div className="mb-4 flex justify-center">
+					<AlertCircle className="h-12 w-12 text-muted-foreground" />
+				</div>
+				<h1 className="text-2xl font-semibold mb-2">Project Not Found</h1>
+				<p className="text-muted-foreground mb-6">
+					The project "{projectId}" does not exist or you don't have access to
+					it.
+				</p>
+				<p className="text-sm text-muted-foreground mb-6">
+					Redirecting to projects list in 3 seconds...
+				</p>
+				<Button
+					onClick={() => router.push(`/${tenantId}/projects`)}
+					variant="default"
+				>
+					Go to Projects List
+				</Button>
+			</div>
+		</div>
+	);
+}


### PR DESCRIPTION
## Summary
- Fixes bug where visiting a non-existent project URL doesn't show an error
- Adds project validation in layout.tsx to check if project exists before rendering
- Creates custom not-found page with auto-redirect to projects list after 3 seconds

## Problem
Previously, when visiting a URL like `/inkeep/projects/my-project/graphs` where `my-project` doesn't exist, the page would still render without any error indication.

## Solution
1. Added a `layout.tsx` file at the project route level that validates project existence
2. If project doesn't exist, triggers Next.js `notFound()` to show 404 page
3. Created custom `not-found.tsx` page that:
   - Shows clear error message with project ID
   - Auto-redirects to projects list after 3 seconds
   - Provides manual button to go to projects list immediately

## Test Plan
- [x] Build passes (`pnpm build`)
- [x] TypeScript check passes (`pnpm typecheck`)
- [x] Linting passes (`pnpm lint`)
- [ ] Manual testing: Visit non-existent project URL and verify redirect
- [ ] Manual testing: Visit existing project URL and verify it still works

🤖 Generated with [Claude Code](https://claude.ai/code)