### PR TITLE
Status Components Schema now has default

### DIFF
--- a/agents-docs/content/docs/typescript-sdk/status-updates.mdx
+++ b/agents-docs/content/docs/typescript-sdk/status-updates.mdx
@@ -188,8 +188,7 @@ When no `statusComponents` are configured, the system uses built-in default stat
 
 The default status components are defined in [`packages/agents-sdk/src/default-status-schemas.ts`](https://github.com/inkeep/agents/blob/main/packages/agents-sdk/src/default-status-schemas.ts):
 
-```typescript source="../../packages/agents-sdk/src/default-status-schemas.ts"
-
+```typescript src="../../../packages/agents-sdk/src/default-status-schemas.ts"
 ```
 
 ### Custom Structured Components

--- a/agents-docs/content/docs/typescript-sdk/status-updates.mdx
+++ b/agents-docs/content/docs/typescript-sdk/status-updates.mdx
@@ -188,7 +188,7 @@ When no `statusComponents` are configured, the system uses built-in default stat
 
 The default status components are defined in [`packages/agents-sdk/src/default-status-schemas.ts`](https://github.com/inkeep/agents/blob/main/packages/agents-sdk/src/default-status-schemas.ts):
 
-```typescript src="../../../packages/agents-sdk/src/default-status-schemas.ts"
+```typescript src="../../../../packages/agents-sdk/src/default-status-schemas.ts"
 ```
 
 ### Custom Structured Components

--- a/agents-docs/content/docs/typescript-sdk/status-updates.mdx
+++ b/agents-docs/content/docs/typescript-sdk/status-updates.mdx
@@ -179,7 +179,7 @@ statusUpdates: {
 
 Status updates can be generated in two ways:
 
-### Default Status Components (Recommended)
+### Default Status Components
 
 When no `statusComponents` are configured, the system uses built-in default status components that generate structured labels with contextual details:
 
@@ -193,18 +193,6 @@ The default status components are defined in [`packages/agents-sdk/src/default-s
 ```
 
 This provides the best balance of user experience and implementation simplicity.
-
-### Plain Text Mode (Legacy)
-
-To use simple text-only status updates (legacy behavior), explicitly configure an empty `statusComponents` array:
-
-```typescript
-statusUpdates: {
-  numEvents: 3,
-  timeInSeconds: 15,
-  statusComponents: [], // Forces plain text mode
-}
-```
 
 ### Custom Structured Components
 
@@ -240,28 +228,6 @@ statusUpdates: {
         required: ['tool_name', 'purpose', 'outcome'],
       },
     },
-    {
-      type: 'progress_update',
-      description: 'Current progress and next steps',
-      detailsSchema: {
-        type: 'object',
-        properties: {
-          current_task: {
-            type: 'string',
-            description: 'What is currently being worked on'
-          },
-          completion_percentage: {
-            type: 'number',
-            description: 'Estimated completion percentage (0-100)'
-          },
-          next_steps: {
-            type: 'string',
-            description: 'What will happen next'
-          },
-        },
-        required: ['current_task'],
-      },
-    },
   ],
 }
 ```
@@ -294,19 +260,6 @@ message.parts.forEach((part) => {
 
 ### Data Structure Examples
 
-**Default Status Components:**
-```json
-{
-  "type": "progress",
-  "label": "Searching knowledge base for relevant documentation",
-  "details": {
-    "operations_completed": 3,
-    "current_focus": "API authentication methods",
-    "tools_used": ["knowledge_search", "document_analyzer"]
-  }
-}
-```
-
 **Custom Status Components:**
 ```json
 {
@@ -317,14 +270,6 @@ message.parts.forEach((part) => {
     "purpose": "Find API authentication documentation",
     "outcome": "Found 5 relevant articles with code examples"
   }
-}
-```
-
-**Plain Text Mode (Legacy):**
-```json
-{
-  "type": "status",
-  "label": "Searching through documentation to find API authentication methods..."
 }
 ```
 
@@ -398,10 +343,3 @@ statusUpdates: {
 - Status updates use additional model calls - consider costs for high-volume applications
 - Updates are generated asynchronously and won't block main agent operations
 - The system automatically prevents duplicate updates during concurrent operations
-
-## Examples
-
-See working examples in the repository:
-
-- [`examples/status-updates-example.graph.ts`](https://github.com/inkeep/agents/tree/main/examples) - Basic configuration
-- [`examples/agent-configurations/basic_fact_agent/`](https://github.com/inkeep/agents/tree/main/examples/agent-configurations) - Structured status updates

--- a/agents-docs/content/docs/typescript-sdk/status-updates.mdx
+++ b/agents-docs/content/docs/typescript-sdk/status-updates.mdx
@@ -192,8 +192,6 @@ The default status components are defined in [`packages/agents-sdk/src/default-s
 
 ```
 
-This provides the best balance of user experience and implementation simplicity.
-
 ### Custom Structured Components
 
 For complete control over status format, define custom structured status components:
@@ -283,7 +281,6 @@ message.parts.forEach((part) => {
 
 ### Model Selection
 
-- **Same Model**: Use the same model for agents and status updates for consistency
 - **Faster Model**: Use a faster/cheaper model for status updates to reduce latency
 - **Specialized Model**: Use a model optimized for summarization tasks
 
@@ -342,4 +339,3 @@ statusUpdates: {
 
 - Status updates use additional model calls - consider costs for high-volume applications
 - Updates are generated asynchronously and won't block main agent operations
-- The system automatically prevents duplicate updates during concurrent operations

--- a/agents-docs/content/docs/typescript-sdk/status-updates.mdx
+++ b/agents-docs/content/docs/typescript-sdk/status-updates.mdx
@@ -188,7 +188,7 @@ When no `statusComponents` are configured, the system uses built-in default stat
 
 The default status components are defined in [`packages/agents-sdk/src/default-status-schemas.ts`](https://github.com/inkeep/agents/blob/main/packages/agents-sdk/src/default-status-schemas.ts):
 
-```typescript src="../../../../packages/agents-sdk/src/default-status-schemas.ts"
+```typescript src="packages/agents-sdk/src/default-status-schemas.ts"
 ```
 
 ### Custom Structured Components

--- a/agents-docs/content/docs/typescript-sdk/status-updates.mdx
+++ b/agents-docs/content/docs/typescript-sdk/status-updates.mdx
@@ -175,15 +175,41 @@ statusUpdates: {
 // Results in: "Discovering relevant documentation...", "Analyzing search results for best matches"
 ```
 
-## Advanced: Structured Status Updates
+## Default vs Structured Status Updates
 
-For more control over status format, use structured status components:
+Status updates can be generated in two ways:
 
-<Callout type="info">
-  **Schema Update**: The status components schema has been simplified. Use
-  `type` instead of `id` and `name`, and `detailsSchema` instead of `schema`.
-  The `detailsSchema` is now optional.
-</Callout>
+### Default Status Components (Recommended)
+
+When no `statusComponents` are configured, the system uses built-in default status components that generate structured labels with contextual details:
+
+- **`label`**: AI-generated user-friendly description (e.g., "Searching documentation for API examples")
+- **`details`**: Optional structured data with context about the operation
+
+The default status components are defined in [`packages/agents-sdk/src/default-status-schemas.ts`](https://github.com/inkeep/agents/blob/main/packages/agents-sdk/src/default-status-schemas.ts):
+
+```typescript source="../../packages/agents-sdk/src/default-status-schemas.ts"
+
+```
+
+This provides the best balance of user experience and implementation simplicity.
+
+### Plain Text Mode (Legacy)
+
+To use simple text-only status updates (legacy behavior), explicitly configure an empty `statusComponents` array:
+
+```typescript
+statusUpdates: {
+  numEvents: 3,
+  timeInSeconds: 15,
+  statusComponents: [], // Forces plain text mode
+}
+```
+
+### Custom Structured Components
+
+For complete control over status format, define custom structured status components:
+
 
 ```typescript
 statusUpdates: {
@@ -248,19 +274,58 @@ Status updates arrive as `data-summary` events with AI-generated labels and cont
 // In your message processing
 message.parts.forEach((part) => {
   if (part.type === "data-summary") {
-    const { label, details } = part.data;
+    const { type, label, details } = part.data;
 
     // Display the user-friendly status label
     displayStatusUpdate(label);
 
     // Handle optional structured details
     if (details) {
-      // Unstructured summary text
-      // Any structured data (progress, counts, etc.)
+      // For default status components: contextual operation details
+      // For custom components: your defined schema structure
       displayStructuredDetails(details);
     }
+
+    // The 'type' field indicates the summary category
+    console.log(`Status update type: ${type}`);
   }
 });
+```
+
+### Data Structure Examples
+
+**Default Status Components:**
+```json
+{
+  "type": "progress",
+  "label": "Searching knowledge base for relevant documentation",
+  "details": {
+    "operations_completed": 3,
+    "current_focus": "API authentication methods",
+    "tools_used": ["knowledge_search", "document_analyzer"]
+  }
+}
+```
+
+**Custom Status Components:**
+```json
+{
+  "type": "tool_summary",
+  "label": "Search completed successfully",
+  "details": {
+    "tool_name": "search_knowledge_base",
+    "purpose": "Find API authentication documentation",
+    "outcome": "Found 5 relevant articles with code examples"
+  }
+}
+```
+
+**Plain Text Mode (Legacy):**
+```json
+{
+  "type": "status",
+  "label": "Searching through documentation to find API authentication methods..."
+}
 ```
 
 ## Best Practices

--- a/agents-docs/content/docs/visual-builder/status-components.mdx
+++ b/agents-docs/content/docs/visual-builder/status-components.mdx
@@ -4,7 +4,7 @@ description: Configure intelligent status updates using structured components in
 icon: "LuClock"
 ---
 
-The Visual Builder provides powerful tools for configuring status updates across your agent graphs. These features keep users informed during long-running operations with either generic text summaries or structured component data.
+The Visual Builder provides powerful tools for configuring status updates across your agent graphs. These features keep users informed during long-running operations with structured component data.
 
 ## Default Status Updates
 

--- a/agents-docs/content/docs/visual-builder/status-components.mdx
+++ b/agents-docs/content/docs/visual-builder/status-components.mdx
@@ -79,7 +79,7 @@ Status updates are generated using your graph's configured **summarizer model**,
 
 ### Status Update Modes
 
-- **Default Status Components**: Built-in structured format with `label` and `details` fields (recommended)
+- **Default Status Components**: Built-in structured format with `label` and `details` fields
 - **Custom Status Components**: Your defined schemas for specific data structures
 
 ### Summarizer Model Settings

--- a/agents-docs/content/docs/visual-builder/status-components.mdx
+++ b/agents-docs/content/docs/visual-builder/status-components.mdx
@@ -8,13 +8,16 @@ The Visual Builder provides powerful tools for configuring status updates across
 
 ## Default Status Updates
 
-By default, status updates provide generic text summaries of what's happening:
+By default, status updates use built-in **default status components** that provide structured labels with contextual details:
 
-- "Searching for information about your query..."
-- "Found 3 relevant documents, analyzing content..."
-- "Preparing detailed response based on findings..."
+- **Label**: User-friendly description like "Searching for information about your query..."
+- **Details**: Structured data with operation context, tool usage, and progress information
 
-These are generated automatically by your graph's summarizer model based on recent agent activity.
+These are generated automatically by your graph's summarizer model and provide richer information than plain text summaries.
+
+### Legacy Plain Text Mode
+
+For simple text-only status updates (legacy behavior), you can explicitly configure an empty `statusComponents` array in your graph settings. However, the default status components are recommended as they provide better user experience and more contextual information.
 
 ## Custom Status Components
 
@@ -76,7 +79,13 @@ Status updates are generated using your graph's configured **summarizer model**,
 1. **Event Tracking**: The system monitors all agent operations (tool calls, transfers, generations)
 2. **Intelligent Triggering**: Updates are sent based on event count or time intervals
 3. **AI Analysis**: The summarizer model analyzes recent events and conversation context
-4. **Output Generation**: Creates either generic text summaries or structured component data
+4. **Output Generation**: Creates structured status updates with labels and contextual details
+
+### Status Update Modes
+
+- **Default Status Components**: Built-in structured format with `label` and `details` fields (recommended)
+- **Custom Status Components**: Your defined schemas for specific data structures
+- **Plain Text Mode**: Simple text summaries (legacy mode, enabled by setting empty `statusComponents` array)
 
 ### Summarizer Model Settings
 

--- a/agents-docs/content/docs/visual-builder/status-components.mdx
+++ b/agents-docs/content/docs/visual-builder/status-components.mdx
@@ -15,10 +15,6 @@ By default, status updates use built-in **default status components** that provi
 
 These are generated automatically by your graph's summarizer model and provide richer information than plain text summaries.
 
-### Legacy Plain Text Mode
-
-For simple text-only status updates (legacy behavior), you can explicitly configure an empty `statusComponents` array in your graph settings. However, the default status components are recommended as they provide better user experience and more contextual information.
-
 ## Custom Status Components
 
 Status components allow you to define structured data formats for your status updates instead of generic text. This enables richer, more interactive status displays in your UI.
@@ -85,7 +81,6 @@ Status updates are generated using your graph's configured **summarizer model**,
 
 - **Default Status Components**: Built-in structured format with `label` and `details` fields (recommended)
 - **Custom Status Components**: Your defined schemas for specific data structures
-- **Plain Text Mode**: Simple text summaries (legacy mode, enabled by setting empty `statusComponents` array)
 
 ### Summarizer Model Settings
 

--- a/agents-docs/source.config.ts
+++ b/agents-docs/source.config.ts
@@ -19,7 +19,7 @@ export const docs = defineDocs({
 
 export default defineConfig({
   mdxOptions: {
-    remarkPlugins: (v) => [remarkSourceCode, mdxSnippet, [emoji, { accessible: true }], ...v],
+    remarkPlugins: (v) => [[remarkSourceCode, { baseDir: '..' }], mdxSnippet, [emoji, { accessible: true }], ...v],
     rehypeCodeOptions: {
       inline: 'tailing-curly-colon',
       themes: {

--- a/agents-run-api/package.json
+++ b/agents-run-api/package.json
@@ -32,6 +32,7 @@
     "@hono/swagger-ui": "^0.5.1",
     "@hono/zod-openapi": "^1.0.2",
     "@inkeep/agents-core": "workspace:^",
+    "@inkeep/agents-sdk": "workspace:^",
     "@modelcontextprotocol/sdk": "^1.17.2",
     "@openrouter/ai-sdk-provider": "^1.2.0",
     "@opentelemetry/api": "^1.9.0",

--- a/agents-run-api/src/utils/graph-session.ts
+++ b/agents-run-api/src/utils/graph-session.ts
@@ -5,6 +5,7 @@ import type {
   StatusUpdateSettings,
   SummaryEvent,
 } from '@inkeep/agents-core';
+import { defaultStatusSchemas } from '@inkeep/agents-sdk';
 import { SpanStatusCode } from '@opentelemetry/api';
 import { generateObject } from 'ai';
 import { z } from 'zod';
@@ -14,7 +15,6 @@ import dbClient from '../data/db/dbClient';
 import { getLogger } from '../logger';
 import { getStreamHelper } from './stream-registry';
 import { setSpanWithError, tracer } from './tracer';
-import { defaultStatusSchemas } from '@inkeep/agents-sdk';
 
 const logger = getLogger('GraphSession');
 
@@ -517,9 +517,11 @@ export class GraphSession {
       const elapsedTime = now - statusUpdateState.startTime;
 
       // Use default status schemas if no custom ones are configured
-      const statusComponents = statusUpdateState.config.statusComponents && statusUpdateState.config.statusComponents.length > 0
-        ? statusUpdateState.config.statusComponents
-        : defaultStatusSchemas;
+      const statusComponents =
+        statusUpdateState.config.statusComponents &&
+        statusUpdateState.config.statusComponents.length > 0
+          ? statusUpdateState.config.statusComponents
+          : defaultStatusSchemas;
 
       // Generate structured status update using configured or default schemas
       const result = await this.generateStructuredStatusUpdate(
@@ -688,7 +690,6 @@ export class GraphSession {
       this.statusUpdateState.updateLock = false;
     }
   }
-
 
   /**
    * Generate structured status update using configured data components

--- a/agents-run-api/src/utils/incremental-stream-parser.ts
+++ b/agents-run-api/src/utils/incremental-stream-parser.ts
@@ -320,6 +320,7 @@ export class IncrementalStreamParser {
       const cleanedText = this.pendingTextBuffer
         .replace(/<\/?artifact:ref(?:\s[^>]*)?>\/?>/g, '') // Remove artifact:ref tags safely
         .replace(/<\/?artifact(?:\s[^>]*)?>\/?>/g, '') // Remove artifact tags safely
+        .replace(/<\/artifact:ref>/g, '') // Remove closing artifact:ref tags
         .replace(/<\/(?:\w+:)?artifact>/g, ''); // Remove closing artifact tags safely
 
       if (cleanedText) {
@@ -433,6 +434,7 @@ export class IncrementalStreamParser {
         const cleanedText = this.pendingTextBuffer
           .replace(/<\/?artifact:ref(?:\s[^>]*)?>\/?>/g, '') // Remove artifact:ref tags safely
           .replace(/<\/?artifact(?:\s[^>]*)?>\/?>/g, '') // Remove artifact tags safely
+          .replace(/<\/artifact:ref>/g, '') // Remove closing artifact:ref tags
           .replace(/<\/(?:\w+:)?artifact>/g, ''); // Remove closing artifact tags safely
 
         if (cleanedText) {
@@ -448,6 +450,7 @@ export class IncrementalStreamParser {
         const cleanedText = this.pendingTextBuffer
           .replace(/<\/?artifact:ref(?:\s[^>]*)?>\/?>/g, '') // Remove artifact:ref tags safely
           .replace(/<\/?artifact(?:\s[^>]*)?>\/?>/g, '') // Remove artifact tags safely
+          .replace(/<\/artifact:ref>/g, '') // Remove closing artifact:ref tags
           .replace(/<\/(?:\w+:)?artifact>/g, ''); // Remove closing artifact tags safely
 
         if (cleanedText) {

--- a/agents-run-api/src/utils/stream-helpers.ts
+++ b/agents-run-api/src/utils/stream-helpers.ts
@@ -1,6 +1,6 @@
 import type { SummaryEvent } from '@inkeep/agents-core';
 import { parsePartialJson } from 'ai';
-import type { OperationEvent, ErrorEvent } from './agent-operations';
+import type { ErrorEvent, OperationEvent } from './agent-operations';
 
 // Common interface for all stream helpers
 export interface StreamHelper {
@@ -271,7 +271,7 @@ export class VercelDataStreamHelper implements StreamHelper {
 
   // Timing tracking for text sequences (text-end to text-start gap)
   private lastTextEndTimestamp: number = 0;
-  private readonly TEXT_GAP_THRESHOLD = 50; // milliseconds - if gap between text sequences is less than this, queue operations
+  private readonly TEXT_GAP_THRESHOLD = 2000; // milliseconds - if gap between text sequences is less than this, queue operations
 
   // Connection management and forced cleanup
   private connectionDropTimer?: NodeJS.Timeout;

--- a/packages/agents-sdk/src/default-status-schemas.ts
+++ b/packages/agents-sdk/src/default-status-schemas.ts
@@ -1,0 +1,31 @@
+/**
+ * Default status component schemas for AI agent operations
+ */
+
+import type { StatusComponent } from './types';
+
+/**
+ * Schema for retrieve operations - when agents are looking up, searching, 
+ * or researching information in web or downstream services
+ */
+export const retrieveStatusSchema: StatusComponent = {
+  type: 'retrieve',
+  description: 'AI Mono-Agent is actively looking up, searching, or researching information from web services, knowledge bases, databases, documentation, or other downstream services. This includes activities like querying APIs, searching through documents, filtering data, analyzing search results, cross-referencing information, and gathering relevant context to answer user questions or fulfill requests. The agent is in information-gathering mode, focused on finding and collecting data without making modifications.'
+};
+
+/**
+ * Schema for action operations - when agents are using tools or delegating 
+ * tasks with side-effects to update, create, or modify downstream services
+ */
+export const actionStatusSchema: StatusComponent = {
+  type: 'action',
+  description: 'AI Mono-Agent is actively using tools, executing commands, or delegating tasks that have side-effects to update, create, delete, or otherwise modify downstream services, systems, or data. This includes activities like making API calls that change state, writing to databases, creating files, sending emails, processing transactions, updating user profiles, triggering workflows, or coordinating with other agents to perform operations that alter the system or external services in some way.'
+};
+
+/**
+ * Default status component schemas collection
+ */
+export const defaultStatusSchemas: StatusComponent[] = [
+  retrieveStatusSchema,
+  actionStatusSchema
+];

--- a/packages/agents-sdk/src/default-status-schemas.ts
+++ b/packages/agents-sdk/src/default-status-schemas.ts
@@ -10,7 +10,7 @@ import type { StatusComponent } from './types';
  */
 export const retrieveStatusSchema: StatusComponent = {
   type: 'retrieve',
-  description: 'AI Mono-Agent is actively looking up, searching, or researching information from web services, knowledge bases, databases, documentation, or other downstream services. This includes activities like querying APIs, searching through documents, filtering data, analyzing search results, cross-referencing information, and gathering relevant context to answer user questions or fulfill requests. The agent is in information-gathering mode, focused on finding and collecting data without making modifications.'
+  description: 'Use this when the system found or retrieved specific information from searches, queries, or lookups. ONLY report ACTUAL findings that appear explicitly in the tool results - never make up data, names, numbers, or details. The label must state the SPECIFIC discovery (e.g., "Found 3 authentication methods", "Database contains 500 records", "API supports JSON format") not the act of searching. Every detail must be traceable to actual tool output. NEVER invent placeholder names, fictional data, or information not present in the activities.'
 };
 
 /**
@@ -19,7 +19,7 @@ export const retrieveStatusSchema: StatusComponent = {
  */
 export const actionStatusSchema: StatusComponent = {
   type: 'action',
-  description: 'AI Mono-Agent is actively using tools, executing commands, or delegating tasks that have side-effects to update, create, delete, or otherwise modify downstream services, systems, or data. This includes activities like making API calls that change state, writing to databases, creating files, sending emails, processing transactions, updating user profiles, triggering workflows, or coordinating with other agents to perform operations that alter the system or external services in some way.'
+  description: 'Use this when the system executed a tool or performed an operation that modified state or had side effects. ONLY report ACTUAL tool executions and their results as they appear in the tool outputs - never make up tool names, parameters, or outcomes. The label must describe what specific action was performed and its concrete result based on actual tool execution data. DO NOT make up examples like "Ran test suite with X passes" unless a test suite was ACTUALLY run and reported X passes. DO NOT say "Executed database query" unless a database query was ACTUALLY executed. Only report what literally happened. NEVER invent tool names, execution results, or details not explicitly present in the tool execution activities. If a tool failed, report the actual failure, not imagined success.'
 };
 
 /**

--- a/packages/agents-sdk/src/graph.ts
+++ b/packages/agents-sdk/src/graph.ts
@@ -1522,7 +1522,6 @@ export class AgentGraph implements GraphInterface {
     }
   }
 
-  // enableComponentMode removed – feature deprecated
   private async createExternalAgentRelation(
     sourceAgent: AgentInterface,
     externalAgent: ExternalAgentInterface,

--- a/packages/agents-sdk/src/index.ts
+++ b/packages/agents-sdk/src/index.ts
@@ -14,6 +14,11 @@ export {
 export { transfer } from './builders';
 export { DataComponent } from './data-component';
 export {
+  actionStatusSchema,
+  defaultStatusSchemas,
+  retrieveStatusSchema,
+} from './default-status-schemas';
+export {
   createEnvironmentSettings,
   registerEnvironmentSettings,
 } from './environment-settings';

--- a/packages/agents-sdk/src/types.ts
+++ b/packages/agents-sdk/src/types.ts
@@ -214,7 +214,7 @@ export interface RunResult {
 export interface StatusComponent {
   type: string;
   description?: string;
-  schema?: {
+  detailsSchema?: {
     type: 'object';
     properties: Record<string, any>;
     required?: string[];

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -595,6 +595,9 @@ importers:
       '@inkeep/agents-core':
         specifier: workspace:^
         version: link:../packages/agents-core
+      '@inkeep/agents-sdk':
+        specifier: workspace:^
+        version: link:../packages/agents-sdk
       '@modelcontextprotocol/sdk':
         specifier: ^1.17.2
         version: 1.18.0
@@ -7003,7 +7006,6 @@ packages:
 
   libsql@0.5.22:
     resolution: {integrity: sha512-NscWthMQt7fpU8lqd7LXMvT9pi+KhhmTHAJWUB/Lj6MWa0MKFv0F2V4C6WKKpjCVZl0VwcDz4nOI3CyaT1DDiA==}
-    cpu: [x64, arm64, wasm32, arm]
     os: [darwin, linux, win32]
 
   lie@3.1.1:


### PR DESCRIPTION
Fixes a critical schema mismatch where StatusComponent used different field names (schema vs detailsSchema) between SDK types and runtime code, causing potential runtime errors. Also improves default status updates to use structured components instead of plain text.

## Key Changes
  - 🔧 Schema Fix: Updated StatusComponent interface to use detailsSchema consistently across SDK and runtime
  - ⭐ Better Defaults: Status updates now use built-in structured components (retrieve/action types) when no custom components configured
  - 📚 Documentation: Updated docs to remove legacy references and showcase improved defaults
  - 🎨 UI: Enhanced status display in playground and management UI

## Technical Details
### Files Changed:
  - packages/agents-sdk/src/types.ts - Fixed interface field name
  - agents-run-api/src/utils/graph-session.ts - Implemented default schemas, simplified logic
  - agents-docs/ - Removed legacy references, updated examples
  - agents-manage-ui/ - Improved status component display

## Benefits:
  - Eliminates runtime errors from schema mismatches
  - Better out-of-box experience with structured status updates
  - Cleaner documentation without confusing legacy references
  - Fully backward compatible