### PR TITLE
refactor(agents-core): reduce comments phase 3 part 6

### DIFF
--- a/packages/agents-core/src/types/a2a.ts
+++ b/packages/agents-core/src/types/a2a.ts
@@ -1,4 +1,3 @@
-// === Core A2A Data Structures ===
 
 export interface PartBase {
   metadata?: { [key: string]: any };
@@ -69,7 +68,6 @@ export interface AgentSkill {
   outputModes?: string[];
 }
 
-// Security Scheme types
 export interface SecuritySchemeBase {
   description?: string;
 }
@@ -205,7 +203,6 @@ export interface TaskArtifactUpdateEvent {
   metadata?: { [key: string]: any };
 }
 
-// === Error Types (Standard and A2A) ===
 
 export interface JSONParseError extends JSONRPCError {
   code: -32700;
@@ -278,7 +275,6 @@ export type A2AError =
   | ContentTypeNotSupportedError
   | InvalidAgentResponseError;
 
-// === Push Notifications ===
 
 export interface PushNotificationAuthenticationInfo {
   schemes: string[];
@@ -296,7 +292,6 @@ export interface TaskPushNotificationConfig {
   pushNotificationConfig: PushNotificationConfig;
 }
 
-// === A2A Request Parameter Types ===
 
 export interface TaskIdParams {
   id: string;
@@ -320,7 +315,6 @@ export interface MessageSendParams {
   metadata?: { [key: string]: any };
 }
 
-// === JSON-RPC Base Structures ===
 
 /**
  * Base interface for all JSON-RPC messages (Requests and Responses).
@@ -363,7 +357,6 @@ export interface JSONRPCErrorResponse extends JSONRPCMessage {
   result?: never;
   error: JSONRPCError | A2AError;
 }
-// === A2A Request Interfaces ===
 
 export interface SendMessageRequest extends JSONRPCRequest {
   method: 'message/send';
@@ -400,42 +393,34 @@ export interface TaskResubscriptionRequest extends JSONRPCRequest {
   params: TaskIdParams;
 }
 
-// === A2A Response Interfaces ===
 
-// --- SendMessage ---
 export interface SendMessageSuccessResponse extends JSONRPCResult<Message | Task> {}
 export type SendMessageResponse = SendMessageSuccessResponse | JSONRPCErrorResponse;
 
-// --- SendStreamingMessage ---
 export interface SendStreamingMessageSuccessResponse
   extends JSONRPCResult<Message | Task | TaskStatusUpdateEvent | TaskArtifactUpdateEvent> {}
 export type SendStreamingMessageResponse =
   | SendStreamingMessageSuccessResponse
   | JSONRPCErrorResponse;
 
-// --- GetTask ---
 export interface GetTaskSuccessResponse extends JSONRPCResult<Task> {}
 export type GetTaskResponse = GetTaskSuccessResponse | JSONRPCErrorResponse;
 
-// --- CancelTask ---
 export interface CancelTaskSuccessResponse extends JSONRPCResult<Task> {}
 export type CancelTaskResponse = CancelTaskSuccessResponse | JSONRPCErrorResponse;
 
-// --- SetTaskPushNotificationConfig ---
 export interface SetTaskPushNotificationConfigSuccessResponse
   extends JSONRPCResult<TaskPushNotificationConfig> {}
 export type SetTaskPushNotificationConfigResponse =
   | SetTaskPushNotificationConfigSuccessResponse
   | JSONRPCErrorResponse;
 
-// --- GetTaskPushNotificationConfig ---
 export interface GetTaskPushNotificationConfigSuccessResponse
   extends JSONRPCResult<TaskPushNotificationConfig> {}
 export type GetTaskPushNotificationConfigResponse =
   | GetTaskPushNotificationConfigSuccessResponse
   | JSONRPCErrorResponse;
 
-// === Union Types for A2A Requests/Responses ===
 
 export type A2ARequest =
   | SendMessageRequest
@@ -458,7 +443,6 @@ export type A2AResponse =
   | GetTaskPushNotificationConfigResponse
   | JSONRPCErrorResponse; // Catch-all for other error responses
 
-// === Backward Compatibility Aliases ===
 // These help bridge our simplified implementation with Google's full schema
 
 export type MessagePart = Part;

--- a/packages/agents-core/src/utils/mcp-client.ts
+++ b/packages/agents-core/src/utils/mcp-client.ts
@@ -173,29 +173,21 @@ export class McpClient {
 
     const { selectedTools, activeTools } = this.serverConfig;
 
-    // Step 1: Determine the universe of available tools
     let availableTools: Tool[];
 
     if (activeTools === undefined) {
-      // activeTools undefined = all tools are available
       availableTools = tools;
     } else if (activeTools.length === 0) {
-      // activeTools empty = no tools available (regardless of selectedTools)
       return [];
     } else {
-      // activeTools defined with items = filter to only those tools
       availableTools = tools.filter((tool: Tool) => activeTools.includes(tool.name));
     }
 
-    // Step 2: Apply selectedTools filtering to available tools
     if (selectedTools === undefined) {
-      // selectedTools undefined = use all available tools
       return availableTools;
     } else if (selectedTools.length === 0) {
-      // selectedTools empty array = no tools selected
       return [];
     } else {
-      // selectedTools has items = filter available tools by selection
       const toolNames = availableTools.map((tool: Tool) => tool.name);
       this.validateSelectedTools(toolNames, selectedTools);
       return availableTools.filter((tool: Tool) => selectedTools.includes(tool.name));
@@ -208,7 +200,6 @@ export class McpClient {
 
     for (const def of tools) {
       try {
-        // Convert JSON Schema to Zod schema
         const createZodSchema = (inputSchema: any) => {
           if (!inputSchema || !inputSchema.properties) {
             return z.object({});
@@ -241,7 +232,6 @@ export class McpClient {
               zodType = zodType.describe(propDef.description);
             }
 
-            // Make field optional if not in required array
             const isRequired = inputSchema.required?.includes(key);
             if (!isRequired) {
               zodType = zodType.optional();


### PR DESCRIPTION
Remove 45 lines of section dividers and helper descriptions from tools.ts, a2a.ts, and mcp-client.ts. Progress: 50% toward Phase 3 goal (516 / 1,026-1,197 lines).