### PR TITLE
mcp client cache

### DIFF
--- a/agents-manage-ui/src/hooks/use-oauth-login.ts
+++ b/agents-manage-ui/src/hooks/use-oauth-login.ts
@@ -14,7 +14,16 @@ export function useOAuthLogin({ tenantId, projectId, onFinish, onError }: UseOAu
   const router = useRouter();
   const { INKEEP_AGENTS_MANAGE_API_URL } = useRuntimeConfig();
 
+  // Track active OAuth attempts to prevent conflicts
+  const activeAttempts = new Map<string, () => void>();
+
   const handleOAuthLogin = (toolId: string) => {
+    // Clean up any previous attempt for this toolId
+    const existingCleanup = activeAttempts.get(toolId);
+    if (existingCleanup) {
+      existingCleanup();
+      activeAttempts.delete(toolId);
+    }
     try {
       // Get the OAuth URL and open in popup window
       const oauthUrl = getOAuthLoginUrl({
@@ -23,23 +32,31 @@ export function useOAuthLogin({ tenantId, projectId, onFinish, onError }: UseOAu
         projectId,
         id: toolId,
       });
+
       const popup = window.open(
         oauthUrl,
         'oauth-popup',
         'width=600,height=700,scrollbars=yes,resizable=yes,status=yes,location=yes'
       );
 
-      // Listen for OAuth success message from popup
+      if (!popup) {
+        console.error(`Failed to open popup for ${toolId} - blocked by browser`);
+        return;
+      }
+
+      // Track completion to prevent duplicate calls
+      let completed = false;
+
+      // Listen for success PostMessage
       const handleMessage = (event: MessageEvent) => {
-        if (event.data.type === 'oauth-success' && event.data.toolId === toolId) {
-          // Clean up listener
+        if (event.data.type === 'oauth-success' && !completed) {
+          completed = true;
           window.removeEventListener('message', handleMessage);
 
           // Call custom success handler or default behavior
           if (onFinish) {
             onFinish(toolId);
           } else {
-            // Default: navigate to server details page
             router.push(`/${tenantId}/projects/${projectId}/mcp-servers/${toolId}`);
           }
         }
@@ -48,30 +65,48 @@ export function useOAuthLogin({ tenantId, projectId, onFinish, onError }: UseOAu
       if (popup) {
         window.addEventListener('message', handleMessage);
 
-        // Fallback: Monitor popup for closure
-        const checkClosed = setInterval(() => {
-          if (popup.closed) {
-            clearInterval(checkClosed);
-            window.removeEventListener('message', handleMessage);
+        // Backup: Monitor popup closure (for errors or PostMessage failures)
+        // Delay backup monitoring to give PostMessage priority
+        let checkPopupClosed: NodeJS.Timeout | null = null;
+        const backupTimeout = setTimeout(() => {
+          if (!completed) {
+            checkPopupClosed = setInterval(() => {
+              try {
+                if (popup.closed && !completed) {
+                  completed = true;
+                  if (checkPopupClosed) clearInterval(checkPopupClosed);
+                  window.removeEventListener('message', handleMessage);
+                  activeAttempts.delete(toolId);
 
-            // Call custom success handler or default behavior
-            if (onFinish) {
-              onFinish(toolId);
-            } else {
-              // Default: navigate to server details page
-              router.push(`/${tenantId}/projects/${projectId}/mcp-servers/${toolId}`);
-            }
+                  // Call custom success handler or default behavior
+                  if (onFinish) {
+                    onFinish(toolId);
+                  } else {
+                    router.push(`/${tenantId}/projects/${projectId}/mcp-servers/${toolId}`);
+                  }
+                }
+              } catch {
+                // Cross-origin errors are expected during OAuth redirects
+              }
+            }, 1000); // Check every second
           }
-        }, 1000);
+        }, 3000); // Wait 3 seconds before starting backup monitoring
+
+        // Register cleanup function for this attempt
+        const cleanup = () => {
+          clearTimeout(backupTimeout);
+          if (checkPopupClosed) clearInterval(checkPopupClosed);
+          window.removeEventListener('message', handleMessage);
+          completed = true;
+        };
+        activeAttempts.set(toolId, cleanup);
       }
     } catch (error) {
-      console.error('OAuth login failed:', error);
       const errorObj = error instanceof Error ? error : new Error('OAuth login failed');
 
       if (onError) {
         onError(errorObj);
       } else {
-        // Default error handling
         toast.error('OAuth login failed. Please try again.');
       }
     }

--- a/packages/agents-core/src/utils/mcp-client.ts
+++ b/packages/agents-core/src/utils/mcp-client.ts
@@ -5,7 +5,11 @@ import type { StreamableHTTPClientTransportOptions } from '@modelcontextprotocol
 import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
 import { DEFAULT_REQUEST_TIMEOUT_MSEC } from '@modelcontextprotocol/sdk/shared/protocol.js';
 import type { Transport } from '@modelcontextprotocol/sdk/shared/transport.js';
-import { CallToolResultSchema, type ClientCapabilities, type Tool } from '@modelcontextprotocol/sdk/types.js';
+import {
+  CallToolResultSchema,
+  type ClientCapabilities,
+  type Tool,
+} from '@modelcontextprotocol/sdk/types.js';
 
 import { tool } from 'ai';
 import { asyncExitHook, gracefulExit } from 'exit-hook';


### PR DESCRIPTION
## Fix MCP Connection Race Condition Causing Timeouts

**Problem**: Agent framework was creating multiple concurrent MCP client connections to the same server, causing timeouts and failures (especially with Maestro's 119 tools).

**Solution**: Implemented connection caching with async locking to ensure only one `McpClient` instance per MCP server. Concurrent requests now wait for the initial connection instead of creating duplicates.

**Results**: 
- Maestro: 60+ second timeout → 4 second success
- Linear: 10 second response → 7 second response (30% improvement)
- Eliminates race conditions and server overload

**Technical**: Added `mcpClientCache` and `mcpConnectionLocks` maps to `Agent.ts` to manage connection lifecycle and prevent concurrent connection attempts.

also added improvement to oauth popup, and nango-store. For nango-store, we try to ignore other fields from the oauth key to be able to fit it into apikey field