### PR TITLE
fix(manage-api): CORS auth headers case sensitivity and base domain matching

### DIFF
--- a/agents-manage-api/src/app.ts
+++ b/agents-manage-api/src/app.ts
@@ -27,12 +27,17 @@ const logger = getLogger('agents-manage-api');
 logger.info({ logger: logger.getTransports() }, 'Logger initialized');
 
 /**
- * Extract the base domain from a hostname (e.g., "foo.bar.inkeep.com" -> "inkeep.com")
+ * Extract the base domain from a hostname (e.g., 'app.preview.inkeep.com' -> 'preview.inkeep.com')
+ * For hostnames with 3+ parts, returns the last 3 parts (subdomain.domain.tld)
+ * For hostnames with 2 parts, returns as-is (domain.tld)
  */
-function getBaseDomain(hostname: string): string | null {
+function getBaseDomain(hostname: string): string {
   const parts = hostname.split('.');
-  if (parts.length < 2) return null;
-  return parts.slice(-2).join('.');
+  // For hostnames like 'agents-manage-ui.preview.inkeep.com', get 'preview.inkeep.com'
+  if (parts.length >= 3) {
+    return parts.slice(-3).join('.');
+  }
+  return hostname;
 }
 
 /**
@@ -48,11 +53,11 @@ function isOriginAllowed(origin: string | undefined): origin is string {
 
   try {
     const requestUrl = new URL(origin);
-    const authUrl = new URL(env.INKEEP_AGENTS_MANAGE_API_URL || 'http://localhost:3002');
+    const apiUrl = new URL(env.INKEEP_AGENTS_MANAGE_API_URL || 'http://localhost:3002');
     const uiUrl = env.INKEEP_AGENTS_MANAGE_UI_URL ? new URL(env.INKEEP_AGENTS_MANAGE_UI_URL) : null;
 
     // Development: allow any localhost
-    if (authUrl.hostname === 'localhost' || authUrl.hostname === '127.0.0.1') {
+    if (apiUrl.hostname === 'localhost' || apiUrl.hostname === '127.0.0.1') {
       return requestUrl.hostname === 'localhost' || requestUrl.hostname === '127.0.0.1';
     }
 
@@ -61,17 +66,12 @@ function isOriginAllowed(origin: string | undefined): origin is string {
       return true;
     }
 
-    // For Vercel deployments, allow any subdomain of the same base domain
-    // Use VERCEL_ENV to determine which URL to use for base domain extraction
-    const vercelUrl =
-      process.env.VERCEL_ENV === 'production'
-        ? process.env.VERCEL_PROJECT_PRODUCTION_URL
-        : process.env.VERCEL_URL;
-    if (vercelUrl) {
-      const baseDomain = getBaseDomain(vercelUrl);
-      if (baseDomain && requestUrl.hostname.endsWith(`.${baseDomain}`)) {
-        return true;
-      }
+// Production: allow origins from the same base domain as the API URL
+    // This handles cases like agents-manage-ui.preview.inkeep.com -> agents-manage-api.preview.inkeep.com
+    const requestBaseDomain = getBaseDomain(requestUrl.hostname);
+    const apiBaseDomain = getBaseDomain(apiUrl.hostname);
+    if (requestBaseDomain === apiBaseDomain) {
+      return true;
     }
 
     return false;
@@ -215,7 +215,7 @@ function createManagementHono(
         origin: (origin) => {
           return isOriginAllowed(origin) ? origin : null;
         },
-        allowHeaders: ['Content-Type', 'Authorization', 'User-Agent'],
+allowHeaders: ['content-type', 'Content-Type', 'authorization', 'Authorization', 'User-Agent'],
         allowMethods: ['POST', 'GET', 'OPTIONS'],
         exposeHeaders: ['Content-Length'],
         maxAge: 600,


### PR DESCRIPTION
## Summary

- Fixes CORS preflight failures for auth routes on deployed instances by including both lowercase and uppercase header variants (`content-type`, `Content-Type`, `authorization`, `Authorization`) in `allowHeaders`
- Adds `getBaseDomain` function to extract base domain from hostnames (e.g., `agents-manage-ui.preview.inkeep.com` → `preview.inkeep.com`)
- Updates `isOriginAllowed` to support same base domain matching for preview deployments, allowing cross-origin requests between `agents-manage-ui.preview.inkeep.com` and `agents-manage-api.preview.inkeep.com`

## Problem

```
Access to fetch at 'https://agents-manage-api.preview.inkeep.com/api/auth/sign-in/email' from origin 'https://agents-manage-ui.preview.inkeep.com' has been blocked by CORS policy: Request header field content-type is not allowed by Access-Control-Allow-Headers in preflight response.
```

## Test plan

- [ ] Verify auth sign-in works on preview deployments
- [ ] Verify CORS preflight requests return correct `Access-Control-Allow-Headers`