### PR TITLE
feat: Add 1GB API request size limit via Content-Length validation

### DIFF
--- a/agents-docs/content/docs/api-reference/request-limits.mdx
+++ b/agents-docs/content/docs/api-reference/request-limits.mdx
@@ -1,0 +1,167 @@
+---
+title: Request Limits
+description: Understanding API request size limitations and error handling
+---
+
+## Overview
+
+Both the Run API and Manage API enforce request size limits to protect the system from excessively large payloads. These limits are enforced at the API level, independent of model-specific constraints.
+
+## Default Limit
+
+The default maximum request size is **1GB** (1,073,741,824 bytes) for both APIs.
+
+This limit is intentionally set high to accommodate:
+- Large conversation histories
+- Multiple file uploads
+- Extensive context data
+- Complex agent configurations
+
+## How It Works
+
+Request size validation occurs via `Content-Length` header inspection:
+
+1. **Early Validation**: The middleware checks the `Content-Length` header before parsing the request body
+2. **Method-Specific**: Only validates requests with bodies (POST, PUT, PATCH, DELETE)
+3. **Skipped for Safe Methods**: GET, HEAD, and OPTIONS requests bypass validation
+4. **Missing Header**: Requests without `Content-Length` are allowed to proceed (body parsing will handle validation)
+
+## Error Response
+
+When a request exceeds the size limit, the API returns a `413 Payload Too Large` response in Problem+JSON format:
+
+```json
+{
+  "title": "Payload Too Large",
+  "status": 413,
+  "detail": "Request payload size (1073741825 bytes) exceeds maximum allowed size of 1073741824 bytes",
+  "code": "payload_too_large",
+  "error": {
+    "code": "payload_too_large",
+    "message": "Request payload exceeds maximum allowed size"
+  }
+}
+```
+
+### Response Headers
+
+```http
+HTTP/1.1 413 Payload Too Large
+Content-Type: application/problem+json
+X-Content-Type-Options: nosniff
+```
+
+## Configuration
+
+If you're self-hosting, you can configure the maximum request size through the `ServerConfig`:
+
+```typescript
+import { createExecutionHono } from '@inkeep/agents-run-api';
+import { createManagementHono } from '@inkeep/agents-manage-api';
+
+const serverConfig = {
+  serverOptions: {
+    maxRequestSizeBytes: 536870912, // 512MB custom limit
+  },
+};
+
+// Apply to Run API
+const runApp = createExecutionHono(serverConfig, credentialStores);
+
+// Apply to Manage API
+const manageApp = createManagementHono(serverConfig, credentialStores);
+```
+
+### Common Size Values
+
+```typescript
+// Size references for common limits
+const sizes = {
+  '1KB': 1024,
+  '1MB': 1048576,
+  '100MB': 104857600,
+  '512MB': 536870912,
+  '1GB': 1073741824,        // Default
+  '2GB': 2147483648,
+};
+```
+
+## Best Practices
+
+### Client-Side
+
+1. **Check Size Before Sending**: Validate payload size on the client before making requests
+2. **Stream Large Data**: For very large data transfers, consider streaming or chunking
+3. **Handle 413 Errors**: Implement retry logic with smaller payloads when receiving 413 responses
+4. **Set Content-Length**: Always include accurate `Content-Length` headers
+
+### Example: Client-Side Validation
+
+```typescript
+function validatePayloadSize(payload: unknown, maxSize = 1073741824): boolean {
+  const payloadString = JSON.stringify(payload);
+  const payloadSize = new TextEncoder().encode(payloadString).length;
+
+  if (payloadSize > maxSize) {
+    console.error(`Payload size (${payloadSize} bytes) exceeds limit (${maxSize} bytes)`);
+    return false;
+  }
+
+  return true;
+}
+
+// Usage
+const requestBody = { messages: [...] };
+if (validatePayloadSize(requestBody)) {
+  await fetch('/v1/chat/completions', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'Content-Length': String(JSON.stringify(requestBody).length),
+    },
+    body: JSON.stringify(requestBody),
+  });
+}
+```
+
+## Troubleshooting
+
+### Common Issues
+
+**Error: 413 Payload Too Large**
+- **Cause**: Request body exceeds the configured size limit
+- **Solution**: Reduce payload size, chunk data, or increase server limit (if self-hosting)
+
+**Request Rejected Despite Small Payload**
+- **Cause**: Incorrect `Content-Length` header
+- **Solution**: Ensure `Content-Length` accurately reflects the actual payload size
+
+**GET Request Receives 413**
+- **Cause**: `Content-Length` header on GET request (should not have body)
+- **Solution**: Remove `Content-Length` header from GET requests
+
+### Monitoring
+
+When monitoring your APIs, track 413 responses to identify:
+- Clients sending oversized payloads
+- Potential misuse or misconfiguration
+- Need to adjust size limits
+
+```typescript
+// Example: Log 413 responses
+app.onError(async (err, c) => {
+  if (err instanceof HTTPException && err.status === 413) {
+    logger.warn({
+      path: c.req.path,
+      contentLength: c.req.header('content-length'),
+      userAgent: c.req.header('user-agent'),
+    }, 'Request size limit exceeded');
+  }
+});
+```
+
+## Related
+
+- [Chat API](/docs/talk-to-your-agents/chat-api) - Learn about chat completion requests
+- [A2A Protocol](/docs/talk-to-your-agents/a2a) - Agent-to-Agent communication
+- [Self-Hosting](/docs/self-hosting/docker) - Configure limits in your deployment

