### PR TITLE
fix: upgrade turbo to 2.6.1 and fix pre-push hook hangs (PRD-5356)

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -5,7 +5,6 @@
 # It runs a single optimized turbo command (pnpm check:husky) that:
 #   - Builds once (cached and reused by all tasks)
 #   - Runs lint, typecheck, and test in parallel after build
-#   - Then runs create-agents E2E tests
 #
 # Usage:
 #   Normal push:                      git push
@@ -13,12 +12,136 @@
 #
 # For more information, see CONTRIBUTING.md
 
+set -e
+
+# Configuration
+TIMEOUT_SECONDS=300  # 5 minutes timeout
+RETRY_COUNT=1
+
 echo "🚀 Running pre-push checks..."
 echo "   Step 1: pnpm check:husky (build, lint, typecheck, unit tests)"
 
-# Run the unified check command
-if ! pnpm check:husky; then
-  echo "❌ Pre-push checks failed. Fix the issues above before pushing."
-  echo "   Run 'pnpm check:husky' locally to reproduce."
-  exit 1
+# Ensure we're in the repository root
+cd "$(git rev-parse --show-toplevel)" || exit 1
+
+# Function to run command with timeout detection
+run_with_timeout() {
+  local timeout=$1
+  local attempt=$2
+  
+  echo ""
+  if [ "$attempt" -gt 1 ]; then
+    echo "   ⚠️  Retry attempt $attempt after clearing cache..."
+  fi
+  
+  # Run command in background and capture PID and process group
+  pnpm check:husky &
+  local cmd_pid=$!
+  local pgid=$(ps -o pgid= -p $cmd_pid 2>/dev/null | tr -d ' ' || echo "")
+  
+  # Monitor the process
+  local elapsed=0
+  local check_interval=5  # Check every 5 seconds
+  
+  while [ $elapsed -lt $timeout ]; do
+    # Check if process is still running
+    if ! kill -0 $cmd_pid 2>/dev/null; then
+      # Process completed, wait for exit code
+      wait $cmd_pid
+      return $?
+    fi
+    
+    # Sleep and increment elapsed time
+    sleep $check_interval
+    elapsed=$((elapsed + check_interval))
+    
+    # Print progress every 60 seconds
+    if [ $((elapsed % 60)) -eq 0 ]; then
+      echo "   ⏳ Still running... (${elapsed}s / ${timeout}s)"
+    fi
+  done
+  
+  # Timeout reached - process is hanging
+  echo ""
+  echo "   ⚠️  Command appears to be hanging (timeout after ${timeout}s)"
+  echo "   🔍 Killing process group (PID: $cmd_pid, PGID: ${pgid:-N/A})..."
+  
+  # Try to kill gracefully first (entire process group if available)
+  if [ -n "$pgid" ] && [ "$pgid" != "1" ]; then
+    kill -TERM -$pgid 2>/dev/null || kill $cmd_pid 2>/dev/null || true
+  else
+    kill $cmd_pid 2>/dev/null || true
+  fi
+  sleep 2
+  
+  # Force kill if still running
+  if kill -0 $cmd_pid 2>/dev/null; then
+    echo "   🔍 Force killing process group..."
+    if [ -n "$pgid" ] && [ "$pgid" != "1" ]; then
+      kill -9 -$pgid 2>/dev/null || kill -9 $cmd_pid 2>/dev/null || true
+    else
+      kill -9 $cmd_pid 2>/dev/null || true
+    fi
+  fi
+  
+  # Wait for process to die
+  wait $cmd_pid 2>/dev/null || true
+  
+  return 124  # Return timeout exit code (same as timeout command)
+}
+
+# Function to clear turbo cache
+clear_turbo_cache() {
+  echo ""
+  echo "   🧹 Clearing turbo cache..."
+  rm -rf .turbo 2>/dev/null || true
+  echo "   ✅ Cache cleared"
+}
+
+# Try running the command with retries
+attempt=1
+max_attempts=$((RETRY_COUNT + 1))
+success=false
+
+while [ $attempt -le $max_attempts ]; do
+  if run_with_timeout $TIMEOUT_SECONDS $attempt; then
+    success=true
+    break
+  fi
+  
+  exit_code=$?
+  
+  if [ $exit_code -eq 124 ]; then
+    # Timeout detected
+    if [ $attempt -lt $max_attempts ]; then
+      clear_turbo_cache
+      attempt=$((attempt + 1))
+      echo ""
+      echo "   🔄 Retrying after cache clear..."
+    else
+      echo ""
+      echo "❌ Pre-push checks timed out after ${max_attempts} attempt(s)."
+      echo ""
+      echo "   The command appears to be hanging. This may be due to:"
+      echo "   1. Corrupted turbo cache (already cleared)"
+      echo "   2. Resource exhaustion"
+      echo "   3. Network issues (if using remote cache)"
+      echo ""
+      echo "   Try running manually:"
+      echo "   1. pnpm clean:turbo"
+      echo "   2. pnpm check:husky"
+      exit 1
+    fi
+  else
+    # Command failed with error (not timeout)
+    echo ""
+    echo "❌ Pre-push checks failed. Fix the issues above before pushing."
+    echo "   Run 'pnpm check:husky' locally to reproduce."
+    exit $exit_code
+  fi
+done
+
+if [ "$success" = true ]; then
+  echo ""
+  echo "✅ Pre-push checks passed!"
 fi

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "check:husky": "turbo check:husky --filter='!agents-cookbook-templates'",
     "check:fix": "biome check --write",
     "clean": "pnpm -r --parallel exec rm -rf node_modules dist build .next .turbo",
