### PR TITLE
refactor(agents-core): complete phase 3 comment reduction

### DIFF
--- a/packages/agents-core/src/api-client/base-client.ts
+++ b/packages/agents-core/src/api-client/base-client.ts
@@ -31,7 +31,6 @@
  * ```
  */
 export async function apiFetch(url: string, options: RequestInit = {}): Promise<Response> {
-  // Build headers with defaults
   const headers: Record<string, string> = {
     'Content-Type': 'application/json',
     Accept: 'application/json',

--- a/packages/agents-core/src/context/ContextConfig.ts
+++ b/packages/agents-core/src/context/ContextConfig.ts
@@ -384,7 +384,6 @@ export function headers<R extends z.ZodTypeAny>(
   return new HeadersSchemaBuilder<R>(options);
 }
 
-// Helper function to create fetch definitions
 export function fetchDefinition<R extends z.ZodTypeAny>(
   options: builderFetchDefinition<R>
 ): Omit<builderFetchDefinition<R>, 'credentialReference'> & {

--- a/packages/agents-core/src/context/ContextFetcher.ts
+++ b/packages/agents-core/src/context/ContextFetcher.ts
@@ -27,7 +27,6 @@ const checkGraphQLErrors: ResponseErrorChecker = (data: unknown) => {
   }
 };
 
-// List of error checkers to validate responses
 // Each checker examines the response and throws if errors are detected
 const responseErrorCheckers: ResponseErrorChecker[] = [
   checkGraphQLErrors,
@@ -104,7 +103,6 @@ export class ContextFetcher {
         transformedData = this.transformResponse(response.data, definition.fetchConfig.transform);
       }
 
-      // Validate against response schema if provided
       if (definition.responseSchema) {
         this.validateResponseWithJsonSchema(
           transformedData,
@@ -370,7 +368,6 @@ export class ContextFetcher {
         'Failed to transform response data'
       );
 
-      // Return original data if transformation fails
       return data;
     }
   }

--- a/packages/agents-core/src/data-access/agentFull.ts
+++ b/packages/agents-core/src/data-access/agentFull.ts
@@ -1489,7 +1489,6 @@ export const deleteFullAgent =
     logger.info({ tenantId, agentId }, 'Deleting full agent and related entities');
 
     try {
-      // Get the agent first to ensure it exists
       const agent = await getFullAgentDefinition(db)({
         scopes: { tenantId, projectId, agentId },
       });
@@ -1499,16 +1498,13 @@ export const deleteFullAgent =
         return false;
       }
 
-      // Step 1: Delete all agent relations for this agent
       await deleteAgentRelationsByAgent(db)({
         scopes: { tenantId, projectId, agentId },
       });
       logger.info({ tenantId, agentId }, 'Agent relations deleted');
 
-      // Step 2: Delete agent-tool relations for agents in this agent
       const subAgentIds = Object.keys(agent.subAgents);
       if (subAgentIds.length > 0) {
-        // Delete agent-tool relations for all agents in this agent
         for (const subAgentId of subAgentIds) {
           await deleteAgentToolRelationByAgent(db)({
             scopes: { tenantId, projectId, agentId, subAgentId: subAgentId },
@@ -1521,7 +1517,6 @@ export const deleteFullAgent =
         );
       }
 
-      // Step 3: Delete the agent metadata
       await deleteAgent(db)({
         scopes: { tenantId, projectId, agentId },
       });

--- a/packages/agents-core/src/data-access/apiKeys.ts
+++ b/packages/agents-core/src/data-access/apiKeys.ts
@@ -140,7 +140,6 @@ export const deleteApiKey =
   (db: DatabaseClient) =>
   async (params: { scopes: ProjectScopeConfig; id: string }): Promise<boolean> => {
     try {
-      // Check if the API key exists
       const existingKey = await getApiKeyById(db)({
         scopes: params.scopes,
         id: params.id,
@@ -253,18 +252,15 @@ export const validateAndGetApiKey = async (
     return null;
   }
 
-  // Validate the full key against the stored hash
   const isValid = await validateApiKey(key, apiKey.keyHash);
   if (!isValid) {
     return null;
   }
 
-  // Check if the key has expired
   if (isApiKeyExpired(apiKey.expiresAt)) {
     return null;
   }
 
-  // Update last used timestamp
   await updateApiKey(db)({
     scopes: { tenantId: apiKey.tenantId, projectId: apiKey.projectId },
     id: apiKey.id,

--- a/packages/agents-core/src/data-access/artifactComponents.ts
+++ b/packages/agents-core/src/data-access/artifactComponents.ts
@@ -86,7 +86,6 @@ export const listArtifactComponentsPaginated =
 
 export const createArtifactComponent =
   (db: DatabaseClient) => async (params: ArtifactComponentInsert) => {
-    // Validate props as JSON Schema if provided
     if (params.props !== null && params.props !== undefined) {
       const propsValidation = validatePropsAsJsonSchema(params.props);
       if (!propsValidation.isValid) {
@@ -114,7 +113,6 @@ export const createArtifactComponent =
 export const updateArtifactComponent =
   (db: DatabaseClient) =>
   async (params: { scopes: ProjectScopeConfig; id: string; data: ArtifactComponentUpdate }) => {
-    // Validate props as JSON Schema if provided
     if (params.data.props !== undefined && params.data.props !== null) {
       const propsValidation = validatePropsAsJsonSchema(params.data.props);
       if (!propsValidation.isValid) {
@@ -372,11 +370,9 @@ export const countArtifactComponentsForAgent =
 export const upsertAgentArtifactComponentRelation =
   (db: DatabaseClient) =>
   async (params: { scopes: SubAgentScopeConfig; artifactComponentId: string }) => {
-    // Check if relation already exists
     const exists = await isArtifactComponentAssociatedWithAgent(db)(params);
 
     if (!exists) {
-      // Create the relation if it doesn't exist
       return await associateArtifactComponentWithAgent(db)(params);
     }
 
@@ -399,7 +395,6 @@ export const upsertArtifactComponent =
     });
 
     if (existing) {
-      // Update existing artifact component
       return await updateArtifactComponent(db)({
         scopes,
         id: params.data.id,
@@ -410,7 +405,6 @@ export const upsertArtifactComponent =
         },
       });
     } else {
-      // Create new artifact component
       return await createArtifactComponent(db)(params.data);
     }
   };

--- a/packages/agents-core/src/data-access/contextCache.ts
+++ b/packages/agents-core/src/data-access/contextCache.ts
@@ -29,7 +29,6 @@ export const getCacheEntry =
         return null;
       }
 
-      // Check if request hash matches (for cache invalidation based on request changes)
       if (
         params.requestHash &&
         cacheEntry.requestHash &&

--- a/packages/agents-core/src/data-access/contextConfigs.ts
+++ b/packages/agents-core/src/data-access/contextConfigs.ts
@@ -48,7 +48,6 @@ export const listContextConfigsPaginated =
       eq(contextConfigs.agentId, params.scopes.agentId)
     );
 
-    // Get paginated results
     const [contextConfigList, totalResult] = await Promise.all([
       db
         .select()
@@ -217,7 +216,6 @@ export const upsertContextConfig =
       });
 
       if (existing) {
-        // Update existing context config
         return await updateContextConfig(db)({
           scopes,
           id: params.data.id,
@@ -229,6 +227,5 @@ export const upsertContextConfig =
       }
     }
 
-    // Create new context config (either no ID provided or ID doesn't exist)
     return await createContextConfig(db)(params.data);
   };

--- a/packages/agents-core/src/data-access/conversations.ts
+++ b/packages/agents-core/src/data-access/conversations.ts
@@ -42,7 +42,6 @@ export const listConversations =
       .limit(limit)
       .offset(offset);
 
-    // Get total count for pagination
     const totalResult = await db
       .select({ count: count() })
       .from(conversations)
@@ -102,7 +101,6 @@ export const deleteConversation =
   (db: DatabaseClient) =>
   async (params: { scopes: ProjectScopeConfig; conversationId: string }): Promise<boolean> => {
     try {
-      // Delete messages first (due to foreign key constraints)
       await db
         .delete(messages)
         .where(
@@ -113,7 +111,6 @@ export const deleteConversation =
           )
         );
 
-      // Delete conversation
       await db
         .delete(conversations)
         .where(
@@ -160,19 +157,16 @@ export const getConversation =
     });
   };
 
-// Create or get existing conversation
 export const createOrGetConversation =
   (db: DatabaseClient) => async (input: ConversationInsert) => {
     const conversationId = input.id || getConversationId();
 
-    // Check if conversation already exists
     if (input.id) {
       const existing = await db.query.conversations.findFirst({
         where: and(eq(conversations.tenantId, input.tenantId), eq(conversations.id, input.id)),
       });
 
       if (existing) {
-        // Update active agent if different
         if (existing.activeSubAgentId !== input.activeSubAgentId) {
           await db
             .update(conversations)

--- a/packages/agents-core/src/data-access/credentialReferences.ts
+++ b/packages/agents-core/src/data-access/credentialReferences.ts
@@ -193,7 +193,6 @@ export const deleteCredentialReference =
       return false;
     }
 
-    // Delete the credential reference
     await db
       .delete(credentialReferences)
       .where(
@@ -277,7 +276,6 @@ export const upsertCredentialReference =
     });
 
     if (existing) {
-      // Update existing credential reference
       const updated = await updateCredentialReference(db)({
         scopes,
         id: params.data.id,
@@ -292,7 +290,6 @@ export const upsertCredentialReference =
       }
       return updated;
     } else {
-      // Create new credential reference
       return await createCredentialReference(db)(params.data);
     }
   };

--- a/packages/agents-core/src/data-access/dataComponents.ts
+++ b/packages/agents-core/src/data-access/dataComponents.ts
@@ -108,7 +108,6 @@ export const listDataComponentsPaginated =
 export const createDataComponent =
   (db: DatabaseClient) =>
   async (params: DataComponentInsert): Promise<DataComponentSelect> => {
-    // Validate props as JSON Schema (required for data components)
     if (params.props) {
       const propsValidation = validatePropsAsJsonSchema(params.props);
       if (!propsValidation.isValid) {
@@ -134,7 +133,6 @@ export const updateDataComponent =
     dataComponentId: string;
     data: DataComponentUpdate;
   }): Promise<DataComponentSelect | null> => {
-    // Validate props as JSON Schema if provided
     if (params.data.props !== undefined && params.data.props !== null) {
       const propsValidation = validatePropsAsJsonSchema(params.data.props);
       if (!propsValidation.isValid) {
@@ -328,11 +326,9 @@ export const isDataComponentAssociatedWithAgent =
 export const upsertAgentDataComponentRelation =
   (db: DatabaseClient) =>
   async (params: { scopes: SubAgentScopeConfig; dataComponentId: string }) => {
-    // Check if relation already exists
     const exists = await isDataComponentAssociatedWithAgent(db)(params);
 
     if (!exists) {
-      // Create the relation if it doesn't exist
       return await associateDataComponentWithAgent(db)(params);
     }
 
@@ -375,7 +371,6 @@ export const upsertDataComponent =
     });
 
     if (existing) {
-      // Update existing data component
       return await updateDataComponent(db)({
         scopes,
         dataComponentId: params.data.id,
@@ -386,7 +381,6 @@ export const upsertDataComponent =
         },
       });
     } else {
-      // Create new data component
       return await createDataComponent(db)(params.data);
     }
   };

--- a/packages/agents-core/src/data-access/externalAgents.ts
+++ b/packages/agents-core/src/data-access/externalAgents.ts
@@ -197,7 +197,6 @@ export const upsertExternalAgent =
     });
 
     if (existing) {
-      // Update existing external agent
       const updated = await updateExternalAgent(db)({
         scopes,
         subAgentId: params.data.id,
@@ -214,7 +213,6 @@ export const upsertExternalAgent =
       }
       return updated;
     } else {
-      // Create new external agent
       return await createExternalAgent(db)(params.data);
     }
   };

--- a/packages/agents-core/src/data-access/functionTools.ts
+++ b/packages/agents-core/src/data-access/functionTools.ts
@@ -161,7 +161,6 @@ export const upsertFunctionTool =
     });
 
     if (existing) {
-      // Update existing function tool
       return await updateFunctionTool(db)({
         scopes,
         functionToolId: params.data.id,
@@ -172,7 +171,6 @@ export const upsertFunctionTool =
         },
       });
     } else {
-      // Create new function tool
       return await createFunctionTool(db)({
         data: params.data,
         scopes,
@@ -189,13 +187,11 @@ export const getFunctionToolsForSubAgent = (db: DatabaseClient) => {
     const { tenantId, projectId, agentId } = scopes;
 
     try {
-      // Get function tools for this agent
       const functionToolsList = await listFunctionTools(db)({
         scopes: { tenantId, projectId, agentId },
         pagination: { page: 1, limit: 1000 },
       });
 
-      // Get sub_agent-function tool relations for this sub_agent
       const relations = await db
         .select()
         .from(subAgentFunctionToolRelations)

--- a/packages/agents-core/src/data-access/functions.ts
+++ b/packages/agents-core/src/data-access/functions.ts
@@ -20,7 +20,6 @@ export const upsertFunction =
       dependencies = autoDetectDependencies(data.executeCode);
     }
 
-    // Check if function exists
     const existingFunction = await db
       .select()
       .from(functions)
@@ -34,7 +33,6 @@ export const upsertFunction =
       .limit(1);
 
     if (existingFunction.length > 0) {
-      // Update existing function
       await db
         .update(functions)
         .set({
@@ -51,7 +49,6 @@ export const upsertFunction =
           )
         );
     } else {
-      // Create new function
       await db.insert(functions).values({
         tenantId,
         projectId,

--- a/packages/agents-core/src/data-access/projectFull.ts
+++ b/packages/agents-core/src/data-access/projectFull.ts
@@ -963,7 +963,6 @@ export const deleteFullProject =
     logger.info({ tenantId, projectId }, 'Deleting full project and related entities');
 
     try {
-      // Step 1: Get the project first to ensure it exists and get its agent
       const project = await getFullProject(
         db,
         logger
@@ -976,7 +975,6 @@ export const deleteFullProject =
         return false;
       }
 
-      // Step 2: Delete all agent in the project
       if (project.agents && Object.keys(project.agents).length > 0) {
         logger.info(
           {
@@ -1022,7 +1020,6 @@ export const deleteFullProject =
         );
       }
 
-      // Step 3: Delete the project itself
       const deleted = await deleteProject(db)({
         scopes: { tenantId, projectId },
       });

--- a/packages/agents-core/src/data-access/subAgentRelations.ts
+++ b/packages/agents-core/src/data-access/subAgentRelations.ts
@@ -195,10 +195,8 @@ export const getExternalAgentRelations =
     };
   };
 
-// Get all related agents (both internal and external) for a given agent
 export const getRelatedAgentsForAgent =
   (db: DatabaseClient) => async (params: { scopes: AgentScopeConfig; subAgentId: string }) => {
-    // Get internal agent relations
     const internalRelations = await db
       .select({
         id: subAgents.id,
@@ -226,7 +224,6 @@ export const getRelatedAgentsForAgent =
         )
       );
 
-    // Get external agent relations
     const externalRelations = await db
       .select({
         id: subAgentRelations.id,
@@ -258,7 +255,6 @@ export const getRelatedAgentsForAgent =
         )
       );
 
-    // Return both types of relations separately
     return {
       internalRelations,
       externalRelations,
@@ -267,7 +263,6 @@ export const getRelatedAgentsForAgent =
 
 export const createSubAgentRelation =
   (db: DatabaseClient) => async (params: SubAgentRelationInsert) => {
-    // Validate that exactly one of targetSubAgentId or externalSubAgentId is provided
     const hasTargetAgent = params.targetSubAgentId != null;
     const hasExternalAgent = params.externalSubAgentId != null;
 
@@ -327,7 +322,6 @@ export const getAgentRelationByParams =
  */
 export const upsertSubAgentRelation =
   (db: DatabaseClient) => async (params: SubAgentRelationInsert) => {
-    // Check if relation already exists
     const existing = await getAgentRelationByParams(db)({
       scopes: { tenantId: params.tenantId, projectId: params.projectId, agentId: params.agentId },
       sourceSubAgentId: params.sourceSubAgentId,
@@ -337,15 +331,12 @@ export const upsertSubAgentRelation =
     });
 
     if (!existing) {
-      // Create the relation if it doesn't exist
       return await createSubAgentRelation(db)(params);
     }
 
-    // Return existing relation if it already exists
     return existing;
   };
 
-// Create external agent relation (convenience function)
 export const createExternalAgentRelation =
   (db: DatabaseClient) => async (params: ExternalSubAgentRelationInsert) => {
     return await createSubAgentRelation(db)({
@@ -411,7 +402,6 @@ export const deleteAgentRelationsByAgent =
     return (result.rowsAffected || 0) > 0;
   };
 
-// Create agent tool relation
 export const createAgentToolRelation =
   (db: DatabaseClient) =>
   async (params: {
@@ -443,7 +433,6 @@ export const createAgentToolRelation =
     return relation[0];
   };
 
-// Update agent tool relation
 export const updateAgentToolRelation =
   (db: DatabaseClient) =>
   async (params: {
@@ -472,7 +461,6 @@ export const updateAgentToolRelation =
     return relation[0];
   };
 
-// Delete agent tool relation
 export const deleteAgentToolRelation =
   (db: DatabaseClient) => async (params: { scopes: AgentScopeConfig; relationId: string }) => {
     const result = await db
@@ -643,7 +631,6 @@ export const listAgentToolRelations =
     };
   };
 
-// Get tools for a specific agent
 export const getToolsForAgent =
   (db: DatabaseClient) =>
   async (params: { scopes: SubAgentScopeConfig; pagination?: PaginationConfig }) => {

--- a/packages/agents-core/src/data-access/subAgents.ts
+++ b/packages/agents-core/src/data-access/subAgents.ts
@@ -126,7 +126,6 @@ export const upsertSubAgent =
     });
 
     if (existing) {
-      // Update existing agent
       const updated = await updateSubAgent(db)({
         scopes,
         subAgentId: params.data.id,
@@ -144,7 +143,6 @@ export const upsertSubAgent =
       }
       return updated;
     } else {
-      // Create new agent
       return await createSubAgent(db)(params.data);
     }
   };
@@ -162,7 +160,6 @@ export const deleteSubAgent =
         )
       );
 
-    // Check if agent still exists to confirm deletion
     const deletedSubAgent = await getSubAgentById(db)({
       scopes: params.scopes,
       subAgentId: params.subAgentId,

--- a/packages/agents-core/src/db/delete.ts
+++ b/packages/agents-core/src/db/delete.ts
@@ -41,13 +41,11 @@ export async function deleteDatabase() {
 
     console.log(`📍 Resolved path: ${resolvedPath}`);
 
-    // Check if the database file exists
     if (!fs.existsSync(resolvedPath)) {
       console.log('⚠️  Database file does not exist, nothing to delete');
       return;
     }
 
-    // Delete the database file
     fs.unlinkSync(resolvedPath);
     console.log('✅ Database file deleted successfully');
 

--- a/packages/agents-core/src/db/test-client.ts
+++ b/packages/agents-core/src/db/test-client.ts
@@ -18,7 +18,6 @@ const __dirname = dirname(__filename);
  * Each call creates a fresh database with all migrations applied
  */
 export async function createTestDatabaseClient(): Promise<DatabaseClient> {
-  // Create in-memory database client
   const client = createClient({
     url: ':memory:',
   });
@@ -68,7 +67,6 @@ export async function createTestDatabaseClient(): Promise<DatabaseClient> {
  * @deprecated Use fresh in-memory databases with beforeEach instead for better test isolation
  */
 export async function cleanupTestDatabase(db: DatabaseClient): Promise<void> {
-  // Delete data from tables in reverse dependency order to handle foreign keys
   const cleanupTables = [
     'messages',
     'conversations',

--- a/packages/agents-core/src/env.ts
+++ b/packages/agents-core/src/env.ts
@@ -10,13 +10,11 @@ export const loadEnvironmentFiles = () => {
   // Define files in priority order (highest to lowest priority)
   const environmentFiles: string[] = [];
 
-  // 1. Current directory .env
   const currentEnv = path.resolve(process.cwd(), '.env');
   if (fs.existsSync(currentEnv)) {
     environmentFiles.push(currentEnv);
   }
 
-  // 3. Search for root .env
   const rootEnv = findUpSync('.env', { cwd: path.dirname(process.cwd()) });
   if (rootEnv) {
     if (rootEnv !== currentEnv) {
@@ -24,7 +22,6 @@ export const loadEnvironmentFiles = () => {
     }
   }
 
-  // 3. Load user global config if exists (~/.inkeep/config)
   // This allows sharing API keys across multiple local repo copies
   const userConfigPath = path.join(os.homedir(), '.inkeep', 'config');
   if (fs.existsSync(userConfigPath)) {

--- a/packages/agents-core/src/utils/apiKeys.ts
+++ b/packages/agents-core/src/utils/apiKeys.ts
@@ -76,7 +76,6 @@ export async function validateApiKey(key: string, storedHash: string): Promise<b
     return timingSafeEqual(storedHashBuffer, hashedBuffer);
   } catch (error) {
     logger.error({ error }, 'Error validating API key');
-    // Return false for any errors (invalid format, etc.)
     return false;
   }
 }

--- a/packages/agents-core/src/utils/auth-detection.ts
+++ b/packages/agents-core/src/utils/auth-detection.ts
@@ -81,7 +81,6 @@ export const discoverOAuthEndpoints = async (
   logger?: PinoLogger
 ): Promise<OAuthConfig | null> => {
   try {
-    // 1. Try direct 401 response first
     const response = await fetch(serverUrl, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
@@ -108,7 +107,6 @@ export const discoverOAuthEndpoints = async (
     // Continue to well-known endpoints
   }
 
-  // 2. Try well-known endpoints
   const url = new URL(serverUrl);
   const baseUrl = `${url.protocol}//${url.host}`;
 