--- a/agents-docs/navigation.ts
+++ b/agents-docs/navigation.ts
@@ -130,6 +130,7 @@ export default {
             'api-reference/authentication/manage-api',
           ],
         },
+        'api-reference/request-limits',
         'api-reference',
       ],
     },

--- a/agents-manage-api/src/__tests__/middleware/request-size-limit.test.ts
+++ b/agents-manage-api/src/__tests__/middleware/request-size-limit.test.ts
@@ -1,0 +1,194 @@
+import { type ServerConfig, CredentialStoreRegistry } from '@inkeep/agents-core';
+import { describe, expect, it } from 'vitest';
+import { createManagementHono } from '../../app';
+
+describe('Request Size Limit Integration - Manage API', () => {
+  const DEFAULT_MAX_SIZE = 1073741824; // 1GB
+  const CUSTOM_MAX_SIZE = 1000; // 1KB for testing
+
+  const createTestApp = (maxRequestSizeBytes?: number) => {
+    const serverConfig: ServerConfig = {
+      serverOptions: {
+        maxRequestSizeBytes,
+      },
+    };
+
+    const credentialStores = new CredentialStoreRegistry();
+    return createManagementHono(serverConfig, credentialStores);
+  };
+
+  describe('Default Size Limit (1GB)', () => {
+    it('should allow requests under the default limit', async () => {
+      const app = createTestApp();
+      const contentLength = '1000000'; // 1MB
+
+      const res = await app.request('/health', {
+        method: 'POST',
+        headers: {
+          'Content-Length': contentLength,
+          'Content-Type': 'application/json',
+        },
+      });
+
+      // The health endpoint doesn't accept POST, but we're testing the middleware passes
+      // We expect a 404 or 405, not 413
+      expect(res.status).not.toBe(413);
+    });
+
+    it('should reject requests exceeding the default limit', async () => {
+      const app = createTestApp();
+      const contentLength = String(DEFAULT_MAX_SIZE + 1);
+
+      const res = await app.request('/health', {
+        method: 'POST',
+        headers: {
+          'Content-Length': contentLength,
+          'Content-Type': 'application/json',
+        },
+      });
+
+      expect(res.status).toBe(413);
+
+      const body = await res.json();
+      expect(body.code).toBe('payload_too_large');
+      expect(body.status).toBe(413);
+      expect(body.title).toBe('Payload Too Large');
+    });
+  });
+
+  describe('Custom Size Limit', () => {
+    it('should allow requests under custom limit', async () => {
+      const app = createTestApp(CUSTOM_MAX_SIZE);
+      const contentLength = '500'; // 500 bytes
+
+      const res = await app.request('/health', {
+        method: 'POST',
+        headers: {
+          'Content-Length': contentLength,
+          'Content-Type': 'application/json',
+        },
+      });
+
+      // Should not be rejected for size
+      expect(res.status).not.toBe(413);
+    });
+
+    it('should reject requests exceeding custom limit', async () => {
+      const app = createTestApp(CUSTOM_MAX_SIZE);
+      const contentLength = String(CUSTOM_MAX_SIZE + 1); // 1001 bytes
+
+      const res = await app.request('/health', {
+        method: 'POST',
+        headers: {
+          'Content-Length': contentLength,
+          'Content-Type': 'application/json',
+        },
+      });
+
+      expect(res.status).toBe(413);
+
+      const body = await res.json();
+      expect(body.code).toBe('payload_too_large');
+      expect(body.detail).toContain(String(CUSTOM_MAX_SIZE + 1));
+      expect(body.detail).toContain(String(CUSTOM_MAX_SIZE));
+    });
+  });
+
+  describe('HTTP Methods', () => {
+    it('should skip validation for GET requests', async () => {
+      const app = createTestApp(100); // Very small limit
+      const contentLength = '10000'; // Exceeds limit
+
+      const res = await app.request('/health', {
+        method: 'GET',
+        headers: {
+          'Content-Length': contentLength,
+        },
+      });
+
+      // Should succeed (GET requests are skipped)
+      expect(res.status).not.toBe(413);
+    });
+
+    it('should skip validation for HEAD requests', async () => {
+      const app = createTestApp(100);
+      const contentLength = '10000';
+
+      const res = await app.request('/health', {
+        method: 'HEAD',
+        headers: {
+          'Content-Length': contentLength,
+        },
+      });
+
+      expect(res.status).not.toBe(413);
+    });
+
+    it('should skip validation for OPTIONS requests', async () => {
+      const app = createTestApp(100);
+      const contentLength = '10000';
+
+      const res = await app.request('/health', {
+        method: 'OPTIONS',
+        headers: {
+          'Content-Length': contentLength,
+        },
+      });
+
+      expect(res.status).not.toBe(413);
+    });
+  });
+
+  describe('Missing Content-Length Header', () => {
+    it('should allow POST requests without Content-Length header', async () => {
+      const app = createTestApp();
+
+      const res = await app.request('/health', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      });
+
+      // Should not be rejected for missing Content-Length
+      expect(res.status).not.toBe(413);
+    });
+  });
+
+  describe('Response Format', () => {
+    it('should return Problem+JSON format for 413 errors', async () => {
+      const app = createTestApp(1000);
+      const contentLength = '2000';
+
+      const res = await app.request('/health', {
+        method: 'POST',
+        headers: {
+          'Content-Length': contentLength,
+          'Content-Type': 'application/json',
+        },
+      });
+
+      expect(res.status).toBe(413);
+      expect(res.headers.get('content-type')).toContain('application/problem+json');
+
+      const body = await res.json();
+
+      // Problem+JSON fields
+      expect(body).toHaveProperty('title');
+      expect(body).toHaveProperty('status');
+      expect(body).toHaveProperty('detail');
+      expect(body).toHaveProperty('code');
+
+      // Error object for backward compatibility
+      expect(body).toHaveProperty('error');
+      expect(body.error).toHaveProperty('code');
+      expect(body.error).toHaveProperty('message');
+
+      // Verify values
+      expect(body.title).toBe('Payload Too Large');
+      expect(body.status).toBe(413);
+      expect(body.code).toBe('payload_too_large');
+      expect(body.error.code).toBe('payload_too_large');
+    });
+  });
+});