-    "clean:turbo": "turbo clean",
+    "clean:turbo": "rm -rf .turbo",
     "prepare": "husky",
     "changeset:quick": "node scripts/quick-changeset.mjs",
     "version": "changeset version",
@@ -65,7 +65,7 @@
     "drizzle-kit": "^0.31.5",
     "husky": "^9.1.6",
     "lint-staged": "^16.1.5",
-    "turbo": "^2.5.5",
+    "turbo": "^2.6.1",
     "unique-names-generator": "^4.7.1",
     "vitest": "^3.2.4"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -43,8 +43,8 @@ importers:
         specifier: ^16.1.5
         version: 16.2.6
       turbo:
-        specifier: ^2.5.5
-        version: 2.6.0
+        specifier: ^2.6.1
+        version: 2.6.1
       unique-names-generator:
         specifier: ^4.7.1
         version: 4.7.1
@@ -10285,38 +10285,38 @@ packages:
   tunnel-agent@0.6.0:
     resolution: {integrity: sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==}
 
-  turbo-darwin-64@2.6.0:
-    resolution: {integrity: sha512-6vHnLAubHj8Ib45Knu+oY0ZVCLO7WcibzAvt5b1E72YHqAs4y8meMAGMZM0jLqWPh/9maHDc16/qBCMxtW4pXg==}
+  turbo-darwin-64@2.6.1:
+    resolution: {integrity: sha512-Dm0HwhyZF4J0uLqkhUyCVJvKM9Rw7M03v3J9A7drHDQW0qAbIGBrUijQ8g4Q9Cciw/BXRRd8Uzkc3oue+qn+ZQ==}
     cpu: [x64]
     os: [darwin]
 
-  turbo-darwin-arm64@2.6.0:
-    resolution: {integrity: sha512-IU+gWMEXNBw8H0pxvE7nPEa5p6yahxbN8g/Q4Bf0AHymsAFqsScgV0peeNbWybdmY9jk1LPbALOsF2kY1I7ZiQ==}
+  turbo-darwin-arm64@2.6.1:
+    resolution: {integrity: sha512-U0PIPTPyxdLsrC3jN7jaJUwgzX5sVUBsKLO7+6AL+OASaa1NbT1pPdiZoTkblBAALLP76FM0LlnsVQOnmjYhyw==}
     cpu: [arm64]
     os: [darwin]
 
-  turbo-linux-64@2.6.0:
-    resolution: {integrity: sha512-CKoiJ2ZFJLCDsWdRlZg+ew1BkGn8iCEGdePhISVpjsGwkJwSVhVu49z2zKdBeL1IhcSKS2YALwp9ellNZANJxw==}
+  turbo-linux-64@2.6.1:
+    resolution: {integrity: sha512-eM1uLWgzv89bxlK29qwQEr9xYWBhmO/EGiH22UGfq+uXr+QW1OvNKKMogSN65Ry8lElMH4LZh0aX2DEc7eC0Mw==}
     cpu: [x64]
     os: [linux]
 
