### PR TITLE
Fix height of JSON editor in fullscreen, change `className` to set height to 100%

### DIFF
--- a/agents-manage-ui/src/components/form/expandable-json-editor.tsx
+++ b/agents-manage-ui/src/components/form/expandable-json-editor.tsx
@@ -70,7 +70,7 @@ function ExpandedJsonEditor({
         value={value || ''}
         onChange={onChange}
         placeholder={placeholder}
-        className="[&>.cm-editor]:max-h-full"
+        className="[&>.cm-editor]:h-full"
       />
       {error && <p className="text-sm text-destructive mt-2">{error}</p>}
     </div>


### PR DESCRIPTION
before
<img width="1325" height="522" alt="image" src="https://github.com/user-attachments/assets/6ba2bc3a-fd07-4103-8607-eb687109a5d1" />

after
<img width="1280" height="539" alt="image" src="https://github.com/user-attachments/assets/fde43001-d676-4172-92a5-e2ab8a78df04" />
