### PR TITLE
Align toast error colors with `<GraphErrorSummaryComponent>` styling

### DIFF
--- a/.changeset/metal-bars-stop.md
+++ b/.changeset/metal-bars-stop.md
@@ -1,0 +1,5 @@
+---
+"@inkeep/agents-manage-ui": patch
+---
+
+Align toast error colors with `<GraphErrorSummaryComponent>` styling

--- a/agents-manage-ui/src/app/globals.css
+++ b/agents-manage-ui/src/app/globals.css
@@ -266,3 +266,8 @@
 .react-flow__attribution {
   padding: 4px 8px;
 }
+
+/* Align toast error colors with `<GraphErrorSummaryComponent>` styling */
+li[data-sonner-toast][data-type="error"] {
+  @apply text-red-700 dark:text-red-400 border-red-200 dark:border-red-800 bg-red-50/50 dark:bg-red-950/30 backdrop-blur-sm shadow-xl;
+}


### PR DESCRIPTION
|before|after|
|:-|:-|
|<img width="862" height="518" alt="image" src="https://github.com/user-attachments/assets/fd23b549-8938-4882-83f6-c0034ccdb380" /> |<img width="860" height="522" alt="image" src="https://github.com/user-attachments/assets/c86b633a-6f76-4d8a-ab36-14112836d38e" /> |
| <img width="865" height="526" alt="image" src="https://github.com/user-attachments/assets/ccab328e-d15f-4509-bef6-ab364b850a7e" />|<img width="856" height="523" alt="image" src="https://github.com/user-attachments/assets/fe3b47d2-6b95-4a3d-957c-a8037ed4eb44" />|