### PR TITLE
fix(manage-api): CORS support for Vercel preview/production deployments

### DIFF
--- a/.changeset/cors-vercel-subdomains.md
+++ b/.changeset/cors-vercel-subdomains.md
@@ -1,0 +1,5 @@
+---
+"@inkeep/agents-manage-api": patch
+---
+
+fix CORS for Vercel preview/production deployments by using VERCEL_URL env vars for subdomain matching

--- a/agents-manage-api/src/app.ts
+++ b/agents-manage-api/src/app.ts
@@ -27,10 +27,19 @@ const logger = getLogger('agents-manage-api');
 logger.info({ logger: logger.getTransports() }, 'Logger initialized');
 
 /**
+ * Extract the base domain from a hostname (e.g., "foo.bar.inkeep.com" -> "inkeep.com")
+ */
+function getBaseDomain(hostname: string): string | null {
+  const parts = hostname.split('.');
+  if (parts.length < 2) return null;
+  return parts.slice(-2).join('.');
+}
+
+/**
  * Check if a request origin is allowed for CORS
  *
  * Development: Allow any localhost origin
- * Production: Only allow origins from the same base domain as INKEEP_AGENTS_MANAGE_API_URL
+ * Production/Preview: Allow the specific UI URL, or any subdomain of the same base domain
  *
  * @returns true if origin is allowed (also narrows type to string)
  */
@@ -50,6 +59,19 @@ function isOriginAllowed(origin: string | undefined): origin is string {
     // Allow the specific UI URL if configured
     if (uiUrl && requestUrl.hostname === uiUrl.hostname) {
       return true;
+    }
+
+    // For Vercel deployments, allow any subdomain of the same base domain
+    // Use VERCEL_ENV to determine which URL to use for base domain extraction
+    const vercelUrl =
+      process.env.VERCEL_ENV === 'production'
+        ? process.env.VERCEL_PROJECT_PRODUCTION_URL
+        : process.env.VERCEL_URL;
+    if (vercelUrl) {
+      const baseDomain = getBaseDomain(vercelUrl);
+      if (baseDomain && requestUrl.hostname.endsWith(`.${baseDomain}`)) {
+        return true;
+      }
     }
 
     return false;


### PR DESCRIPTION
## Summary
- Use `VERCEL_PROJECT_PRODUCTION_URL` or `VERCEL_URL` to dynamically determine allowed subdomains
- Extracts base domain (e.g., `inkeep.com`) and allows any subdomain of that base domain
- Enables CORS for preview deployments without hardcoding domain names

This follows up on the Safari/Firefox CORS fix and addresses the issue where preview deployments were getting blocked due to missing `Access-Control-Allow-Origin`.

## Test plan
- [ ] Test auth in preview deployment
- [ ] Test auth in production deployment
- [ ] Verify localhost still works