### PR TITLE
@inkeep/agents-docs: do not load `<Kbd />` with `next/dynamic`

### DIFF
--- a/agents-docs/src/components/search-trigger.tsx
+++ b/agents-docs/src/components/search-trigger.tsx
@@ -2,14 +2,14 @@
 
 import clsx from 'clsx';
 import { SearchIcon } from 'lucide-react';
-import dynamic from 'next/dynamic';
-import type { ButtonHTMLAttributes } from 'react';
-
-const Kbd = dynamic(() => import('@/components/kbd').then((mod) => mod.Kbd), {
-  ssr: false,
-});
+import { type ButtonHTMLAttributes, useEffect, useState } from 'react';
+import { Kbd } from '@/components/kbd';
 
 export function SearchToggle(props: ButtonHTMLAttributes<HTMLButtonElement>) {
+  const [isMounted, setIsMounted] = useState(false);
+  useEffect(() => {
+    setIsMounted(true);
+  }, []);
   return (
     <button
       type="button"
@@ -23,9 +23,11 @@ export function SearchToggle(props: ButtonHTMLAttributes<HTMLButtonElement>) {
     >
       <SearchIcon className="ms-1 size-4" />
       Search or ask...
-      <div className="ms-auto inline-flex gap-[1px]">
-        <Kbd />
-      </div>
+      {isMounted && (
+        <div className="ms-auto inline-flex gap-[1px]">
+          <Kbd />
+        </div>
+      )}
     </button>
   );
 }


### PR DESCRIPTION
loading Kbd with `next/dynamic` will load this component as new chunk and this is weird. isMounted pattern should be used instead

<img width="2294" height="644" alt="image" src="https://github.com/user-attachments/assets/1d7789ac-db55-4e1e-b9a6-fb34732ee8a6" />
