### PR TITLE
fix: suppress Turbo warnings for test task outputs

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -41,14 +41,44 @@
     "@inkeep/agents-run-api#test": {
       "dependsOn": ["build"],
       "inputs": ["$TURBO_DEFAULT$", "**/*.{test,spec}.{js,jsx,ts,tsx}"],
-      "outputs": ["coverage/**"],
+      "outputs": [],
       "env": ["CI"]
     },
     "@inkeep/agents-cli#test": {
       "dependsOn": ["build"],
       "inputs": ["$TURBO_DEFAULT$", "**/*.{test,spec}.{js,jsx,ts,tsx}"],
-      "outputs": ["coverage/**"],
+      "outputs": [],
       "env": ["CI"]
+    },
+    "@inkeep/agents-core#test": {
+      "dependsOn": ["build"],
+      "inputs": ["$TURBO_DEFAULT$", "**/*.{test,spec}.{js,jsx,ts,tsx}"],
+      "outputs": []
+    },
+    "@inkeep/agents-manage-api#test": {
+      "dependsOn": ["build"],
+      "inputs": ["$TURBO_DEFAULT$", "**/*.{test,spec}.{js,jsx,ts,tsx}"],
+      "outputs": []
+    },
+    "@inkeep/agents-manage-ui#test": {
+      "dependsOn": ["build"],
+      "inputs": ["$TURBO_DEFAULT$", "**/*.{test,spec}.{js,jsx,ts,tsx}"],
+      "outputs": []
+    },
+    "@inkeep/agents-sdk#test": {
+      "dependsOn": ["build"],
+      "inputs": ["$TURBO_DEFAULT$", "**/*.{test,spec}.{js,jsx,ts,tsx}"],
+      "outputs": []
+    },
+    "@inkeep/agents-ui#test": {
+      "dependsOn": ["build"],
+      "inputs": ["$TURBO_DEFAULT$", "**/*.{test,spec}.{js,jsx,ts,tsx}"],
+      "outputs": []
+    },
+    "@inkeep/create-agents#test": {
+      "dependsOn": ["build"],
+      "inputs": ["$TURBO_DEFAULT$", "**/*.{test,spec}.{js,jsx,ts,tsx}"],
+      "outputs": []
     },
     "chat-widget#test": {
       "dependsOn": ["build"],


### PR DESCRIPTION
## Summary
- Fixed Turbo warnings about missing output files for test tasks
- Set empty `outputs` arrays for all package-specific test tasks that don't generate coverage reports

## Problem
When running `pnpm test`, multiple warnings appeared:
```
WARNING  no output files found for task @inkeep/agents-cli#test. Please check your `outputs` key in `turbo.json`
WARNING  no output files found for task @inkeep/agents-core#test. Please check your `outputs` key in `turbo.json`
... (8 total warnings)
```

## Solution
Added explicit test task configurations for all affected packages with empty `outputs` arrays to indicate they don't produce coverage reports.

## Test Plan
- [x] Run `pnpm test` and verify no warnings appear
- [x] Tests still run successfully

🤖 Generated with [Claude Code](https://claude.ai/code)