### PR TITLE
fix: resolve Zod type incompatibility in api-key-form validation

### DIFF
--- a/agents-manage-ui/src/components/api-keys/form/validation.ts
+++ b/agents-manage-ui/src/components/api-keys/form/validation.ts
@@ -12,12 +12,7 @@ export const EXPIRATION_DATE_OPTIONS = [
 export const apiKeySchema = z.object({
   // name: z.string().min(1, 'Please enter a name.'), // todo: will be added soon
   graphId: z.string().min(1, 'Please select a graph.'),
-  expiresAt: z.enum(['1d', '1w', '1m', '3m', '1y', 'never']).refine(
-    (value) => ['1d', '1w', '1m', '3m', '1y', 'never'].includes(value),
-    {
-      message: 'Please select a valid expiration date.',
-    }
-  ),
+  expiresAt: z.enum(['1d', '1w', '1m', '3m', '1y', 'never'] as const),
 });
 
 export type ApiKeyFormData = z.infer<typeof apiKeySchema>;


### PR DESCRIPTION
Remove unnecessary .refine() and add 'as const' to enum definition to fix TypeScript compilation error during Vercel deployment