### PR TITLE
enables line wrapping in the prompt/graph prompts editors

### DIFF
--- a/.changeset/long-ends-prove.md
+++ b/.changeset/long-ends-prove.md
@@ -1,0 +1,5 @@
+---
+"@inkeep/agents-manage-ui": patch
+---
+
+enables line wrapping in the prompt/graph prompts editors

--- a/agents-manage-ui/src/components/form/prompt-editor.tsx
+++ b/agents-manage-ui/src/components/form/prompt-editor.tsx
@@ -216,6 +216,7 @@ export const PromptEditor: FC<TextareaWithSuggestionsProps> = ({
       templateVariablePlugin,
       templateVariableTheme,
       createTemplateVariableLinter(suggestions),
+      EditorView.lineWrapping,
     ];
   }, [contextConfig]);
 


### PR DESCRIPTION
after

<img width="464" height="312" alt="image" src="https://github.com/user-attachments/assets/070ddc04-260b-4d43-aea0-367038b7b033" />
<img width="1269" height="493" alt="image" src="https://github.com/user-attachments/assets/d414ad23-343e-4fdd-a248-449423913117" />

