### PR TITLE
Do not initialize `INKEEP_AGENTS_JWT_SIGNING_SECRET` as empty string in `.env.example`

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -69,4 +69,4 @@ OAUTH_CLIENT_URI=https://inkeep.com
 OAUTH_CLIENT_LOGO_URI=https://inkeep.com/images/logos/inkeep-logo-blue.svg
 
 # ========== SERVICE TOKENS ================
-INKEEP_AGENTS_JWT_SIGNING_SECRET=
+# INKEEP_AGENTS_JWT_SIGNING_SECRET=


### PR DESCRIPTION
when running `pnpm setup-dev`

this will fail zod validation
<img width="673" height="274" alt="image" src="https://github.com/user-attachments/assets/35074fd6-270a-4267-81c9-9e537bfa684e" />
