### PR TITLE
fix: address test failures in agents-core, agents-run-api, and agents-manage-ui

### DIFF
--- a/agents-manage-ui/src/features/agent/domain/__tests__/roundtrip.test.ts
+++ b/agents-manage-ui/src/features/agent/domain/__tests__/roundtrip.test.ts
@@ -148,8 +148,9 @@ describe('agent serialize/deserialize', () => {
     if ('tools' in a1) {
       expect(a1.tools).toContain('t1');
     }
-    if ('canTransferTo' in a1) {
-      expect(a1.canTransferTo).toContain('a2');
+    // Edge has delegateSourceToTarget: true, not transfer
+    if ('canDelegateTo' in a1) {
+      expect(a1.canDelegateTo).toContain('a2');
     }
 
     const deserialized = deserializeAgentData(serialized);

--- a/agents-manage-ui/src/lib/actions/__tests__/tool-approval.test.ts
+++ b/agents-manage-ui/src/lib/actions/__tests__/tool-approval.test.ts
@@ -214,9 +214,9 @@ describe('tool-approval-mapper', () => {
       expect(mockMakeManagementApiRequest).not.toHaveBeenCalled();
     });
 
-    it('should return null for non-update/create operations', async () => {
+    it('should return null for non-update/create/delete operations', async () => {
       const result = await fetchCurrentEntityState({
-        toolName: 'sub-agent-delete-subagent',
+        toolName: 'sub-agent-get-subagent',
         input: {
           request: {
             id: 'test-sub-agent',

--- a/agents-manage-ui/src/lib/utils/__tests__/tool-approval-mapper.test.ts
+++ b/agents-manage-ui/src/lib/utils/__tests__/tool-approval-mapper.test.ts
@@ -155,6 +155,7 @@ describe('tool-approval-mapper', () => {
         input: {
           request: {
             id: 'test-sub-agent',
+            agentId: 'test-agent',
             tenantId: 'default',
             projectId: 'test-project',
           },
@@ -165,7 +166,7 @@ describe('tool-approval-mapper', () => {
 
       expect(result).toEqual(mockResponse.data);
       expect(mockMakeManagementApiRequest).toHaveBeenCalledWith(
-        'tenants/default/projects/test-project/sub-agents/test-sub-agent',
+        'tenants/default/projects/test-project/agents/test-agent/sub-agents/test-sub-agent',
         { method: 'GET' }
       );
     });
@@ -217,9 +218,9 @@ describe('tool-approval-mapper', () => {
       expect(mockMakeManagementApiRequest).not.toHaveBeenCalled();
     });
 
-    it('should return null for non-update/create operations', async () => {
+    it('should return null for non-update/create/delete operations', async () => {
       const result = await fetchCurrentEntityState({
-        toolName: 'sub-agent-delete-subagent',
+        toolName: 'sub-agent-get-subagent',
         input: {
           request: {
             id: 'test-sub-agent',
@@ -243,6 +244,7 @@ describe('tool-approval-mapper', () => {
         input: {
           request: {
             id: 'test-sub-agent',
+            agentId: 'test-agent',
             tenantId: 'default',
             projectId: 'test-project',
           },

--- a/agents-run-api/src/__tests__/agents/Agent.test.ts
+++ b/agents-run-api/src/__tests__/agents/Agent.test.ts
@@ -100,6 +100,10 @@ const {
 
 vi.mock('@inkeep/agents-core', async (importOriginal) => {
   const actual = await importOriginal<typeof import('@inkeep/agents-core')>();
+  const mockModel = 'mocked-language-model';
+  const mockGenerationParams = { temperature: 0.7, maxTokens: 4096 };
+  const mockGenerationConfig = { model: mockModel, ...mockGenerationParams };
+
   return {
     ...actual,
     getCredentialReference: getCredentialReferenceMock,
@@ -129,23 +133,6 @@ vi.mock('@inkeep/agents-core', async (importOriginal) => {
         stuff: vi.fn().mockResolvedValue({}),
       };
     }),
-  };
-});
-
-// Mock anthropic
-vi.mock('@ai-sdk/anthropic', () => ({
-  anthropic: vi.fn().mockReturnValue('mocked-model'),
-}));
-
-// Mock ModelFactory
-vi.mock('@inkeep/agents-core', async () => {
-  const actual = await vi.importActual('@inkeep/agents-core');
-  const mockModel = 'mocked-language-model';
-  const mockGenerationParams = { temperature: 0.7, maxTokens: 4096 };
-  const mockGenerationConfig = { model: mockModel, ...mockGenerationParams };
-
-  return {
-    ...actual,
     ModelFactory: {
       createModel: vi.fn().mockReturnValue(mockModel),
       getGenerationParams: vi.fn().mockReturnValue(mockGenerationParams),
@@ -154,6 +141,11 @@ vi.mock('@inkeep/agents-core', async () => {
     },
   };
 });
+
+// Mock anthropic
+vi.mock('@ai-sdk/anthropic', () => ({
+  anthropic: vi.fn().mockReturnValue('mocked-model'),
+}));
 
 // Mock ToolSessionManager
 vi.mock('../../agents/ToolSessionManager.js', () => ({
@@ -1038,9 +1030,9 @@ describe('Agent Credential Integration', () => {
     // Mock the credential stuffer
     (agent as any).credentialStuffer = {
       buildMcpServerConfig: vi.fn().mockResolvedValue({
+        type: MCPTransportType.streamableHttp,
         url: 'https://mcp.example.com',
         headers: {},
-        transport: { type: MCPTransportType.streamableHttp },
       }),
     };
 

--- a/packages/agents-core/src/__tests__/data-access/subAgents.test.ts
+++ b/packages/agents-core/src/__tests__/data-access/subAgents.test.ts
@@ -383,6 +383,15 @@ describe('Agent Data Access', () => {
         where: vi.fn().mockResolvedValue(undefined),
       });
 
+      // Mock select for checking if sub-agent is default (returns empty array = not default)
+      const mockSelect = vi.fn().mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            limit: vi.fn().mockResolvedValue([]),
+          }),
+        }),
+      });
+
       // Mock getAgentById to return null (agent not found after deletion)
       const mockQuery = {
         subAgents: {
@@ -393,6 +402,7 @@ describe('Agent Data Access', () => {
       const mockDb = {
         ...db,
         delete: mockDelete,
+        select: mockSelect,
         query: mockQuery,
       } as any;
 

--- a/packages/agents-core/src/__tests__/integration/data-access/agents.test.ts
+++ b/packages/agents-core/src/__tests__/integration/data-access/agents.test.ts
@@ -77,6 +77,12 @@ describe('Agent Agent Data Access - Integration Tests', () => {
       expect(fetchedAgent).not.toBeNull();
       expect(fetchedAgent).toMatchObject(agentData);
 
+      // Clear defaultSubAgentId before deleting sub-agent
+      await updateAgent(db)({
+        scopes: { tenantId: testTenantId, projectId: testProjectId, agentId: agentData.id },
+        data: { defaultSubAgentId: null },
+      });
+
       // Delete the agent and agent
       await deleteSubAgent(db)({
         scopes: { tenantId: testTenantId, projectId: testProjectId, agentId: agentData.id },
@@ -115,6 +121,12 @@ describe('Agent Agent Data Access - Integration Tests', () => {
       // Fetch with relations
       const agentWithAgent = await getAgentWithDefaultSubAgent(db)({
         scopes: { tenantId: testTenantId, projectId: testProjectId, agentId: agentData.id },
+      });
+
+      // Clear defaultSubAgentId before deleting sub-agent
+      await updateAgent(db)({
+        scopes: { tenantId: testTenantId, projectId: testProjectId, agentId: agentData.id },
+        data: { defaultSubAgentId: null },
       });
 
       // Delete the agent and agent


### PR DESCRIPTION
## Summary
- Fix test failures across multiple packages that were caused by implementation changes not reflected in tests
- All 170+ test files now pass with 0 failures

## Changes

### agents-core
- `subAgents.test.ts`: Add missing `db.select` mock for the new "is default sub-agent" check in `deleteSubAgent`
- `agents.test.ts` (integration): Clear `defaultSubAgentId` before deleting sub-agents in cleanup to avoid `SubAgentIsDefaultError`

### agents-run-api
- `Agent.test.ts`: Merge duplicate `vi.mock('@inkeep/agents-core')` calls into one - the second was overwriting the first, breaking `agentHasArtifactComponentsMock`
- `Agent.test.ts`: Fix `buildMcpServerConfig` mock to return `type` at top level instead of nested `transport.type`

### agents-manage-ui
- `tool-approval.test.ts` & `tool-approval-mapper.test.ts`: Fix tests to use GET operations for "non-update/create/delete" tests (delete operations now fetch current state)
- `tool-approval-mapper.test.ts`: Add missing `agentId` to sub-agent test requests
- `roundtrip.test.ts`: Fix test to check `canDelegateTo` instead of `canTransferTo` (edge had `delegateSourceToTarget: true`, not transfer)

## Test plan
- [x] `pnpm test` passes all packages
- [x] No regressions in existing tests