### PR TITLE
chore: move drizzle-kit to root devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
   "devDependencies": {
     "@biomejs/biome": "2.2.4",
     "@changesets/cli": "^2.29.6",
+    "drizzle-kit": "^0.31.4",
     "husky": "^9.1.6",
     "lint-staged": "^16.1.5",
     "turbo": "^2.5.5"

--- a/packages/agents-core/package.json
+++ b/packages/agents-core/package.json
@@ -79,7 +79,6 @@
     "@types/node": "^20.11.24",
     "@vitest/coverage-v8": "^2.0.0",
     "clean-package": "^2.2.0",
-    "drizzle-kit": "^0.31.4",
     "tsx": "^4.19.2",
     "typescript": "^5.9.2",
     "vitest": "^3.1.4"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,6 +21,9 @@ importers:
       '@changesets/cli':
         specifier: ^2.29.6
         version: 2.29.7(@types/node@24.5.2)
+      drizzle-kit:
+        specifier: ^0.31.4
+        version: 0.31.4
       husky:
         specifier: ^9.1.6
         version: 9.1.7
@@ -919,9 +922,6 @@ importers:
       clean-package:
         specifier: ^2.2.0
         version: 2.2.0
-      drizzle-kit:
-        specifier: ^0.31.4
-        version: 0.31.4
       tsx:
         specifier: ^4.19.2
         version: 4.20.5


### PR DESCRIPTION
## Summary
- Moved `drizzle-kit` from `@inkeep/agents-core` package to root-level devDependencies
- Makes drizzle-kit available across the entire monorepo
- Updated pnpm-lock.yaml accordingly

## Test plan
- [x] Run `pnpm install` to verify lock file is correct
- [x] Verify drizzle-kit is accessible from root level

🤖 Generated with [Claude Code](https://claude.com/claude-code)