### PR TITLE
feat: Register additional OpenAPI schemas for $ref reuse

### DIFF
--- a/packages/agents-core/src/validation/schemas.ts
+++ b/packages/agents-core/src/validation/schemas.ts
@@ -871,22 +871,28 @@ export const SingleResponseSchema = <T extends z.ZodTypeAny>(itemSchema: T) =>
     data: itemSchema,
   });
 
-export const ErrorResponseSchema = z.object({
-  error: z.string(),
-  message: z.string().optional(),
-  details: z.any().optional().openapi({
-    description: 'Additional error details',
-  }),
-});
+export const ErrorResponseSchema = z
+  .object({
+    error: z.string(),
+    message: z.string().optional(),
+    details: z.any().optional().openapi({
+      description: 'Additional error details',
+    }),
+  })
+  .openapi('ErrorResponse');
 
-export const ExistsResponseSchema = z.object({
-  exists: z.boolean(),
-});
+export const ExistsResponseSchema = z
+  .object({
+    exists: z.boolean(),
+  })
+  .openapi('ExistsResponse');
 
-export const RemovedResponseSchema = z.object({
-  message: z.string(),
-  removed: z.boolean(),
-});
+export const RemovedResponseSchema = z
+  .object({
+    message: z.string(),
+    removed: z.boolean(),
+  })
+  .openapi('RemovedResponse');
 
 // === Project Schemas ===
 export const ProjectSelectSchema = createSelectSchema(projects);


### PR DESCRIPTION
## Summary
Registers 3 utility schemas that were previously inlined throughout the OpenAPI specification:
- `ErrorResponse`
- `ExistsResponse`  
- `RemovedResponse`

This is part 1 of a 2-part OpenAPI optimization effort. Part 2 will introduce concrete response wrapper schemas for larger gains.

## Results
- **Schema count**: 58 → 61 (+3)
- **Spec size**: 232,004 → 230,120 bytes
- **Reduction**: 1,884 bytes (~0.8%)
- `ErrorResponse` now referenced 16 times via `$ref` instead of being inlined

## Why Small Reduction?
The modest size reduction is expected because:
1. These 3 schemas are relatively small
2. They weren't used very frequently throughout the spec
3. The main size savings will come from registering response wrapper schemas in Part 2

## Technical Details
Added `.openapi('SchemaName')` registration to:
```typescript
export const ErrorResponseSchema = z
  .object({
    error: z.string(),
    message: z.string().optional(),
    details: z.any().optional().openapi({
      description: 'Additional error details',
    }),
  })
  .openapi('ErrorResponse');  // ← Added registration

// Similar for ExistsResponse and RemovedResponse
```

## Testing
- ✅ All existing tests passing
- ✅ OpenAPI spec validates successfully
- ✅ Schema references working correctly

## Next Steps
Part 2 will register concrete response wrapper schemas (e.g., `ProjectResponse`, `ProjectListResponse`) to eliminate the 54+ instances of wrapper duplication, targeting an additional 30-40KB reduction.