### PR TITLE
fix(manage-api): Safari CORS fix for auth routes

### DIFF
--- a/.changeset/fix-safari-cors.md
+++ b/.changeset/fix-safari-cors.md
@@ -1,0 +1,5 @@
+---
+"@inkeep/agents-manage-api": patch
+---
+
+fix Safari and Firefox CORS issue by adding User-Agent to allowed headers for auth routes

--- a/agents-manage-api/src/app.ts
+++ b/agents-manage-api/src/app.ts
@@ -193,7 +193,7 @@ function createManagementHono(
         origin: (origin) => {
           return isOriginAllowed(origin) ? origin : null;
         },
-        allowHeaders: ['Content-Type', 'Authorization'],
+        allowHeaders: ['Content-Type', 'Authorization', 'User-Agent'],
         allowMethods: ['POST', 'GET', 'OPTIONS'],
         exposeHeaders: ['Content-Length'],
         maxAge: 600,
@@ -214,7 +214,7 @@ function createManagementHono(
       origin: (origin) => {
         return isOriginAllowed(origin) ? origin : null;
       },
-      allowHeaders: ['content-type', 'Content-Type', 'authorization', 'Authorization'],
+      allowHeaders: ['content-type', 'Content-Type', 'authorization', 'Authorization', 'User-Agent'],
       allowMethods: ['POST', 'OPTIONS'],
       exposeHeaders: ['Content-Length'],
       maxAge: 600,


### PR DESCRIPTION
## Summary
- Add `User-Agent` to CORS `allowHeaders` for Better Auth routes (`/api/auth/*`)
- Add `User-Agent` to CORS `allowHeaders` for playground token routes

Safari requires headers it sends (like `User-Agent`) to be explicitly listed in `Access-Control-Allow-Headers`. Without this, auth and sign-in routes fail with CORS errors in Safari only.

## Test plan
- [ ] Test sign-in flow in Safari with auth enabled
- [ ] Verify Chrome/Firefox still work (regression check)