--- a/agents-manage-api/src/app.ts
+++ b/agents-manage-api/src/app.ts
@@ -1,6 +1,10 @@
 import { createRoute, OpenAPIHono } from '@hono/zod-openapi';
-import type { CredentialStoreRegistry, ServerConfig } from '@inkeep/agents-core';
-import { handleApiError } from '@inkeep/agents-core';
+import {
+  type CredentialStoreRegistry,
+  handleApiError,
+  requestSizeLimitMiddleware,
+  type ServerConfig,
+} from '@inkeep/agents-core';
 import { Hono } from 'hono';
 import { cors } from 'hono/cors';
 import { HTTPException } from 'hono/http-exception';
@@ -38,6 +42,14 @@ function createManagementHono(
     c.set('credentialStores', credentialStores);
     return next();
   });
+
+  // Request size limit middleware - validate Content-Length before body parsing
+  app.use(
+    '*',
+    requestSizeLimitMiddleware({
+      maxRequestSizeBytes: serverConfig.serverOptions?.maxRequestSizeBytes,
+    })
+  );
 
   // Logging middleware - let hono-pino create its own logger to preserve formatting
   app.use(

--- a/agents-run-api/src/__tests__/middleware/request-size-limit.test.ts
+++ b/agents-run-api/src/__tests__/middleware/request-size-limit.test.ts
@@ -1,0 +1,194 @@
+import { describe, expect, it } from 'vitest';
+import { createExecutionHono } from '../../app';
+import { type ServerConfig, CredentialStoreRegistry } from '@inkeep/agents-core';
+
+describe('Request Size Limit Integration - Run API', () => {
+  const DEFAULT_MAX_SIZE = 1073741824; // 1GB
+  const CUSTOM_MAX_SIZE = 1000; // 1KB for testing
+
+  const createTestApp = (maxRequestSizeBytes?: number) => {
+    const serverConfig: ServerConfig = {
+      serverOptions: {
+        maxRequestSizeBytes,
+      },
+    };
+
+    const credentialStores = new CredentialStoreRegistry();
+    return createExecutionHono(serverConfig, credentialStores);
+  };
+
+  describe('Default Size Limit (1GB)', () => {
+    it('should allow requests under the default limit', async () => {
+      const app = createTestApp();
+      const contentLength = '1000000'; // 1MB
+
+      const res = await app.request('/health', {
+        method: 'POST',
+        headers: {
+          'Content-Length': contentLength,
+          'Content-Type': 'application/json',
+        },
+      });
+
+      // The health endpoint doesn't accept POST, but we're testing the middleware passes
+      // We expect a 404 or 405, not 413
+      expect(res.status).not.toBe(413);
+    });
+
+    it('should reject requests exceeding the default limit', async () => {
+      const app = createTestApp();
+      const contentLength = String(DEFAULT_MAX_SIZE + 1);
+
+      const res = await app.request('/health', {
+        method: 'POST',
+        headers: {
+          'Content-Length': contentLength,
+          'Content-Type': 'application/json',
+        },
+      });
+
+      expect(res.status).toBe(413);
+
+      const body = await res.json();
+      expect(body.code).toBe('payload_too_large');
+      expect(body.status).toBe(413);
+      expect(body.title).toBe('Payload Too Large');
+    });
+  });
+
+  describe('Custom Size Limit', () => {
+    it('should allow requests under custom limit', async () => {
+      const app = createTestApp(CUSTOM_MAX_SIZE);
+      const contentLength = '500'; // 500 bytes
+
+      const res = await app.request('/health', {
+        method: 'POST',
+        headers: {
+          'Content-Length': contentLength,
+          'Content-Type': 'application/json',
+        },
+      });
+
+      // Should not be rejected for size
+      expect(res.status).not.toBe(413);
+    });
+
+    it('should reject requests exceeding custom limit', async () => {
+      const app = createTestApp(CUSTOM_MAX_SIZE);
+      const contentLength = String(CUSTOM_MAX_SIZE + 1); // 1001 bytes
+
+      const res = await app.request('/health', {
+        method: 'POST',
+        headers: {
+          'Content-Length': contentLength,
+          'Content-Type': 'application/json',
+        },
+      });
+
+      expect(res.status).toBe(413);
+
+      const body = await res.json();
+      expect(body.code).toBe('payload_too_large');
+      expect(body.detail).toContain(String(CUSTOM_MAX_SIZE + 1));
+      expect(body.detail).toContain(String(CUSTOM_MAX_SIZE));
+    });
+  });
+
+  describe('HTTP Methods', () => {
+    it('should skip validation for GET requests', async () => {
+      const app = createTestApp(100); // Very small limit
+      const contentLength = '10000'; // Exceeds limit
+
+      const res = await app.request('/health', {
+        method: 'GET',
+        headers: {
+          'Content-Length': contentLength,
+        },
+      });
+
+      // Should succeed (GET requests are skipped)
+      expect(res.status).not.toBe(413);
+    });
+
+    it('should skip validation for HEAD requests', async () => {
+      const app = createTestApp(100);
+      const contentLength = '10000';
+
+      const res = await app.request('/health', {
+        method: 'HEAD',
+        headers: {
+          'Content-Length': contentLength,
+        },
+      });
+
+      expect(res.status).not.toBe(413);
+    });
+
+    it('should skip validation for OPTIONS requests', async () => {
+      const app = createTestApp(100);
+      const contentLength = '10000';
+
+      const res = await app.request('/health', {
+        method: 'OPTIONS',
+        headers: {
+          'Content-Length': contentLength,
+        },
+      });
+
+      expect(res.status).not.toBe(413);
+    });
+  });
+
+  describe('Missing Content-Length Header', () => {
+    it('should allow POST requests without Content-Length header', async () => {
+      const app = createTestApp();
+
+      const res = await app.request('/health', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      });
+
+      // Should not be rejected for missing Content-Length
+      expect(res.status).not.toBe(413);
+    });
+  });
+
+  describe('Response Format', () => {
+    it('should return Problem+JSON format for 413 errors', async () => {
+      const app = createTestApp(1000);
+      const contentLength = '2000';
+
+      const res = await app.request('/health', {
+        method: 'POST',
+        headers: {
+          'Content-Length': contentLength,
+          'Content-Type': 'application/json',
+        },
+      });
+
+      expect(res.status).toBe(413);
+      expect(res.headers.get('content-type')).toContain('application/problem+json');
+
+      const body = await res.json();
+
+      // Problem+JSON fields
+      expect(body).toHaveProperty('title');
+      expect(body).toHaveProperty('status');
+      expect(body).toHaveProperty('detail');
+      expect(body).toHaveProperty('code');
+
+      // Error object for backward compatibility
+      expect(body).toHaveProperty('error');
+      expect(body.error).toHaveProperty('code');
+      expect(body.error).toHaveProperty('message');
+
+      // Verify values
+      expect(body.title).toBe('Payload Too Large');
+      expect(body.status).toBe(413);
+      expect(body.code).toBe('payload_too_large');
+      expect(body.error.code).toBe('payload_too_large');
+    });
+  });
+});

