### PR TITLE
feat: add detailed permission diagnostics to requirePermission middleware

### DIFF
--- a/agents-manage-api/src/middleware/require-permission.ts
+++ b/agents-manage-api/src/middleware/require-permission.ts
@@ -18,11 +18,21 @@ type MinimalAuthVariables = {
   };
 };
 
+function formatPermissionsForDisplay(permissions: Permission): string[] {
+  const formatted: string[] = [];
+  for (const [resource, actions] of Object.entries(permissions)) {
+    const actionList = Array.isArray(actions) ? actions : [actions];
+    for (const action of actionList) {
+      formatted.push(`${resource}:${action}`);
+    }
+  }
+  return formatted;
+}
+
 export const requirePermission = <Env extends MinimalAuthVariables = MinimalAuthVariables>(
   permissions: Permission
 ) =>
   createMiddleware<Env>(async (c, next) => {
-    // Use process.env directly to support test environment variables set after module load
     const isTestEnvironment = process.env.ENVIRONMENT === 'test';
 
     const auth = c.get('auth');
@@ -34,17 +44,25 @@ export const requirePermission = <Env extends MinimalAuthVariables = MinimalAuth
 
     const userId = c.get('userId');
     const tenantId = c.get('tenantId');
+    const tenantRole = c.get('tenantRole');
+    const requiredPermissions = formatPermissionsForDisplay(permissions);
 
     if (!userId || !tenantId) {
       throw createApiError({
         code: 'unauthorized',
-        message: 'User or organization not found',
+        message: 'User or organization context not found. Ensure you are authenticated and belong to an organization.',
+        instance: c.req.path,
+        extensions: {
+          requiredPermissions,
+          context: {
+            hasUserId: !!userId,
+            hasTenantId: !!tenantId,
+          },
+        },
       });
     }
 
     try {
-      // Type assertion needed due to better-auth's complex type inference
-      // hasPermission is provided by the organization plugin
       const result = await auth.api.hasPermission({
         body: {
           permissions,
@@ -56,7 +74,16 @@ export const requirePermission = <Env extends MinimalAuthVariables = MinimalAuth
       if (!result || !result.success) {
         throw createApiError({
           code: 'forbidden',
-          message: 'You do not have the required permissions to perform this action',
+          message: `Permission denied. Required: ${requiredPermissions.join(', ')}`,
+          instance: c.req.path,
+          extensions: {
+            requiredPermissions,
+            context: {
+              userId,
+              organizationId: tenantId,
+              currentRole: tenantRole || 'unknown',
+            },
+          },
         });
       }
 
@@ -66,9 +93,16 @@ export const requirePermission = <Env extends MinimalAuthVariables = MinimalAuth
         throw error;
       }
 
+      const errorMessage = error instanceof Error ? error.message : 'Unknown error';
+
       throw createApiError({
         code: 'internal_server_error',
         message: 'Failed to verify permissions',
+        instance: c.req.path,
+        extensions: {
+          requiredPermissions,
+          internalError: errorMessage,
+        },
       });
     }
   });

--- a/packages/agents-core/src/utils/error.ts
+++ b/packages/agents-core/src/utils/error.ts
@@ -82,11 +82,13 @@ export function createApiError({
   message,
   instance,
   requestId,
+  extensions,
 }: {
   code: ErrorCodes;
   message: string;
   instance?: string;
   requestId?: string;
+  extensions?: Record<string, unknown>;
 }): HTTPException {
   const status = errorCodeToHttpStatus[code];
   const title = getTitleFromCode(code);
@@ -106,6 +108,7 @@ export function createApiError({
   const responseBody = {
     ...problemDetails,
     error: { code, message: errorMessage },
+    ...(extensions && extensions),
   };
 
   const res = new Response(JSON.stringify(responseBody), {


### PR DESCRIPTION
## Summary

Enhances the `requirePermission` middleware to return detailed Problem Details responses that help diagnose permission-related issues.

## Changes

### `packages/agents-core/src/utils/error.ts`
- Added optional `extensions` parameter to `createApiError` function
- Allows custom diagnostic fields to be included in Problem Details responses

### `agents-manage-api/src/middleware/require-permission.ts`
- Added `formatPermissionsForDisplay` helper to convert permission objects to readable format
- Enhanced error responses to include:
  - **requiredPermissions**: Array of permissions needed (e.g., `["agent:read", "agent:write"]`)
  - **context**: Debugging information (userId, organizationId, currentRole)
  - **instance**: The request path

## Example Response

```json
{
  "title": "Forbidden",
  "status": 403,
  "detail": "Permission denied. Required: agent:read, agent:write",
  "code": "forbidden",
  "instance": "/api/agents/123",
  "error": {
    "code": "forbidden",
    "message": "Permission denied. Required: agent:read, agent:write"
  },
  "requiredPermissions": ["agent:read", "agent:write"],
  "context": {
    "userId": "user_abc123",
    "organizationId": "org_xyz789",
    "currentRole": "member"
  }
}
```

## Testing
- [x] Typecheck passes
- [x] Lint passes