### PR TITLE
better monaco-editor test cleanup

### DIFF
--- a/agents-manage-ui/src/lib/__tests__/monaco-utils.test.tsx
+++ b/agents-manage-ui/src/lib/__tests__/monaco-utils.test.tsx
@@ -39,15 +39,22 @@ describe('Monaco-Editor Functionality', () => {
     });
   });
 
-  afterEach(() => {
+  afterEach(async () => {
     editor?.dispose();
     model?.dispose();
     container?.remove();
+
+    // Wait for any pending operations to complete
+    const { promise, resolve } = Promise.withResolvers();
+    requestAnimationFrame(resolve);
+    await promise;
   });
 
   it('should test monaco.editor.tokenize with proper worker initialization', async () => {
     // Wait for Monaco workers to initialize
-    await new Promise((resolve) => setTimeout(resolve, 1000));
+    const { promise, resolve } = Promise.withResolvers();
+    requestAnimationFrame(resolve);
+    await promise;
 
     expect(monaco.editor.tokenize(model.getValue(), 'json')).toMatchInlineSnapshot(`
       [


### PR DESCRIPTION
sometimes test crash with error. This PR should improve it

```
⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯ Unhandled Errors ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯

Vitest caught 2 unhandled errors during the test run.
This might cause false positive tests. Resolve unhandled errors to make sure your tests are not affected.

⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯ Unhandled Rejection ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯
TypeError: Failed to execute 'dispatchEvent' on 'EventTarget': parameter 1 is not of type 'Event'.
 ❯ Object.exports.convert ../node_modules/.pnpm/jsdom@26.1.0/node_modules/jsdom/lib/jsdom/living/generated/Event.js:22:9
 ❯ Worker.dispatchEvent ../node_modules/.pnpm/jsdom@26.1.0/node_modules/jsdom/lib/jsdom/living/generated/EventTarget.js:236:24
 ❯ ../node_modules/.pnpm/@vitest+web-worker@3.1.4_vitest@3.2.4_@types+debug@4.1.12_@types+node@20.19.19_jiti@2.6_2a73bdc69e62de28a668b9f96e4a8988/node_modules/@vitest/web-worker/dist/pure.js:603:10
    601|      message: e.message
    602|     });
    603|     this.dispatchEvent(error);
       |          ^
    604|     this.onerror?.(error);
    605|     console.error(e);
 ❯ processTicksAndRejections node:internal/process/task_queues:105:5

This error originated in "src/lib/__tests__/monaco-utils.test.tsx" test file. It doesn't mean the error was thrown inside the file itself, but while it was running.
This error was caught after test environment was torn down. Make sure to cancel any running tasks before test finishes:
- cancel timeouts using clearTimeout and clearInterval
- wait for promises to resolve using the await keyword

⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯ Unhandled Rejection ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯
TypeError: Failed to execute 'dispatchEvent' on 'EventTarget': parameter 1 is not of type 'Event'.
 ❯ Object.exports.convert ../node_modules/.pnpm/jsdom@26.1.0/node_modules/jsdom/lib/jsdom/living/generated/Event.js:22:9
 ❯ Worker.dispatchEvent ../node_modules/.pnpm/jsdom@26.1.0/node_modules/jsdom/lib/jsdom/living/generated/EventTarget.js:236:24
 ❯ ../node_modules/.pnpm/@vitest+web-worker@3.1.4_vitest@3.2.4_@types+debug@4.1.12_@types+node@20.19.19_jiti@2.6_2a73bdc69e62de28a668b9f96e4a8988/node_modules/@vitest/web-worker/dist/pure.js:603:10
    601|      message: e.message
    602|     });
    603|     this.dispatchEvent(error);
       |          ^
    604|     this.onerror?.(error);
    605|     console.error(e);
 ❯ processTicksAndRejections node:internal/process/task_queues:105:5

This error originated in "src/lib/__tests__/monaco-utils.test.tsx" test file. It doesn't mean the error was thrown inside the file itself, but while it was running.
This error was caught after test environment was torn down. Make sure to cancel any running tasks before test finishes:
- cancel timeouts using clearTimeout and clearInterval
- wait for promises to resolve using the await keyword
⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯


 Test Files  5 passed (5)
      Tests  44 passed (44)
     Errors  2 errors
   Start at  21:49:42
   Duration  6.44s (transform 4.21s, setup 479ms, collect 6.64s, tests 402ms, environment 1.72s, prepare 490ms)
```