### PR TITLE
fix(create-agents): use 127.0.0.1 instead of localhost to fix E2E test on CI

### DIFF
--- a/create-agents-template/apps/manage-api/vite.config.ts
+++ b/create-agents-template/apps/manage-api/vite.config.ts
@@ -11,6 +11,7 @@ export default defineConfig({
   ],
   server: {
     port: 3002,
+    host: '127.0.0.1', // Explicitly bind to IPv4 to avoid IPv6/IPv4 resolution issues
     allowedHosts: true,
     strictPort: true,
     cors: {

--- a/packages/create-agents/src/__tests__/e2e/quickstart.test.ts
+++ b/packages/create-agents/src/__tests__/e2e/quickstart.test.ts
@@ -12,7 +12,8 @@ import {
   waitForServerReady,
 } from './utils';
 
-const manageApiUrl = 'http://localhost:3002';
+// Use 127.0.0.1 instead of localhost to avoid IPv6/IPv4 resolution issues on CI (Ubuntu)
+const manageApiUrl = 'http://127.0.0.1:3002';
 
 describe('create-agents quickstart e2e', () => {
   let testDir: string;
@@ -82,8 +83,8 @@ describe('create-agents quickstart e2e', () => {
       /ENVIRONMENT=development/,
       /OPENAI_API_KEY=test-openai-key/,
       /DATABASE_URL=postgresql:\/\/appuser:password@localhost:5432\/inkeep_agents/,
-      /INKEEP_AGENTS_MANAGE_API_URL="http:\/\/localhost:3002"/,
-      /INKEEP_AGENTS_RUN_API_URL="http:\/\/localhost:3003"/,
+      /INKEEP_AGENTS_MANAGE_API_URL="http:\/\/127\.0\.0\.1:3002"/,
+      /INKEEP_AGENTS_RUN_API_URL="http:\/\/127\.0\.0\.1:3003"/,
       /INKEEP_AGENTS_JWT_SIGNING_SECRET=\w+/, // Random secret should be generated
     ]);
     console.log('.env file verified');

--- a/packages/create-agents/src/utils.ts
+++ b/packages/create-agents/src/utils.ts
@@ -374,8 +374,8 @@ export const createAgents = async (
         `  pnpm setup   # Setup project in database\n` +
         `  pnpm dev     # Start development servers\n\n` +
         `${color.yellow('Available services:')}\n` +
-        `  • Manage API: http://localhost:3002\n` +
-        `  • Run API: http://localhost:3003\n` +
+        `  • Manage API: http://127.0.0.1:3002\n` +
+        `  • Run API: http://127.0.0.1:3003\n` +
         `  • Manage UI: Available with management API\n` +
         `\n${color.yellow('Configuration:')}\n` +
         `  • Edit .env for environment variables\n` +
@@ -433,12 +433,13 @@ GOOGLE_GENERATIVE_AI_API_KEY=${config.googleKey || 'your-google-key-here'}
 
 # Inkeep API URLs
 # Internal URLs (server-side, Docker internal networking)
-INKEEP_AGENTS_MANAGE_API_URL="http://localhost:3002"
-INKEEP_AGENTS_RUN_API_URL="http://localhost:3003"
+# Using 127.0.0.1 instead of localhost to avoid IPv6/IPv4 resolution issues
+INKEEP_AGENTS_MANAGE_API_URL="http://127.0.0.1:3002"
+INKEEP_AGENTS_RUN_API_URL="http://127.0.0.1:3003"
 
 # Public URLs (client-side, browser accessible)
-PUBLIC_INKEEP_AGENTS_MANAGE_API_URL="http://localhost:3002"
-PUBLIC_INKEEP_AGENTS_RUN_API_URL="http://localhost:3003"
+PUBLIC_INKEEP_AGENTS_MANAGE_API_URL="http://127.0.0.1:3002"
+PUBLIC_INKEEP_AGENTS_RUN_API_URL="http://127.0.0.1:3003"
 
 # SigNoz Configuration
 SIGNOZ_URL=your-signoz-url-here
@@ -478,10 +479,11 @@ async function createInkeepConfig(config: FileConfig) {
 const config = defineConfig({
   tenantId: "${config.tenantId}",
   agentsManageApi: {
-    url: 'http://localhost:3002',
+    // Using 127.0.0.1 instead of localhost to avoid IPv6/IPv4 resolution issues
+    url: 'http://127.0.0.1:3002',
   },
   agentsRunApi: {
-    url: 'http://localhost:3003',
+    url: 'http://127.0.0.1:3003',
   },
 });
     


### PR DESCRIPTION
## Summary

Fixes the E2E test failure on CI (Ubuntu) where the test fails with "fetch failed" error.

**Root Cause**: On Ubuntu in CI, `localhost` can resolve to `::1` (IPv6) first, while the Vite dev server binds to `127.0.0.1` (IPv4). This causes `fetch()` to fail to connect.

**Solution**: Use `127.0.0.1` explicitly instead of `localhost` to avoid DNS resolution issues:
- Update test URLs to use `127.0.0.1`
- Update generated `.env` template to use `127.0.0.1`
- Update generated `inkeep.config.ts` template to use `127.0.0.1`
- Configure Vite to explicitly bind to `127.0.0.1`

## Test plan

- [x] E2E test passes locally
- [ ] CI E2E test should now pass

Related issue: https://github.com/inkeep/agents/actions/runs/19838412213/job/56842101574