### PR TITLE
fix: format tsconfig.json arrays to single lines for Biome

### DIFF
--- a/agents-manage-ui/tsconfig.json
+++ b/agents-manage-ui/tsconfig.json
@@ -1,11 +1,7 @@
 {
   "compilerOptions": {
     "target": "ES2017",
-    "lib": [
-      "dom",
-      "dom.iterable",
-      "ESNext"
-    ],
+    "lib": ["dom", "dom.iterable", "ESNext"],
     "allowJs": true,
     "skipLibCheck": true,
     "strict": true,
@@ -22,13 +18,9 @@
       }
     ],
     "paths": {
-      "@/*": [
-        "./src/*"
-      ]
+      "@/*": ["./src/*"]
     },
-    "types": [
-      "vitest/globals"
-    ],
+    "types": ["vitest/globals"],
     "resolveJsonModule": true
   },
   "include": [
@@ -38,10 +30,5 @@
     ".next/types/**/*.ts",
     ".next/dev/types/**/*.ts"
   ],
-  "exclude": [
-    "node_modules",
-    ".next",
-    "cypress",
-    "cypress.config.ts"
-  ]
+  "exclude": ["node_modules", ".next", "cypress", "cypress.config.ts"]
 }


### PR DESCRIPTION
Fixes Biome formatting errors in CI by formatting JSON arrays to single lines per Biome's formatting rules.

## Changes
- Formatted arrays in `agents-manage-ui/tsconfig.json` to single lines:
  - `lib` array
  - `paths["@/*"]` array  
  - `types` array
  - `exclude` array

This addresses the Biome Format error that was causing CI failures.