### PR TITLE
fix(cypress): use correct event types for sidebar hover test

### DIFF
--- a/agents-manage-ui/cypress/e2e/sidebar.cy.ts
+++ b/agents-manage-ui/cypress/e2e/sidebar.cy.ts
@@ -41,10 +41,10 @@ describe('Sidebar', () => {
     it('should temporarily expands on hover and collapses again on blur', () => {
       cy.visit(`${projectUrl}/agents/weather-agent`);
       cy.get('[data-slot=sidebar]').should('have.attr', 'data-state', 'collapsed');
-      cy.get('[data-slot=sidebar]').trigger('mouseover');
+      cy.get('[data-slot=sidebar]').trigger('mouseenter');
       cy.get('[data-slot=sidebar]').should('have.attr', 'data-state', 'expanded');
       cy.get('.react-flow__node').then(([domEl]) => {
-        cy.get('[data-slot=sidebar]').trigger('mouseout', { relatedTarget: domEl });
+        cy.get('[data-slot=sidebar]').trigger('mouseleave', { relatedTarget: domEl });
       });
       cy.get('[data-slot=sidebar]').should('have.attr', 'data-state', 'collapsed');
     });


### PR DESCRIPTION
## Summary

- Fixed flaky Cypress test `should temporarily expands on hover and collapses again on blur` in `sidebar.cy.ts`
- Changed `mouseover` to `mouseenter` and `mouseout` to `mouseleave` to match the sidebar handler's expected event types

## Root Cause

The sidebar's `handleHover` callback checks `event.type === 'mouseleave'` to determine if the mouse left the sidebar:

```typescript
const isBlur = event.type === 'mouseleave';
// ...
setOpen(!isBlur);
```

When the test triggered `mouseout`, `isBlur` was `false` (since `'mouseout' !== 'mouseleave'`), so `setOpen(true)` was called, keeping the sidebar expanded instead of collapsing it.

## Test Plan

- [ ] Cypress E2E tests pass on CI
- [ ] The `sidebar.cy.ts` hover test specifically passes