### PR TITLE
Add 'break-words' class to base node component

### DIFF
--- a/.changeset/poor-taxis-tell.md
+++ b/.changeset/poor-taxis-tell.md
@@ -2,4 +2,4 @@
 "@inkeep/agents-manage-ui": patch
 ---
 
-Add 'wrap-break-word' class to base node component
+Add 'break-words' class to base node component

--- a/agents-manage-ui/src/components/agent/nodes/base-node.tsx
+++ b/agents-manage-ui/src/components/agent/nodes/base-node.tsx
@@ -63,7 +63,7 @@ export const BaseNodeContent = forwardRef<HTMLDivElement, HTMLAttributes<HTMLDiv
     <div
       ref={ref}
       data-slot="base-node-content"
-      className={cn('flex flex-col gap-y-2 p-4 text-foreground wrap-break-word', className)}
+      className={cn('flex flex-col gap-y-2 p-4 text-foreground break-words', className)}
       {...props}
     />
   )


### PR DESCRIPTION
## before
<img width="567" height="236" alt="image" src="https://github.com/user-attachments/assets/60a89988-81f6-4d9a-bba1-2fe9cd52c808" />

## after

<img width="395" height="229" alt="image" src="https://github.com/user-attachments/assets/5dbf40c1-8dab-4bcf-bbb6-f1d709edfaf3" />
