### PR TITLE
feat: auto-center graph when sidepanes open/close

### DIFF
--- a/agents-manage-ui/src/components/graph/graph.tsx
+++ b/agents-manage-ui/src/components/graph/graph.tsx
@@ -179,7 +179,7 @@ function Flow({
     return lookup;
   }, [graph?.agents]);
 
-  const { screenToFlowPosition, updateNodeData } = useReactFlow();
+  const { screenToFlowPosition, updateNodeData, fitView } = useReactFlow();
   const {
     nodes: storeNodes,
     edges,
@@ -258,6 +258,28 @@ function Flow({
       }));
     }
   }, []);
+
+  // Auto-center graph when sidepane opens/closes
+  // biome-ignore lint/correctness/useExhaustiveDependencies: we want to trigger on isOpen changes
+  useEffect(() => {
+    // Delay to allow CSS transition to complete (300ms transition + 50ms buffer)
+    const timer = setTimeout(() => {
+      fitView({ maxZoom: 1, duration: 200 });
+    }, 350);
+
+    return () => clearTimeout(timer);
+  }, [isOpen, fitView]);
+
+  // Auto-center graph when playground opens/closes
+  // biome-ignore lint/correctness/useExhaustiveDependencies: we want to trigger on showPlayground changes
+  useEffect(() => {
+    // Delay to allow CSS transition to complete
+    const timer = setTimeout(() => {
+      fitView({ maxZoom: 1, duration: 200 });
+    }, 350);
+
+    return () => clearTimeout(timer);
+  }, [showPlayground, fitView]);
 
   // biome-ignore lint/correctness/useExhaustiveDependencies: we only want to add/connect edges once
   const onConnectWrapped = useCallback((params: Connection) => {


### PR DESCRIPTION
## Summary
- Automatically recenters the graph view when sidepanes open or close
- Prevents graph nodes from becoming partially obscured by sidepanes

## Changes
- Added `fitView()` calls triggered by `isOpen` state changes (sidepane)
- Added `fitView()` calls triggered by `showPlayground` state changes (playground)
- Uses 350ms delay to allow CSS transitions to complete before recentering
- Maintains `maxZoom: 1` and adds 200ms smooth fitView animation

## Testing
- Verified with Playwright MCP:
  - Opening playground automatically recenters graph
  - Closing playground automatically recenters graph
  - Graph remains fully visible in all scenarios
- All tests pass (`pnpm test`)
- TypeScript checks pass (`pnpm typecheck`)
- Build succeeds (`pnpm build`)
- Linting passes (`pnpm lint`)

## Screenshots
See `.playwright-mcp/` directory for screenshots showing:
- Initial graph state
- Graph auto-centered with playground open
- Graph auto-centered after playground closes

🤖 Generated with [Claude Code](https://claude.com/claude-code)