@@ -129,7 +127,6 @@ export const detectAuthenticationRequired = async ({
   error: Error;
   logger?: PinoLogger;
 }): Promise<boolean> => {
-  // 1. Primary check: OAuth 2.1/PKCE endpoint discovery (most reliable)
   try {
     const hasOAuthEndpoints = await checkForOAuthEndpoints(serverUrl, logger);
     if (hasOAuthEndpoints) {
@@ -143,7 +140,6 @@ export const detectAuthenticationRequired = async ({
     logger?.debug({ toolId, discoveryError }, 'OAuth endpoint discovery failed');
   }
 
-  // 2. Secondary check: Only for very specific OAuth patterns
   try {
     const response = await fetch(serverUrl, {
       method: 'POST',

--- a/packages/agents-core/src/utils/conversations.ts
+++ b/packages/agents-core/src/utils/conversations.ts
@@ -1,6 +1,5 @@
 import { customAlphabet } from 'nanoid';
 
-// Create a custom nanoid generator with only lowercase letters and numbers
 // This ensures IDs are always lowercase and never start with a hyphen
 export const generateId = customAlphabet('abcdefghijklmnopqrstuvwxyz0123456789', 21);
 

--- a/packages/agents-core/src/utils/execution.ts
+++ b/packages/agents-core/src/utils/execution.ts
@@ -26,7 +26,6 @@ export function createExecutionContext(params: {
  * Get execution context from API key authentication
  */
 export function getRequestExecutionContext(c: Context): ExecutionContext {
-  // Get execution context from API key authentication
   const executionContext = c.get('executionContext');
 
   if (!executionContext) {

--- a/packages/agents-core/src/utils/logger.ts
+++ b/packages/agents-core/src/utils/logger.ts
@@ -194,7 +194,6 @@ class LoggerFactory {
       return logger;
     }
 
-    // Create logger using factory or default
     let logger: PinoLogger;
     if (this.config.loggerFactory) {
       logger = this.config.loggerFactory(name);

--- a/packages/agents-core/src/validation/agentFull.ts
+++ b/packages/agents-core/src/validation/agentFull.ts
@@ -7,7 +7,6 @@ import type {
 } from '../types/entities';
 import { AgentWithinContextOfProjectSchema } from './schemas';
 
-// Type guard functions
 export function isInternalAgent(agent: SubAgentDefinition): agent is InternalSubAgentDefinition {
   return 'prompt' in agent;
 }
@@ -32,7 +31,6 @@ export function validateToolReferences(
   agentData: FullAgentDefinition,
   availableToolIds?: Set<string>
 ): void {
-  // If no tool IDs provided, skip validation (will be done at project level)
   if (!availableToolIds) {
     return;
   }
@@ -63,7 +61,6 @@ export function validateDataComponentReferences(
   agentData: FullAgentDefinition,
   availableDataComponentIds?: Set<string>
 ): void {
-  // If no dataComponent IDs provided, skip validation (will be done at project level)
   if (!availableDataComponentIds) {
     return;
   }
@@ -96,7 +93,6 @@ export function validateArtifactComponentReferences(
   agentData: FullAgentDefinition,
   availableArtifactComponentIds?: Set<string>
 ): void {
-  // If no artifactComponent IDs provided, skip validation (will be done at project level)
   if (!availableArtifactComponentIds) {
     return;
   }
@@ -131,7 +127,6 @@ export function validateAgentRelationships(agentData: FullAgentDefinition): void
   for (const [subAgentId, subAgent] of Object.entries(agentData.subAgents)) {
     // Only internal agents have relationship properties
     if (isInternalAgent(subAgent)) {
-      // Validate transfer targets
       if (subAgent.canTransferTo && Array.isArray(subAgent.canTransferTo)) {
         for (const targetId of subAgent.canTransferTo) {
           if (!availableAgentIds.has(targetId)) {
@@ -142,7 +137,6 @@ export function validateAgentRelationships(agentData: FullAgentDefinition): void
         }
       }
 
-      // Validate delegation targets
       if (subAgent.canDelegateTo && Array.isArray(subAgent.canDelegateTo)) {
         for (const targetId of subAgent.canDelegateTo) {
           if (!availableAgentIds.has(targetId)) {
@@ -172,18 +166,15 @@ export function validateAgentStructure(
     artifactComponentIds?: Set<string>;
   }
 ): void {
-  // Validate default agent exists (if specified)
   if (agentData.defaultSubAgentId && !agentData.subAgents[agentData.defaultSubAgentId]) {
     throw new Error(`Default agent '${agentData.defaultSubAgentId}' does not exist in agents`);
   }
 
-  // Validate resource references if project resources are provided
   if (projectResources) {
     validateToolReferences(agentData, projectResources.toolIds);
     validateDataComponentReferences(agentData, projectResources.dataComponentIds);
     validateArtifactComponentReferences(agentData, projectResources.artifactComponentIds);
   }
 
-  // Validate agent relationships (this is always agent-scoped)
   validateAgentRelationships(agentData);
 }

--- a/packages/agents-core/src/validation/event-schemas.ts
+++ b/packages/agents-core/src/validation/event-schemas.ts
@@ -1,10 +1,8 @@
 import { z } from 'zod';
 
-// =============================================================================
 // EVENT DATA SCHEMAS
 // These schemas define the structure of event data used across the agent system
 // They ensure consistent naming and type safety for inter-agent communication
-// =============================================================================
 
 /**
  * Agent transfer event data
@@ -70,9 +68,7 @@ export const DataOperationEventSchema = z.object({
 
 export type DataOperationEvent = z.infer<typeof DataOperationEventSchema>;
 
-// =============================================================================
 // HELPER SCHEMAS FOR A2A METADATA
-// =============================================================================
 
 /**
  * Message metadata for A2A communication

--- a/packages/agents-core/src/validation/id-validation.ts
+++ b/packages/agents-core/src/validation/id-validation.ts
@@ -39,7 +39,6 @@ export function generateIdFromName(name: string): string {
   // Truncate if necessary
   const truncatedId = id.substring(0, MAX_ID_LENGTH);
 
-  // Validate the generated ID
   const result = resourceIdSchema.safeParse(truncatedId);
   if (!result.success) {
     throw new Error(`Generated ID "${truncatedId}" is not valid: ${result.error.message}`);

--- a/packages/agents-core/src/validation/props-validation.ts
+++ b/packages/agents-core/src/validation/props-validation.ts
@@ -90,11 +90,9 @@ export function validatePropsAsJsonSchema(props: any): PropsValidationResult {
 
   // Use AJV to validate the schema structure (without resolving references)
   try {
-    // Create a copy of the schema without $schema field to avoid external resolution
     const schemaToValidate = { ...props };
     delete schemaToValidate.$schema;
 
-    // Create a new AJV instance that doesn't resolve references
     const schemaValidator = new Ajv({
       strict: false, // Allow unknown keywords like inPreview
       validateSchema: true, // Validate the schema itself

--- a/packages/agents-core/src/validation/schemas.ts
+++ b/packages/agents-core/src/validation/schemas.ts
@@ -591,7 +591,6 @@ export const FunctionToolApiInsertSchema =
 export const FunctionToolApiUpdateSchema =
   createApiUpdateSchema(FunctionToolUpdateSchema).openapi('FunctionToolUpdate');
 
-// === Function Schemas ===
 export const FunctionSelectSchema = createSelectSchema(functions);
 export const FunctionInsertSchema = createInsertSchema(functions).extend({
   id: resourceIdSchema,
@@ -604,7 +603,6 @@ export const FunctionApiInsertSchema =
 export const FunctionApiUpdateSchema =
   createApiUpdateSchema(FunctionUpdateSchema).openapi('FunctionUpdate');
 
-// === Context Config Schemas ===
 // Zod schemas for validation
 export const FetchConfigSchema = z
   .object({
@@ -671,7 +669,6 @@ export const ContextConfigApiUpdateSchema = createApiUpdateSchema(ContextConfigU
   })
   .openapi('ContextConfigUpdate');
 
-// === SubAgent Tool Relation Schemas ===
 export const SubAgentToolRelationSelectSchema = createSelectSchema(subAgentToolRelations);
 export const SubAgentToolRelationInsertSchema = createInsertSchema(subAgentToolRelations).extend({
   id: resourceIdSchema,
@@ -693,7 +690,6 @@ export const SubAgentToolRelationApiUpdateSchema = createAgentScopedApiUpdateSch
   SubAgentToolRelationUpdateSchema
 ).openapi('SubAgentToolRelationUpdate');
 
-// === Ledger Artifact Schemas ===
 export const LedgerArtifactSelectSchema = createSelectSchema(ledgerArtifacts);
 export const LedgerArtifactInsertSchema = createInsertSchema(ledgerArtifacts);
 export const LedgerArtifactUpdateSchema = LedgerArtifactInsertSchema.partial();
@@ -702,7 +698,6 @@ export const LedgerArtifactApiSelectSchema = createApiSchema(LedgerArtifactSelec
 export const LedgerArtifactApiInsertSchema = createApiInsertSchema(LedgerArtifactInsertSchema);
 export const LedgerArtifactApiUpdateSchema = createApiUpdateSchema(LedgerArtifactUpdateSchema);
 
-// === Full Agent Definition Schemas ===
 export const StatusComponentSchema = z
   .object({
     type: z.string(),
@@ -760,7 +755,6 @@ export const AgentWithinContextOfProjectSchema = AgentApiInsertSchema.extend({
   prompt: z.string().max(5000, 'Agent prompt cannot exceed 5000 characters').optional(),
 });
 
-// === Response wrapper schemas ===
 export const PaginationSchema = z
   .object({
     page: z.coerce.number().min(1).default(1),
@@ -804,7 +798,6 @@ export const RemovedResponseSchema = z
   })
   .openapi('RemovedResponse');
 
-// === Project Schemas ===
 export const ProjectSelectSchema = createSelectSchema(projects);
 export const ProjectInsertSchema = createInsertSchema(projects)
   .extend({
@@ -841,7 +834,6 @@ export const FullProjectDefinitionSchema = ProjectApiInsertSchema.extend({
   updatedAt: z.string().optional(),
 });
 
-// === Concrete Response Wrapper Schemas ===
 // Single item response wrappers
 export const ProjectResponse = z
   .object({ data: ProjectApiSelectSchema })
@@ -886,7 +878,6 @@ export const MessageResponse = z
   .object({ data: MessageApiSelectSchema })
   .openapi('MessageResponse');
 
-// List response wrappers with pagination
 export const ProjectListResponse = z
   .object({
     data: z.array(ProjectApiSelectSchema),
@@ -1002,7 +993,6 @@ export const SubAgentArtifactComponentListResponse = z
   })
   .openapi('SubAgentArtifactComponentListResponse');
 
-// === Common parameter schemas ===
 export const HeadersScopeSchema = z.object({
   'x-inkeep-tenant-id': z.string().optional().openapi({
     description: 'Tenant identifier',


### PR DESCRIPTION
Comprehensive cleanup removing 108 lines of obvious CRUD and operation narration comments across 30 files. Completes Phase 3: total 624 lines removed (61% of 1,026-1,197 target). Patterns removed: CRUD operations, Return statements, Build/Map/Convert, section dividers, helper descriptions. All JSDoc and complex logic preserved.