--- a/agents-run-api/src/app.ts
+++ b/agents-run-api/src/app.ts
@@ -4,6 +4,7 @@ import {
   type CredentialStoreRegistry,
   type ExecutionContext,
   handleApiError,
+  requestSizeLimitMiddleware,
   type ServerConfig,
 } from '@inkeep/agents-core';
 import { context as otelContext, propagation } from '@opentelemetry/api';
@@ -53,6 +54,14 @@ function createExecutionHono(
     }
     return next();
   });
+
+  // Request size limit middleware - validate Content-Length before body parsing
+  app.use(
+    '*',
+    requestSizeLimitMiddleware({
+      maxRequestSizeBytes: serverConfig.serverOptions?.maxRequestSizeBytes,
+    })
+  );
 
   // Body parsing middleware - parse once and share across all handlers
   app.use('*', async (c, next) => {

--- a/agents-run-api/src/routes/chat.ts
+++ b/agents-run-api/src/routes/chat.ts
@@ -5,6 +5,7 @@ import {
   createApiError,
   createMessage,
   createOrGetConversation,
+  errorSchemaFactory,
   getActiveAgentForConversation,
   getAgentWithDefaultSubAgent,
   getConversationId,
@@ -134,6 +135,7 @@ const chatCompletionsRoute = createRoute({
         },
       },
     },
+    413: errorSchemaFactory('payload_too_large', 'Request payload exceeds maximum allowed size'),
     500: {
       description: 'Internal server error',
       content: {

--- a/packages/agents-core/src/middleware/__tests__/request-size-limit.test.ts
+++ b/packages/agents-core/src/middleware/__tests__/request-size-limit.test.ts
@@ -1,0 +1,219 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { Context, Next } from 'hono';
+import { HTTPException } from 'hono/http-exception';
+import {
+  DEFAULT_MAX_REQUEST_SIZE_BYTES,
+  requestSizeLimitMiddleware,
+} from '../request-size-limit';
+
+describe('requestSizeLimitMiddleware', () => {
+  const createMockContext = (
+    method: string,
+    contentLength?: string
+  ): { c: Context; next: Next } => {
+    const c = {
+      req: {
+        method,
+        path: '/test',
+        header: vi.fn((name: string) => {
+          if (name === 'content-length') return contentLength;
+          if (name === 'user-agent') return 'test-agent';
+          return undefined;
+        }),
+      },
+    } as unknown as Context;
+
+    const next = vi.fn(() => Promise.resolve());
+
+    return { c, next };
+  };
+
+  describe('Method Skipping', () => {
+    it('should skip validation for GET requests', async () => {
+      const { c, next } = createMockContext('GET');
+      const middleware = requestSizeLimitMiddleware();
+
+      await middleware(c, next);
+
+      expect(next).toHaveBeenCalled();
+    });
+
+    it('should skip validation for HEAD requests', async () => {
+      const { c, next } = createMockContext('HEAD');
+      const middleware = requestSizeLimitMiddleware();
+
+      await middleware(c, next);
+
+      expect(next).toHaveBeenCalled();
+    });
+
+    it('should skip validation for OPTIONS requests', async () => {
+      const { c, next } = createMockContext('OPTIONS');
+      const middleware = requestSizeLimitMiddleware();
+
+      await middleware(c, next);
+
+      expect(next).toHaveBeenCalled();
+    });
+  });
+
+  describe('Content-Length Header', () => {
+    it('should allow request when Content-Length is missing', async () => {
+      const { c, next } = createMockContext('POST', undefined);
+      const middleware = requestSizeLimitMiddleware();
+
+      await middleware(c, next);
+
+      expect(next).toHaveBeenCalled();
+    });
+
+    it('should allow request when Content-Length is invalid', async () => {
+      const { c, next } = createMockContext('POST', 'invalid');
+      const middleware = requestSizeLimitMiddleware();
+
+      await middleware(c, next);
+
+      expect(next).toHaveBeenCalled();
+    });
+
+    it('should allow request when Content-Length is negative', async () => {
+      const { c, next } = createMockContext('POST', '-100');
+      const middleware = requestSizeLimitMiddleware();
+
+      await middleware(c, next);
+
+      expect(next).toHaveBeenCalled();
+    });
+  });
+
+  describe('Size Validation', () => {
+    it('should allow request under the default limit', async () => {
+      const { c, next } = createMockContext('POST', '1000000'); // 1MB
+      const middleware = requestSizeLimitMiddleware();
+
+      await middleware(c, next);
+
+      expect(next).toHaveBeenCalled();
+    });
+
+    it('should allow request at exactly the default limit', async () => {
+      const { c, next } = createMockContext('POST', String(DEFAULT_MAX_REQUEST_SIZE_BYTES));
+      const middleware = requestSizeLimitMiddleware();
+
+      await middleware(c, next);
+
+      expect(next).toHaveBeenCalled();
+    });
+
+    it('should reject request exceeding the default limit', async () => {
+      const { c, next } = createMockContext('POST', String(DEFAULT_MAX_REQUEST_SIZE_BYTES + 1));
+      const middleware = requestSizeLimitMiddleware();
+
+      await expect(middleware(c, next)).rejects.toThrow(HTTPException);
+      expect(next).not.toHaveBeenCalled();
+    });
+
+    it('should reject request exceeding custom limit', async () => {
+      const customLimit = 1000;
+      const { c, next } = createMockContext('POST', '2000');
+      const middleware = requestSizeLimitMiddleware({ maxRequestSizeBytes: customLimit });
+
+      await expect(middleware(c, next)).rejects.toThrow(HTTPException);
+      expect(next).not.toHaveBeenCalled();
+    });
+
+    it('should allow request under custom limit', async () => {
+      const customLimit = 5000;
+      const { c, next } = createMockContext('POST', '3000');
+      const middleware = requestSizeLimitMiddleware({ maxRequestSizeBytes: customLimit });
+
+      await middleware(c, next);
+
+      expect(next).toHaveBeenCalled();
+    });
+  });
+
+  describe('Error Response', () => {
+    it('should throw HTTPException with 413 status', async () => {
+      const { c, next } = createMockContext('POST', String(DEFAULT_MAX_REQUEST_SIZE_BYTES + 1));
+      const middleware = requestSizeLimitMiddleware();
+
+      try {
+        await middleware(c, next);
+        expect.fail('Should have thrown an error');
+      } catch (error) {
+        expect(error).toBeInstanceOf(HTTPException);
+        const httpError = error as HTTPException;
+        expect(httpError.status).toBe(413);
+      }
+    });
+
+    it('should include payload_too_large error code in response', async () => {
+      const { c, next } = createMockContext('POST', String(DEFAULT_MAX_REQUEST_SIZE_BYTES + 1));
+      const middleware = requestSizeLimitMiddleware();
+
+      try {
+        await middleware(c, next);
+        expect.fail('Should have thrown an error');
+      } catch (error) {
+        expect(error).toBeInstanceOf(HTTPException);
+        const httpError = error as HTTPException;
+        const response = httpError.getResponse();
+        const body = await response.json();
+        expect(body.code).toBe('payload_too_large');
+      }
+    });
+
+    it('should include size information in error message', async () => {
+      const requestSize = DEFAULT_MAX_REQUEST_SIZE_BYTES + 1000;
+      const { c, next } = createMockContext('POST', String(requestSize));
+      const middleware = requestSizeLimitMiddleware();
+
+      try {
+        await middleware(c, next);
+        expect.fail('Should have thrown an error');
+      } catch (error) {
+        expect(error).toBeInstanceOf(HTTPException);
+        const httpError = error as HTTPException;
+        const response = httpError.getResponse();
+        const body = await response.json();
+        expect(body.detail).toContain(String(requestSize));
+        expect(body.detail).toContain(String(DEFAULT_MAX_REQUEST_SIZE_BYTES));
+      }
+    });
+  });
+
+  describe('Different HTTP Methods', () => {
+    it('should validate POST requests', async () => {
+      const { c, next } = createMockContext('POST', String(DEFAULT_MAX_REQUEST_SIZE_BYTES + 1));
+      const middleware = requestSizeLimitMiddleware();
+
+      await expect(middleware(c, next)).rejects.toThrow(HTTPException);
+      expect(next).not.toHaveBeenCalled();
+    });
+
+    it('should validate PUT requests', async () => {
+      const { c, next } = createMockContext('PUT', String(DEFAULT_MAX_REQUEST_SIZE_BYTES + 1));
+      const middleware = requestSizeLimitMiddleware();
+
+      await expect(middleware(c, next)).rejects.toThrow(HTTPException);
+      expect(next).not.toHaveBeenCalled();
+    });
+
+    it('should validate PATCH requests', async () => {
+      const { c, next } = createMockContext('PATCH', String(DEFAULT_MAX_REQUEST_SIZE_BYTES + 1));
+      const middleware = requestSizeLimitMiddleware();
+
+      await expect(middleware(c, next)).rejects.toThrow(HTTPException);
+      expect(next).not.toHaveBeenCalled();
+    });
+
+    it('should validate DELETE requests with body', async () => {
+      const { c, next } = createMockContext('DELETE', String(DEFAULT_MAX_REQUEST_SIZE_BYTES + 1));
+      const middleware = requestSizeLimitMiddleware();
+
+      await expect(middleware(c, next)).rejects.toThrow(HTTPException);
+      expect(next).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/packages/agents-core/src/middleware/index.ts
+++ b/packages/agents-core/src/middleware/index.ts
@@ -1,1 +1,2 @@
 export * from './contextValidation';
+export * from './request-size-limit';

--- a/packages/agents-core/src/middleware/request-size-limit.ts
+++ b/packages/agents-core/src/middleware/request-size-limit.ts
@@ -1,0 +1,107 @@
+import type { Context, MiddlewareHandler } from 'hono';
+import { createApiError } from '../utils/error';
+import { getLogger } from '../utils/logger';
+
+const logger = getLogger('request-size-limit');
+
+/**
+ * Default maximum request size: 1GB (1,073,741,824 bytes)
+ * This is an API-level limit independent of model constraints
+ */
+export const DEFAULT_MAX_REQUEST_SIZE_BYTES = 1073741824;
+
+/**
+ * Request size limit middleware options
+ */
+export interface RequestSizeLimitOptions {
+  /**
+   * Maximum request size in bytes
+   * Default: 1GB (1,073,741,824 bytes)
+   */
+  maxRequestSizeBytes?: number;
+}
+
+/**
+ * Middleware to enforce request payload size limits via Content-Length header validation.
+ *
+ * This middleware checks the Content-Length header of incoming requests and returns
+ * a 413 Payload Too Large error if the size exceeds the configured limit.
+ *
+ * Key features:
+ * - Validates Content-Length header before expensive body parsing
+ * - Skips validation for GET, HEAD, and OPTIONS requests (no body expected)
+ * - Returns standard Problem+JSON error response on failure
+ * - Logs violations for monitoring
+ *
+ * @param options - Configuration options
+ * @returns Hono middleware handler
+ *
+ * @example
+ * ```typescript
+ * import { requestSizeLimitMiddleware } from '@inkeep/agents-core';
+ *
+ * app.use('*', requestSizeLimitMiddleware({
+ *   maxRequestSizeBytes: 1073741824 // 1GB
+ * }));
+ * ```
+ */
+export function requestSizeLimitMiddleware(
+  options: RequestSizeLimitOptions = {}
+): MiddlewareHandler {
+  const maxSize = options.maxRequestSizeBytes ?? DEFAULT_MAX_REQUEST_SIZE_BYTES;
+
+  return async (c: Context, next) => {
+    const method = c.req.method;
+
+    // Skip validation for methods that don't typically have request bodies
+    if (method === 'GET' || method === 'HEAD' || method === 'OPTIONS') {
+      return next();
+    }
+
+    // Get Content-Length header
+    const contentLength = c.req.header('content-length');
+
+    // If Content-Length is not provided, allow the request to proceed
+    // (body parsing middleware will handle missing/malformed bodies)
+    if (!contentLength) {
+      return next();
+    }
+
+    const requestSize = Number.parseInt(contentLength, 10);
+
+    // Validate Content-Length is a valid number
+    if (Number.isNaN(requestSize) || requestSize < 0) {
+      logger.warn(
+        {
+          contentLength,
+          method,
+          path: c.req.path,
+        },
+        'Invalid Content-Length header received'
+      );
+      return next(); // Allow to proceed, body parser will handle the error
+    }
+
+    // Check if request size exceeds limit
+    if (requestSize > maxSize) {
+      logger.warn(
+        {
+          requestSize,
+          maxSize,
+          method,
+          path: c.req.path,
+          userAgent: c.req.header('user-agent'),
+        },
+        'Request payload size exceeds maximum allowed size'
+      );
+
+      throw createApiError({
+        code: 'payload_too_large',
+        message: `Request payload size (${requestSize} bytes) exceeds maximum allowed size of ${maxSize} bytes`,
+      });
+    }
+
+    // Request size is within limits, proceed
+    return next();
+  };
+}

--- a/packages/agents-core/src/types/server.ts
+++ b/packages/agents-core/src/types/server.ts
@@ -82,6 +82,16 @@ export interface ServerOptions {
    * Default: 60000ms (60 seconds)
    */
   requestTimeout?: number;
+
+  /**
+   * Maximum request payload size in bytes
+   * Limits the size of incoming request bodies via Content-Length header validation.
+   * This is an API-level limit independent of model constraints, set high to accommodate large payloads.
+   * Requests exceeding this limit will receive a 413 Payload Too Large response.
+   * Scenario: Set lower for APIs with small payloads, keep at 1GB for general purpose APIs.
+   * Default: 1073741824 bytes (1GB)
+   */
+  maxRequestSizeBytes?: number;
 }
 
 /**

--- a/packages/agents-core/src/utils/error.ts
+++ b/packages/agents-core/src/utils/error.ts
@@ -8,6 +8,7 @@ export const ErrorCode = z.enum([
   'forbidden',
   'not_found',
   'conflict',
+  'payload_too_large',
   'internal_server_error',
   'unprocessable_entity',
 ]);
@@ -18,6 +19,7 @@ const errorCodeToHttpStatus: Record<z.infer<typeof ErrorCode>, number> = {
   forbidden: 403,
   not_found: 404,
   conflict: 409,
+  payload_too_large: 413,
   unprocessable_entity: 422,
   internal_server_error: 500,
 };
@@ -224,6 +226,8 @@ function getTitleFromCode(code: ErrorCodes): string {
       return 'Not Found';
     case 'conflict':
       return 'Conflict';
+    case 'payload_too_large':
+      return 'Payload Too Large';
     case 'unprocessable_entity':
       return 'Unprocessable Entity';
     case 'internal_server_error':
@@ -291,6 +295,7 @@ export const commonCreateErrorResponses = {
   400: errorSchemaFactory('bad_request', 'Bad Request'),
   401: errorSchemaFactory('unauthorized', 'Unauthorized'),
   403: errorSchemaFactory('forbidden', 'Forbidden'),
+  413: errorSchemaFactory('payload_too_large', 'Request payload exceeds maximum allowed size'),
   422: errorSchemaFactory('unprocessable_entity', 'Unprocessable Entity'),
   500: errorSchemaFactory('internal_server_error', 'Internal Server Error'),
 } as const;
@@ -300,6 +305,7 @@ export const commonUpdateErrorResponses = {
   401: errorSchemaFactory('unauthorized', 'Unauthorized'),
   403: errorSchemaFactory('forbidden', 'Forbidden'),
   404: errorSchemaFactory('not_found', 'Not Found'),
+  413: errorSchemaFactory('payload_too_large', 'Request payload exceeds maximum allowed size'),
   422: errorSchemaFactory('unprocessable_entity', 'Unprocessable Entity'),
   500: errorSchemaFactory('internal_server_error', 'Internal Server Error'),
 } as const;
@@ -318,6 +324,7 @@ export const commonDeleteErrorResponses = {
   401: errorSchemaFactory('unauthorized', 'Unauthorized'),
   403: errorSchemaFactory('forbidden', 'Forbidden'),
   404: errorSchemaFactory('not_found', 'Not Found'),
+  413: errorSchemaFactory('payload_too_large', 'Request payload exceeds maximum allowed size'),
   422: errorSchemaFactory('unprocessable_entity', 'Unprocessable Entity'),
   500: errorSchemaFactory('internal_server_error', 'Internal Server Error'),
 } as const;


### PR DESCRIPTION
## Summary

Implements API-level request size validation independent of model constraints. Both Run API and Manage API now enforce a configurable 1GB default limit through Content-Length header validation before body parsing.

## Changes

### Core Infrastructure
- **Added `payload_too_large` error code (413)** to the core error system
- **Created request-size-limit middleware** with configurable `maxRequestSizeBytes`
- **Updated ServerOptions** to support `maxRequestSizeBytes` configuration (default: 1GB)
- **Applied middleware** to both `agents-run-api` and `agents-manage-api`
- **Updated OpenAPI schemas** to document 413 error responses in common error response schemas

### Implementation Details
- Middleware validates Content-Length headers **before expensive body parsing**
- Skips safe methods (GET/HEAD/OPTIONS) that don't typically have request bodies
- Returns proper **Problem+JSON error responses** when limits are exceeded
- Error response includes both received size and maximum allowed size for debugging

### Testing
- ✅ **18 unit tests** for middleware logic (method skipping, size validation, error responses)
- ✅ **9 integration tests** for Run API (default/custom limits, HTTP methods, response format)
- ✅ **9 integration tests** for Manage API (matching Run API test coverage)
- ✅ **All tests passing** (36 new tests)

### Documentation
- ✅ **Comprehensive API reference docs** at `/docs/api-reference/request-limits`
- Includes: Overview, configuration examples, best practices, troubleshooting, client-side validation examples
- Added to navigation for discoverability

## Why 1GB?

The 1GB default is intentionally set high to be well above any model's context window requirements while still providing protection against abuse. This is purely an API-level limit independent of model constraints.

## Configuration Example

```typescript
import { createExecutionHono } from '@inkeep/agents-run-api';

const serverConfig = {
  serverOptions: {
    maxRequestSizeBytes: 536870912, // 512MB custom limit
  },
};

const app = createExecutionHono(serverConfig, credentialStores);
```

## Error Response Example

```json
{
  "title": "Payload Too Large",
  "status": 413,
  "detail": "Request payload size (1073741825 bytes) exceeds maximum allowed size of 1073741824 bytes",
  "code": "payload_too_large",
  "error": {
    "code": "payload_too_large",
    "message": "Request payload exceeds maximum allowed size"
  }
}
```

## Related Files
- `packages/agents-core/src/middleware/request-size-limit.ts` (new middleware)
- `packages/agents-core/src/utils/error.ts` (413 error code support)
- `packages/agents-core/src/types/server.ts` (ServerOptions configuration)
- `agents-run-api/src/app.ts` (middleware application)
- `agents-manage-api/src/app.ts` (middleware application)
- `agents-docs/content/docs/api-reference/request-limits.mdx` (documentation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)