### PR TITLE
feat(manage-ui): add context breakdown per AI generation activity in trace viewer

### DIFF
--- a/agents-manage-ui/src/components/traces/timeline/types.ts
+++ b/agents-manage-ui/src/components/traces/timeline/types.ts
@@ -110,6 +110,8 @@ export interface ActivityItem {
   // Tool approval fields
   approvalToolName?: string;
   approvalToolCallId?: string;
+  // Context breakdown for AI generation spans
+  contextBreakdown?: ContextBreakdown;
 }
 
 export interface ToolCall {

--- a/agents-manage-ui/src/lib/actions/copilot-token.ts
+++ b/agents-manage-ui/src/lib/actions/copilot-token.ts
@@ -80,7 +80,6 @@ export async function getCopilotTokenAction(): Promise<ActionResult<CopilotToken
     // Read cookies and format as a cookie header string
     const cookieStore = await cookies();
     const allCookies = cookieStore.getAll();
-    console.log('allCookies', allCookies);
     const cookieHeader = allCookies.map((c) => `${c.name}=${c.value}`).join('; ');
 
     return {


### PR DESCRIPTION
## Summary

- Adds per-activity context breakdown data to AI model streamed text activities in the trace timeline
- Builds a `spanId`→`contextBreakdown` map from `agent.generate` spans
- Looks up context breakdown from parent span for each AI generation activity
- Adds `contextBreakdown` field to `ActivityItem` type
- Removes debug `console.log` from copilot-token action

## Context

Previously, context breakdown was only available at the conversation level. This change associates context breakdown data with individual AI generation activities, enabling more granular token usage analysis in the trace viewer timeline.

## Test plan

- [ ] Verify context breakdown appears on AI generation activities in trace timeline
- [ ] Confirm context breakdown data matches expected values from telemetry