### PR TITLE
fix: Make prompt field optional for internal agents in graph validation

### DIFF
--- a/packages/agents-core/src/client-exports.ts
+++ b/packages/agents-core/src/client-exports.ts
@@ -186,8 +186,10 @@ export const FullGraphDefinitionSchema = AgentGraphApiInsertSchema.extend({
   agents: z.record(
     z.string(),
     z.union([
-      AgentApiInsertSchema.extend({
+      // Internal agent schema - prompt is optional for initial creation
+      AgentApiInsertSchema.omit({ prompt: true }).extend({
         id: z.string(),
+        prompt: z.string().optional(), // Make prompt optional for graph creation
         tools: z.array(z.string()),
         dataComponents: z.array(z.string()).optional(),
         artifactComponents: z.array(z.string()).optional(),

--- a/packages/agents-core/src/types/entities.ts
+++ b/packages/agents-core/src/types/entities.ts
@@ -306,14 +306,7 @@ export type FullGraphAgentInsert = z.infer<typeof FullGraphAgentInsertSchema>;
 // === Full Project Types ===
 export type FullProjectDefinition = z.infer<typeof FullProjectDefinitionSchema>;
 // Type helpers for better TypeScript support
-export type InternalAgentDefinition = z.infer<typeof AgentApiInsertSchema> & {
-  tools: string[];
-  selectedTools?: Record<string, string[]>;
-  dataComponents?: string[];
-  artifactComponents?: string[];
-  canTransferTo?: string[];
-  canDelegateTo?: string[];
-};
+export type InternalAgentDefinition = z.infer<typeof FullGraphAgentInsertSchema>;
 
 export type AgentDefinition = InternalAgentDefinition | ExternalAgentApiInsert;
 export type ToolDefinition = ToolApiInsert & { credentialReferenceId?: string | null };

--- a/packages/agents-core/src/validation/graphFull.ts
+++ b/packages/agents-core/src/validation/graphFull.ts
@@ -9,7 +9,9 @@ import { FullGraphDefinitionSchema } from '../validation/schemas';
 
 // Type guard functions
 export function isInternalAgent(agent: AgentDefinition): agent is InternalAgentDefinition {
-  return 'prompt' in agent;
+  // Check for absence of baseUrl to identify internal agents
+  // since prompt is now optional for initial creation
+  return !('baseUrl' in agent);
 }
 
 export function isExternalAgent(agent: AgentDefinition): agent is ExternalAgentApiInsert {


### PR DESCRIPTION
## Summary
- Fixed validation bug where both `prompt` and `baseUrl` fields were shown as required when creating/updating agent graphs
- Made `prompt` field optional for internal agents during initial graph creation
- Updated type guards to properly distinguish between internal and external agents

## Problem
The UI was showing validation errors for both:
- `Agent is missing required field: Prompt` (for internal agents)
- `Agent is missing required field: Host URL` (for external agents)

This happened because the union schema validation was failing when neither field was present in a new agent, resulting in both error messages being displayed.

## Solution
1. Made the `prompt` field optional in `FullGraphAgentInsertSchema` for initial creation
2. Updated type guards to check for absence of `baseUrl` rather than presence of `prompt`
3. Updated type definitions to use the correct schema

## Test Plan
- [x] All existing tests pass (`pnpm test`)
- [x] TypeScript compilation succeeds (`pnpm typecheck`)
- [x] Linting passes (`pnpm lint`)
- [x] Build succeeds for all packages
- [ ] Manually tested graph creation/update in UI - validation errors no longer appear

🤖 Generated with [Claude Code](https://claude.ai/code)