### PR TITLE
fix: remove pipe character from documentation title

### DIFF
--- a/agents-docs/content/docs/community/contributing/overview.mdx
+++ b/agents-docs/content/docs/community/contributing/overview.mdx
@@ -1,5 +1,5 @@
 ---
-title: Overview | Contributing
+title: Contributing Overview
 description: How to contribute to the Inkeep Agent Framework
 icon: "LuGitPullRequest"
 ---


### PR DESCRIPTION
Changed title from "Overview | Contributing" to "Contributing Overview" to avoid potential front matter parsing issues with pipe characters.

🤖 Generated with [Claude Code](https://claude.com/claude-code)