### PR TITLE
Revert "fix pnpm warning: `WARN The field "pnpm.overrides" was found in /agents/agents-docs/package.json. This will not take effect. You should configure "pnpm.overrides" at the root of the workspace instead.`"

### DIFF
--- a/agents-docs/package.json
+++ b/agents-docs/package.json
@@ -70,5 +70,11 @@
   },
   "engines": {
     "node": ">=22.0.0"
+  },
+  "pnpm": {
+    "overrides": {
+      "@types/react": "19.2.2",
+      "@types/react-dom": "19.2.2"
+    }
   }
 }


### PR DESCRIPTION
Reverts inkeep/agents#894