-  turbo-linux-arm64@2.6.0:
-    resolution: {integrity: sha512-WroVCdCvJbrhNxNdw7XB7wHAfPPJPV+IXY+ZKNed+9VdfBu/2mQNfKnvqTuFTH7n+Pdpv8to9qwhXRTJe26upg==}
+  turbo-linux-arm64@2.6.1:
+    resolution: {integrity: sha512-MFFh7AxAQAycXKuZDrbeutfWM5Ep0CEZ9u7zs4Hn2FvOViTCzIfEhmuJou3/a5+q5VX1zTxQrKGy+4Lf5cdpsA==}
     cpu: [arm64]
     os: [linux]
 
-  turbo-windows-64@2.6.0:
-    resolution: {integrity: sha512-7pZo5aGQPR+A7RMtWCZHusarJ6y15LQ+o3jOmpMxTic/W6Bad+jSeqo07TWNIseIWjCVzrSv27+0odiYRYtQdA==}
+  turbo-windows-64@2.6.1:
+    resolution: {integrity: sha512-buq7/VAN7KOjMYi4tSZT5m+jpqyhbRU2EUTTvp6V0Ii8dAkY2tAAjQN1q5q2ByflYWKecbQNTqxmVploE0LVwQ==}
     cpu: [x64]
     os: [win32]
 
-  turbo-windows-arm64@2.6.0:
-    resolution: {integrity: sha512-1Ty+NwIksQY7AtFUCPrTpcKQE7zmd/f7aRjdT+qkqGFQjIjFYctEtN7qo4vpQPBgCfS1U3ka83A2u/9CfJQ3wQ==}
+  turbo-windows-arm64@2.6.1:
+    resolution: {integrity: sha512-7w+AD5vJp3R+FB0YOj1YJcNcOOvBior7bcHTodqp90S3x3bLgpr7tE6xOea1e8JkP7GK6ciKVUpQvV7psiwU5Q==}
     cpu: [arm64]
     os: [win32]
 
-  turbo@2.6.0:
-    resolution: {integrity: sha512-kC5VJqOXo50k0/0jnJDDjibLAXalqT9j7PQ56so0pN+81VR4Fwb2QgIE9dTzT3phqOTQuEXkPh3sCpnv5Isz2g==}
+  turbo@2.6.1:
+    resolution: {integrity: sha512-qBwXXuDT3rA53kbNafGbT5r++BrhRgx3sAo0cHoDAeG9g1ItTmUMgltz3Hy7Hazy1ODqNpR+C7QwqL6DYB52yA==}
     hasBin: true
 
   tw-animate-css@1.4.0:
@@ -11174,7 +11174,7 @@ snapshots:
       '@babel/types': 7.28.5
       '@jridgewell/remapping': 2.3.5
       convert-source-map: 2.0.0
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       gensync: 1.0.0-beta.2
       json5: 2.2.3
       semver: 6.3.1
@@ -11226,7 +11226,7 @@ snapshots:
       '@babel/core': 7.28.5
       '@babel/helper-compilation-targets': 7.27.2
       '@babel/helper-plugin-utils': 7.27.1
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       lodash.debounce: 4.0.8
       resolve: 1.22.11
     transitivePeerDependencies:
@@ -11886,7 +11886,7 @@ snapshots:
       '@babel/parser': 7.28.5
       '@babel/template': 7.27.2
       '@babel/types': 7.28.5
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -12367,7 +12367,7 @@ snapshots:
       '@antfu/install-pkg': 1.1.0
       '@antfu/utils': 9.3.0
       '@iconify/types': 2.0.0
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       globals: 15.15.0
       kolorist: 1.8.0
       local-pkg: 1.1.2
@@ -17323,7 +17323,7 @@ snapshots:
       '@ampproject/remapping': 2.3.0
       '@bcoe/v8-coverage': 1.0.2
       ast-v8-to-istanbul: 0.3.8
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       istanbul-lib-coverage: 3.2.2
       istanbul-lib-report: 3.0.1
       istanbul-lib-source-maps: 5.0.6
@@ -17381,7 +17381,7 @@ snapshots:
 
   '@vitest/web-worker@3.1.4(vitest@3.2.4(@types/debug@4.1.12)(@types/node@20.19.24)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.2)(tsx@4.20.6)(yaml@2.8.1))':
     dependencies:
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.24)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.2)(tsx@4.20.6)(yaml@2.8.1)
     transitivePeerDependencies:
       - supports-color
