### PR TITLE
fix: increase Next.js static page generation timeout to prevent CI failures

### DIFF
--- a/agents-docs/next.config.mjs
+++ b/agents-docs/next.config.mjs
@@ -12,6 +12,8 @@ const redirects = JSON.parse(fs.readFileSync(redirectsPath, 'utf8'));
 /** @type {import('next').NextConfig} */
 const config = {
   reactStrictMode: true,
+  // Increase timeout for static page generation in CI environments
+  staticPageGenerationTimeout: 180, // 3 minutes instead of default 60 seconds
   async redirects() {
     return redirects.map((item) => ({ ...item, permanent: isProd }));
   },


### PR DESCRIPTION
## Summary
- Increased `staticPageGenerationTimeout` from default 60s to 180s (3 minutes) in Next.js config
- This prevents intermittent CI failures where pages timeout during static generation

## Problem
The CI was intermittently failing with timeout errors when building the docs site. Pages like `/api-keys`, `/concepts`, `/quick-start` were taking more than 60 seconds to generate and failing after 3 retries, causing the build to exit with error code 1.

Example error from CI:
```
Failed to build /[[...slug]]/page: /api-keys (attempt 1 of 3) because it took more than 60 seconds
Failed to build /[[...slug]]/page: /concepts (attempt 1 of 3) because it took more than 60 seconds
Failed to build /[[...slug]]/page: /quick-start (attempt 1 of 3) because it took more than 60 seconds
```

## Solution
Added `staticPageGenerationTimeout: 180` to `next.config.mjs` to give the build process more time to complete in CI environments. This is a common issue with Next.js 15 when generating many static pages.

## Test plan
- [x] Tested build locally with `pnpm build` - passes successfully
- [ ] CI should pass without timeout errors

Note: There's an existing typecheck issue in agents-manage-ui that's unrelated to this change and exists on main branch.

🤖 Generated with Claude Code