### PR TITLE
Fix broken `og-image`, `twitter-image`, `og-url` on docs website

### DIFF
--- a/agents-docs/src/lib/metadata.ts
+++ b/agents-docs/src/lib/metadata.ts
@@ -11,11 +11,11 @@ export function createMetadata(override: Metadata): Metadata {
   return {
     ...override,
     icons: '/icon.svg',
-    metadataBase: new URL('https://https://docs.inkeep.com//'),
+    metadataBase: new URL('https://docs.inkeep.com//'),
     openGraph: {
       title: override.title ?? undefined,
       description: override.description ?? undefined,
-      url: 'https://https://docs.inkeep.com//',
+      url: 'https://docs.inkeep.com//',
       //   images: "/banner.png",
       siteName: 'Inkeep Agents',
       ...override.openGraph,


### PR DESCRIPTION
<img width="550" height="31" alt="image" src="https://github.com/user-attachments/assets/d6c1b994-92c3-4fc1-b6bc-d0a1ee904e69" />
<img width="657" height="31" alt="image" src="https://github.com/user-attachments/assets/68ffc93e-018c-4f4e-8443-b727807efb00" />
<img width="641" height="25" alt="image" src="https://github.com/user-attachments/assets/5239b27e-66df-4f6f-bdf9-cd484a4d1df8" />
