### PR TITLE
fix: configure Vercel to use pnpm for agents-docs build

### DIFF
--- a/agents-docs/vercel.json
+++ b/agents-docs/vercel.json
@@ -1,5 +1,5 @@
 {
-  "buildCommand": "pnpm build",
-  "installCommand": "pnpm install",
+  "buildCommand": "cd .. && pnpm install --frozen-lockfile && pnpm --filter @inkeep/agents-docs build",
+  "installCommand": "cd .. && pnpm install --frozen-lockfile",
   "framework": "nextjs"
 }


### PR DESCRIPTION
## Summary
- Adds `vercel.json` to `agents-docs/` to explicitly configure pnpm as the package manager
- Fixes Vercel build failure: `npm error Unsupported URL Type "workspace:": workspace:^`

## Problem
The Vercel deployment for `agents-docs` was failing because:
1. The `vercel.json` configuration was removed in commit c35a27853 (PR #811)
2. A workspace dependency `@inkeep/agents-cli: "workspace:^"` was added in commit 0efbef56e
3. Without explicit configuration, Vercel defaults to npm for the `agents-docs` build
4. npm doesn't support the pnpm-specific `workspace:` protocol

## Solution
Restore the `vercel.json` configuration to explicitly tell Vercel to use pnpm for installing dependencies and building, which properly handles workspace protocol dependencies.

## Test Plan
- [ ] Verify Vercel deployment succeeds after merging
- [ ] Check that the build uses pnpm (should see "Package Manager: pnpm" in logs)
- [ ] Confirm no workspace protocol errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)