### PR TITLE
docs: do not hide 'on this page' text in table of contents

### DIFF
--- a/agents-docs/src/app/global.css
+++ b/agents-docs/src/app/global.css
@@ -122,10 +122,6 @@ html {
   left: calc(var(--fd-sidebar-width) + 1.1rem);
   /* @apply rounded-none lg:px-1 mx-0 shadow-none w-full border-0 bg-background top-[calc(var(--fd-banner-height)_+_var(--fd-nav-height))] after:bg-gradient-to-b after:from-[hsl(var(--background))] after:absolute after:w-full after:h-6 after:top-full after:left-0; */
 }
-/* hide the 'on this page' text */
-#nd-toc h3 {
-  display: none;
-}
 
 /* tailwind typography overrides */
 @utility prose {


### PR DESCRIPTION
I don't think we should hide this toc header

<img width="543" height="414" alt="image" src="https://github.com/user-attachments/assets/d99c7793-3bb4-4ac3-ba7e-a66cb6039edb" />
