### PR TITLE
fix(docs): add custom 404 page with proper theme styling

### DIFF
--- a/agents-docs/src/app/not-found.tsx
+++ b/agents-docs/src/app/not-found.tsx
@@ -1,24 +1,34 @@
+'use client';
+
 import Link from 'next/link';
+import { useEffect } from 'react';
 
 export default function NotFound() {
+  useEffect(() => {
+    document.documentElement.style.overflow = 'hidden';
+    document.body.style.overflow = 'hidden';
+
+    return () => {
+      document.documentElement.style.overflow = '';
+      document.body.style.overflow = '';
+    };
+  }, []);
+
   return (
-    <>
-      <style>{`html, body { overflow: hidden !important; }`}</style>
-      <div className="fixed inset-0 top-[var(--fd-nav-height)] flex flex-col items-center justify-center px-4 bg-background text-foreground">
-        <h1 className="text-6xl font-bold text-fd-muted-foreground mb-4">404</h1>
-        <h2 className="text-xl font-medium text-fd-muted-foreground mb-6">
-          This page could not be found.
-        </h2>
-        <p className="text-fd-muted-foreground mb-8 text-center max-w-md">
-          The page you&apos;re looking for doesn&apos;t exist or has been moved.
-        </p>
-        <Link
-          href="/"
-          className="inline-flex items-center justify-center rounded-md bg-fd-primary px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-fd-primary/90"
-        >
-          Go to Overview
-        </Link>
-      </div>
-    </>
+    <div className="fixed inset-0 top-[var(--fd-nav-height)] flex flex-col items-center justify-center px-4 bg-background text-foreground">
+      <h1 className="text-6xl font-bold text-fd-muted-foreground mb-4">404</h1>
+      <h2 className="text-xl font-medium text-fd-muted-foreground mb-6">
+        This page could not be found.
+      </h2>
+      <p className="text-fd-muted-foreground mb-8 text-center max-w-md">
+        The page you&apos;re looking for doesn&apos;t exist or has been moved.
+      </p>
+      <Link
+        href="/"
+        className="inline-flex items-center justify-center rounded-md bg-fd-primary px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-fd-primary/90"
+      >
+        Go to Overview
+      </Link>
+    </div>
   );
 }


### PR DESCRIPTION
## Summary
- Add custom `not-found.tsx` for 404 page handling in the docs site
- Fix background color issue in light mode (was showing dark/black background instead of white)
- Fix layout positioning issues in dark mode
- Prevent page from being scrollable on 404 page

## Changes
- Created `agents-docs/src/app/not-found.tsx` with:
  - Theme-aware background and text colors using CSS variables (`bg-background`, `text-foreground`)
  - Fixed positioning to properly center content below the navbar
  - Overflow hidden to prevent scrolling
  - "Go to Overview" button to help users navigate

## Test plan
- [x] Verify 404 page displays correctly in light mode (white background)
- [x] Verify 404 page displays correctly in dark mode (dark background)
- [x] Verify page is not scrollable
- [x] Verify sidebar and navbar are visible
- [x] Verify "Go to Overview" link works