### PR TITLE
fix(docs): standardize design tokens in 404 page to use shadcn/ui

### DIFF
--- a/agents-docs/src/app/not-found.tsx
+++ b/agents-docs/src/app/not-found.tsx
@@ -22,11 +22,11 @@ export default function NotFound() {
       aria-labelledby="error-title"
     >
       <h1 id="error-title" className="sr-only">404 - Page Not Found</h1>
-      <div className="text-6xl font-bold text-fd-muted-foreground mb-4" aria-hidden="true">404</div>
-      <h2 className="text-xl font-medium text-fd-muted-foreground mb-6">
+      <div className="text-6xl font-bold text-muted-foreground mb-4" aria-hidden="true">404</div>
+      <h2 className="text-xl font-medium text-muted-foreground mb-6">
         This page could not be found.
       </h2>
-      <p className="text-fd-muted-foreground mb-8 text-center max-w-md">
+      <p className="text-muted-foreground mb-8 text-center max-w-md">
         The page you&apos;re looking for doesn&apos;t exist or has been moved.
       </p>
       <Button asChild>


### PR DESCRIPTION
## Summary
- Replace fumadocs tokens with shadcn/ui tokens in the 404 page for consistency with the rest of the codebase
- Changes: `text-fd-muted-foreground` → `text-muted-foreground`, `bg-fd-primary` → `bg-primary`, `text-white` → `text-primary-foreground`

## Test plan
- [x] Verify 404 page displays correctly in light mode
- [x] Verify 404 page displays correctly in dark mode
- [x] Verify button styling matches shadcn/ui button component patterns

Closes PRD-5466