### PR TITLE
Fix typecheck error: add missing toolPolicies field

### DIFF
--- a/packages/agents-core/src/data-access/subAgentRelations.ts
+++ b/packages/agents-core/src/data-access/subAgentRelations.ts
@@ -645,6 +645,7 @@ export const getAgentsForTool =
           toolId: subAgentToolRelations.toolId,
           selectedTools: subAgentToolRelations.selectedTools,
           headers: subAgentToolRelations.headers,
+          toolPolicies: subAgentToolRelations.toolPolicies,
           createdAt: subAgentToolRelations.createdAt,
           updatedAt: subAgentToolRelations.updatedAt,
           subAgent: {


### PR DESCRIPTION
## Summary
- Fixed typecheck errors in `@inkeep/agents-manage-api` by adding missing `toolPolicies` field to the database query
- The field exists in the schema but was not being selected in the `getAgentsForTool` function

## Changes
- Added `toolPolicies: subAgentToolRelations.toolPolicies` to the select statement in `packages/agents-core/src/data-access/subAgentRelations.ts:648`

## Test plan
- [x] Run `pnpm typecheck` - all packages pass
- [x] Verified the field exists in the database schema
- [x] Confirmed the fix resolves all type errors in agents-manage-api routes

🤖 Generated with [Claude Code](https://claude.com/claude-code)