@@ -17800,7 +17800,7 @@ snapshots:
     dependencies:
       bytes: 3.1.2
       content-type: 1.0.5
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       http-errors: 2.0.0
       iconv-lite: 0.6.3
       on-finished: 2.4.1
@@ -18815,7 +18815,7 @@ snapshots:
 
   esbuild-register@3.6.0(esbuild@0.25.9):
     dependencies:
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       esbuild: 0.25.9
     transitivePeerDependencies:
       - supports-color
@@ -18996,7 +18996,7 @@ snapshots:
       content-type: 1.0.5
       cookie: 0.7.2
       cookie-signature: 1.2.2
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       encodeurl: 2.0.0
       escape-html: 1.0.3
       etag: 1.8.1
@@ -19101,7 +19101,7 @@ snapshots:
 
   finalhandler@2.1.0:
     dependencies:
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       encodeurl: 2.0.0
       escape-html: 1.0.3
       on-finished: 2.4.1
@@ -19129,7 +19129,7 @@ snapshots:
 
   follow-redirects@1.15.11(debug@4.4.3):
     optionalDependencies:
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
 
   for-each@0.3.5:
     dependencies:
@@ -19390,7 +19390,7 @@ snapshots:
   gel@2.1.1:
     dependencies:
       '@petamoriken/float16': 3.9.3
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       env-paths: 3.0.0
       semver: 7.7.3
       shell-quote: 1.8.3
@@ -19735,7 +19735,7 @@ snapshots:
   http-proxy-agent@7.0.2:
     dependencies:
       agent-base: 7.1.4
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -19748,7 +19748,7 @@ snapshots:
   https-proxy-agent@7.0.6:
     dependencies:
       agent-base: 7.1.4
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -20025,7 +20025,7 @@ snapshots:
   istanbul-lib-source-maps@5.0.6:
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       istanbul-lib-coverage: 3.2.2
     transitivePeerDependencies:
       - supports-color
@@ -20946,7 +20946,7 @@ snapshots:
   micromark@4.0.2:
     dependencies:
       '@types/debug': 4.1.12
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       decode-named-character-reference: 1.2.0
       devlop: 1.1.0
       micromark-core-commonmark: 2.0.3
@@ -22338,7 +22338,7 @@ snapshots:
 
   require-in-the-middle@7.5.2:
     dependencies:
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       module-details-from-path: 1.0.4
       resolve: 1.22.11
     transitivePeerDependencies:
@@ -22346,7 +22346,7 @@ snapshots:
 
   require-in-the-middle@8.0.1:
     dependencies:
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       module-details-from-path: 1.0.4
     transitivePeerDependencies:
       - supports-color
@@ -22418,7 +22418,7 @@ snapshots:
 
   router@2.2.0:
     dependencies:
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       depd: 2.0.0
       is-promise: 4.0.0
       parseurl: 1.3.3
@@ -22500,7 +22500,7 @@ snapshots:
 
   send@1.2.0:
     dependencies:
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       encodeurl: 2.0.0
       escape-html: 1.0.3
       etag: 1.8.1
@@ -22759,7 +22759,7 @@ snapshots:
       arg: 5.0.2
       bluebird: 3.7.2
       check-more-types: 2.24.0
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       execa: 5.1.1
       lazy-ass: 1.6.0
       ps-tree: 1.2.0
@@ -23185,7 +23185,7 @@ snapshots:
       cac: 6.7.14
       chokidar: 4.0.3
       consola: 3.4.2
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       esbuild: 0.25.9
       fix-dts-default-cjs-exports: 1.0.1
       joycon: 3.1.1
@@ -23218,32 +23218,32 @@ snapshots:
     dependencies:
       safe-buffer: 5.2.1
 
-  turbo-darwin-64@2.6.0:
+  turbo-darwin-64@2.6.1:
     optional: true
 
-  turbo-darwin-arm64@2.6.0:
+  turbo-darwin-arm64@2.6.1:
     optional: true
 
-  turbo-linux-64@2.6.0:
+  turbo-linux-64@2.6.1:
     optional: true
 
