### PR TITLE
fix: propagate baseUrl correctly in API key authentication

### DIFF
--- a/agents-run-api/src/a2a/client.ts
+++ b/agents-run-api/src/a2a/client.ts
@@ -186,7 +186,7 @@ export class A2AClient {
       this.serviceEndpointUrl = agentCard.url; // Cache the service endpoint URL from the agent card
       return agentCard;
     } catch (error) {
-      console.error('Error fetching or parsing Agent Card:');
+      console.error('Error fetching or parsing Agent Card:', error);
       // Allow the promise to reject so users of agentCardPromise can handle it.
       throw error;
     }

--- a/agents-run-api/src/middleware/api-key-auth.ts
+++ b/agents-run-api/src/middleware/api-key-auth.ts
@@ -37,7 +37,7 @@ export const apiKeyAuth = () =>
 
       if (authHeader?.startsWith('Bearer ')) {
         try {
-          executionContext = await extractContextFromApiKey(authHeader.substring(7));
+          executionContext = await extractContextFromApiKey(authHeader.substring(7), baseUrl);
           executionContext.agentId = agentId;
           logger.info({}, 'Development/test environment - API key authenticated successfully');
         } catch {
@@ -115,7 +115,7 @@ export const apiKeyAuth = () =>
         await next();
         return;
       } else if (apiKey) {
-        const executionContext = await extractContextFromApiKey(apiKey);
+        const executionContext = await extractContextFromApiKey(apiKey, baseUrl);
         executionContext.agentId = agentId;
 
         c.set('executionContext', executionContext);
@@ -141,7 +141,7 @@ export const apiKeyAuth = () =>
     }
 
     try {
-      const executionContext = await extractContextFromApiKey(apiKey);
+      const executionContext = await extractContextFromApiKey(apiKey, baseUrl);
       executionContext.agentId = agentId;
 
       c.set('executionContext', executionContext);
@@ -172,7 +172,7 @@ export const apiKeyAuth = () =>
     }
   });
 
-export const extractContextFromApiKey = async (apiKey: string) => {
+export const extractContextFromApiKey = async (apiKey: string, baseUrl?: string) => {
   const apiKeyRecord = await validateAndGetApiKey(apiKey, dbClient);
 
   if (!apiKeyRecord) {
@@ -187,6 +187,7 @@ export const extractContextFromApiKey = async (apiKey: string) => {
     projectId: apiKeyRecord.projectId,
     graphId: apiKeyRecord.graphId,
     apiKeyId: apiKeyRecord.id,
+    baseUrl: baseUrl,
   });
 };
 /**


### PR DESCRIPTION
## Problem

The `baseUrl` was not being propagated correctly through the API key authentication chain in remote deployments. This caused the system to fall back to `localhost:3003` instead of using the actual deployment URL when fetching agent cards via A2A protocol.

## Root Cause

The `extractContextFromApiKey` function in `agents-run-api/src/middleware/api-key-auth.ts` did not accept or pass the `baseUrl` parameter to `createExecutionContext`, causing it to fall back to:
```typescript
baseUrl: params.baseUrl || process.env.API_URL || 'http://localhost:3003'
```

## Changes

1. **Updated `extractContextFromApiKey` function signature** to accept optional `baseUrl` parameter
2. **Updated all 3 calls to `extractContextFromApiKey`** to pass the `baseUrl` extracted from the request:
   - Development/test mode with API key (line 40)
   - Bypass secret mode with API key (line 118)
   - Production mode (line 144)
3. **Improved error logging** in A2AClient to show actual error details instead of swallowing them

## Testing

- ✅ TypeScript compilation passes
- ✅ Full monorepo build succeeds
- ✅ All type checks pass
- ✅ Pre-push checks complete

## Impact

This ensures that A2A agent card fetches at `/.well-known/agent.json` use the correct deployment URL in production environments, fixing the agent card discovery bug in remote deployments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)