### PR TITLE
fix: resolve Zod v4 compatibility issue with @hookform/resolvers

### DIFF
--- a/agents-manage-ui/src/components/api-keys/form/api-key-form.tsx
+++ b/agents-manage-ui/src/components/api-keys/form/api-key-form.tsx
@@ -59,7 +59,7 @@ export function ApiKeyForm({
   onApiKeyCreated,
 }: ApiKeyFormProps) {
   const form = useForm<ApiKeyFormData>({
-    resolver: zodResolver(apiKeySchema),
+    resolver: zodResolver(apiKeySchema as any),
     defaultValues: initialData || defaultValues,
   });
 

--- a/turbo.json
+++ b/turbo.json
@@ -13,7 +13,11 @@
     "ENVIRONMENT",
     "DB_FILE_NAME",
     "PORT",
-    "LOG_LEVEL"
+    "LOG_LEVEL",
+    "INKEEP_AGENTS_MANAGE_API_BYPASS_SECRET",
+    "NANGO_SECRET_KEY",
+    "NANGO_HOST",
+    "SIGNOZ_API_KEY"
   ],
   "tasks": {
     "sync:licenses": {


### PR DESCRIPTION
## Summary
- Fixed TypeScript compatibility issue between @hookform/resolvers v5.2.1 and Zod v4.1.5 that was causing Vercel build failures
- Added missing environment variables to turbo.json for proper Vercel builds

## Changes
1. **Fixed Zod resolver type compatibility** in `agents-manage-ui/src/components/api-keys/form/api-key-form.tsx`
   - Added type cast to `zodResolver(apiKeySchema as any)` to resolve type mismatch
   - This is a temporary workaround for the known compatibility issue between these library versions

2. **Updated turbo.json** with missing environment variables:
   - `INKEEP_AGENTS_MANAGE_API_BYPASS_SECRET`
   - `NANGO_SECRET_KEY`
   - `NANGO_HOST`
   - `SIGNOZ_API_KEY`

## Context
The Vercel build was failing with a TypeScript error about incompatible Zod type definitions. This is a known issue when using @hookform/resolvers v5.x with Zod v4.x (see [react-hook-form/resolvers#768](https://github.com/react-hook-form/resolvers/issues/768)).

## Test plan
- [x] Build passes locally with `pnpm build --filter=@inkeep/agents-manage-ui`
- [ ] Vercel preview build should pass
- [ ] No runtime errors in API key form functionality

🤖 Generated with [Claude Code](https://claude.ai/code)