-  turbo-linux-arm64@2.6.0:
+  turbo-linux-arm64@2.6.1:
     optional: true
 
-  turbo-windows-64@2.6.0:
+  turbo-windows-64@2.6.1:
     optional: true
 
-  turbo-windows-arm64@2.6.0:
+  turbo-windows-arm64@2.6.1:
     optional: true
 
-  turbo@2.6.0:
+  turbo@2.6.1:
     optionalDependencies:
-      turbo-darwin-64: 2.6.0
-      turbo-darwin-arm64: 2.6.0
-      turbo-linux-64: 2.6.0
-      turbo-linux-arm64: 2.6.0
-      turbo-windows-64: 2.6.0
-      turbo-windows-arm64: 2.6.0
+      turbo-darwin-64: 2.6.1
+      turbo-darwin-arm64: 2.6.1
+      turbo-linux-64: 2.6.1
+      turbo-linux-arm64: 2.6.1
+      turbo-windows-64: 2.6.1
+      turbo-windows-arm64: 2.6.1
 
   tw-animate-css@1.4.0: {}
 
@@ -23579,7 +23579,7 @@ snapshots:
   vite-node@3.2.4(@types/node@20.19.24)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.20.6)(yaml@2.8.1):
     dependencies:
       cac: 6.7.14
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       es-module-lexer: 1.7.0
       pathe: 2.0.3
       vite: 7.1.12(@types/node@20.19.24)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.20.6)(yaml@2.8.1)
@@ -23600,7 +23600,7 @@ snapshots:
   vite-node@3.2.4(@types/node@24.10.0)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.20.6)(yaml@2.8.1):
     dependencies:
       cac: 6.7.14
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       es-module-lexer: 1.7.0
       pathe: 2.0.3
       vite: 7.1.12(@types/node@24.10.0)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.20.6)(yaml@2.8.1)
@@ -23620,7 +23620,7 @@ snapshots:
 
   vite-tsconfig-paths@5.1.4(typescript@5.9.3)(vite@7.2.0(@types/node@20.19.24)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.20.6)(yaml@2.8.1)):
     dependencies:
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       globrex: 0.1.2
       tsconfck: 3.1.6(typescript@5.9.3)
     optionalDependencies:
@@ -23725,7 +23725,7 @@ snapshots:
       '@vitest/spy': 3.2.4
       '@vitest/utils': 3.2.4
       chai: 5.3.3
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       expect-type: 1.2.2
       magic-string: 0.30.19
       pathe: 2.0.3
@@ -23768,7 +23768,7 @@ snapshots:
       '@vitest/spy': 3.2.4
       '@vitest/utils': 3.2.4
       chai: 5.3.3
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       expect-type: 1.2.2
       magic-string: 0.30.19
       pathe: 2.0.3

--- a/turbo.json
+++ b/turbo.json
@@ -151,7 +151,8 @@
     },
     "check:husky": {
       "dependsOn": ["build", "lint", "typecheck", "test"],
-      "cache": false
+      "cache": false,
+      "outputs": []
     }
   }
 }


### PR DESCRIPTION
## Summary

This PR upgrades turbo to 2.6.1 and implements automatic timeout detection and cache clearing in the pre-push hook to fix hangs that previously required manual terminal restarts and cache clearing.

## Changes

- **Upgraded turbo**: From `^2.5.5` to `^2.6.1` (latest stable)
- **Pre-push hook improvements**:
  - Added 5-minute timeout detection
  - Automatic turbo cache clearing on timeout
  - Automatic retry after cache clear
  - Improved process group termination to prevent zombie processes
  - Better error messages and troubleshooting guidance
- **Fixed `clean:turbo` command**: Changed from non-existent `turbo clean` to `rm -rf .turbo`
- **Turbo config**: Added explicit `outputs: []` to `check:husky` task

## How It Works

1. Pre-push hook runs `pnpm check:husky` with timeout monitoring
2. If command hangs (exceeds 5 minutes), it:
   - Detects the hang
   - Kills the process group (including all child processes)
   - Clears the turbo cache automatically
   - Retries once
3. If retry succeeds, push continues normally
4. If retry also times out, provides helpful error messages

## Testing

- [x] Turbo configuration validated with dry-run
- [x] Pre-push hook syntax validated
- [x] All files linted successfully

## Related

Fixes PRD-5356