### PR TITLE
Improve pre-push hook performance with affected-only checks and remote caching

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,3 +66,6 @@ dist/
 out/
 .source/
 vite.config.d.ts
+
+# Turborepo
+.turbo

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -2,9 +2,13 @@
 # Pre-push hook for Agent Framework
 #
 # This hook runs before each push to ensure code quality.
-# It runs a single optimized turbo command (pnpm check:husky) that:
-#   - Builds once (cached and reused by all tasks)
-#   - Runs lint, typecheck, and test in parallel after build
+# It uses turbo's affected-only filtering to only check packages
+# that have changed since origin/main, making it much faster.
+#
+# Performance optimizations:
+#   - Only checks packages affected by your changes (--filter='...[origin/main]')
+#   - Uses turbo remote caching when configured (see scripts/setup-turbo-cache.sh)
+#   - Excludes docs and cookbook templates from checks
 #
 # Usage:
 #   Normal push:                      git push
@@ -18,11 +22,44 @@ set -e
 TIMEOUT_SECONDS=300  # 5 minutes timeout
 RETRY_COUNT=1
 
-echo "🚀 Running pre-push checks..."
-echo "   Step 1: pnpm check:husky (build, lint, typecheck, unit tests)"
-
 # Ensure we're in the repository root
 cd "$(git rev-parse --show-toplevel)" || exit 1
+
+# Determine the base ref for affected filtering
+# Try to use origin/main, fall back to HEAD~1 if not available
+get_base_ref() {
+  if git rev-parse --verify origin/main >/dev/null 2>&1; then
+    echo "origin/main"
+  elif git rev-parse --verify main >/dev/null 2>&1; then
+    echo "main"
+  else
+    # Fallback: compare against parent commit
+    echo "HEAD~1"
+  fi
+}
+
+BASE_REF=$(get_base_ref)
+
+# Check if there are any changes affecting packages
+has_package_changes() {
+  # Check if any non-ignored files have changed
+  git diff --name-only "$BASE_REF"...HEAD 2>/dev/null | grep -qvE '^(\.github/|docs/|\.md$|\.txt$)' || \
+  git diff --name-only HEAD 2>/dev/null | grep -qvE '^(\.github/|docs/|\.md$|\.txt$)'
+}
+
+echo "🚀 Running pre-push checks..."
+echo "   Using affected-only mode (comparing against $BASE_REF)"
+
+# Show cache status
+if [ -n "$TURBO_TOKEN" ] && [ -n "$TURBO_TEAM" ]; then
+  echo "   ✅ Remote caching enabled (team: $TURBO_TEAM)"
+else
+  echo "   ⚠️  Remote caching not configured (run: pnpm turbo:login)"
+fi
+
+# Build the turbo command with affected-only filtering
+# Excludes: agents-cookbook-templates, agents-docs (docs don't need pre-push validation)
+TURBO_FILTER="--filter='...[$BASE_REF]' --filter='!agents-cookbook-templates' --filter='!@inkeep/agents-docs'"
 
 # Function to run command with timeout detection
 run_with_timeout() {
@@ -36,7 +73,7 @@ run_with_timeout() {
   
   # Run command in background and capture PID and process group
   # Force stream UI mode (not TUI) for non-interactive git hook environment
-  TURBO_UI=stream pnpm check:husky &
+  eval "TURBO_UI=stream pnpm turbo check:husky $TURBO_FILTER" &
   local cmd_pid=$!
   local pgid=$(ps -o pgid= -p $cmd_pid 2>/dev/null | tr -d ' ' || echo "")
   

--- a/package.json
+++ b/package.json
@@ -36,6 +36,8 @@
     "check:fix": "biome check --write",
     "clean": "pnpm -r --parallel exec rm -rf node_modules dist build .next .turbo",
     "clean:turbo": "rm -rf .turbo",
+    "turbo:login": "turbo login && turbo link",
+    "turbo:setup-cache": "sh scripts/setup-turbo-cache.sh",
     "prepare": "husky",
     "changeset:quick": "node scripts/quick-changeset.mjs",
     "version": "changeset version",
@@ -55,6 +57,7 @@
     "mcp:watch:manage": "pnpm --filter @inkeep/agents-manage-mcp watch",
     "workflow:profile": "node scripts/workflows/profile.mjs",
     "workflow:profile:verbose": "node scripts/workflows/profile.mjs --verbose",
+    "profile:prepush": "node scripts/profile-prepush.mjs",
     "setup-dev": "sh scripts/setup.sh"
   },
   "version": "0.1.0",

--- a/scripts/profile-prepush.mjs
+++ b/scripts/profile-prepush.mjs
@@ -1,0 +1,218 @@
+#!/usr/bin/env node
+
+/**
+ * Script to profile pre-push hook (check:husky) performance
+ * Usage: node scripts/profile-prepush.mjs [--run]
+ *
+ * Without --run: Analyzes the most recent turbo summary
+ * With --run: Runs check:husky with profiling and then analyzes
+ */
+
+import { execSync } from "child_process";
+import { readFileSync, readdirSync, existsSync } from "fs";
+import { join } from "path";
+import { parseArgs } from "util";
+
+const { values } = parseArgs({
+  options: {
+    run: { type: "boolean", default: false },
+    help: { type: "boolean", short: "h", default: false },
+  },
+});
+
+const colors = {
+  reset: "\x1b[0m",
+  bright: "\x1b[1m",
+  dim: "\x1b[2m",
+  red: "\x1b[31m",
+  green: "\x1b[32m",
+  yellow: "\x1b[33m",
+  blue: "\x1b[34m",
+  magenta: "\x1b[35m",
+  cyan: "\x1b[36m",
+};
+
+function formatDuration(seconds) {
+  if (seconds >= 60) {
+    const minutes = Math.floor(seconds / 60);
+    const secs = (seconds % 60).toFixed(1);
+    return `${minutes}m ${secs}s`;
+  }
+  return `${seconds.toFixed(1)}s`;
+}
+
+function formatBar(value, max, width = 40) {
+  const filled = Math.round((value / max) * width);
+  return "█".repeat(filled) + "░".repeat(width - filled);
+}
+
+function findLatestSummary() {
+  const turboRunsDir = join(process.cwd(), ".turbo", "runs");
+  if (!existsSync(turboRunsDir)) {
+    return null;
+  }
+
+  const files = readdirSync(turboRunsDir)
+    .filter((f) => f.endsWith(".json"))
+    .map((f) => ({
+      name: f,
+      path: join(turboRunsDir, f),
+      mtime: new Date(readFileSync(join(turboRunsDir, f), "utf8").match(/"startTime":\s*(\d+)/)?.[1] || 0),
+    }))
+    .sort((a, b) => b.mtime - a.mtime);
+
+  return files[0]?.path || null;
+}
+
+function analyzeSummary(summaryPath) {
+  const summary = JSON.parse(readFileSync(summaryPath, "utf8"));
+
+  const totalTime = (summary.execution.endTime - summary.execution.startTime) / 1000;
+  const tasks = summary.tasks.map((t) => ({
+    ...t,
+    duration: (t.execution.endTime - t.execution.startTime) / 1000,
+  }));
+
+  // Group by task type
+  const byTaskType = {};
+  for (const task of tasks) {
+    if (!byTaskType[task.task]) {
+      byTaskType[task.task] = { tasks: [], total: 0 };
+    }
+    byTaskType[task.task].tasks.push(task);
+    byTaskType[task.task].total += task.duration;
+  }
+
+  // Group by package
+  const byPackage = {};
+  for (const task of tasks) {
+    if (!byPackage[task.package]) {
+      byPackage[task.package] = { tasks: [], total: 0 };
+    }
+    byPackage[task.package].tasks.push(task);
+    byPackage[task.package].total += task.duration;
+  }
+
+  // Find slowest tasks
+  const sortedTasks = [...tasks].sort((a, b) => b.duration - a.duration);
+  const maxDuration = sortedTasks[0]?.duration || 1;
+
+  console.log(`\n${colors.bright}${colors.cyan}╔════════════════════════════════════════════════════════════════╗${colors.reset}`);
+  console.log(`${colors.bright}${colors.cyan}║           PRE-PUSH HOOK PERFORMANCE PROFILE                   ║${colors.reset}`);
+  console.log(`${colors.bright}${colors.cyan}╚════════════════════════════════════════════════════════════════╝${colors.reset}\n`);
+
+  console.log(`${colors.bright}Total Wall-Clock Time:${colors.reset} ${colors.yellow}${formatDuration(totalTime)}${colors.reset}`);
+  console.log(`${colors.dim}Tasks Executed: ${summary.execution.attempted} | Cached: ${summary.execution.cached}${colors.reset}\n`);
+
+  // Task type breakdown
+  console.log(`${colors.bright}${colors.blue}═══ Time by Task Type (sum across packages) ═══${colors.reset}\n`);
+  const sortedTypes = Object.entries(byTaskType).sort((a, b) => b[1].total - a[1].total);
+  const maxTypeTotal = sortedTypes[0]?.[1].total || 1;
+
+  for (const [taskType, data] of sortedTypes) {
+    const bar = formatBar(data.total, maxTypeTotal, 30);
+    console.log(`  ${colors.green}${taskType.padEnd(12)}${colors.reset} ${bar} ${formatDuration(data.total).padStart(8)} (${data.tasks.length} pkgs)`);
+  }
+
+  // Slowest individual tasks
+  console.log(`\n${colors.bright}${colors.blue}═══ Slowest Individual Tasks (Top 10) ═══${colors.reset}\n`);
+  for (const task of sortedTasks.slice(0, 10)) {
+    const bar = formatBar(task.duration, maxDuration, 30);
+    const taskName = `${task.package.replace("@inkeep/", "")}#${task.task}`;
+    const cached = task.cache?.status === "HIT" ? `${colors.green}[cached]${colors.reset}` : "";
+    console.log(`  ${bar} ${formatDuration(task.duration).padStart(8)}  ${taskName} ${cached}`);
+  }
+
+  // Critical path analysis
+  console.log(`\n${colors.bright}${colors.blue}═══ Critical Path Analysis ═══${colors.reset}\n`);
+
+  // Find tasks that block the most other tasks
+  const buildTasks = tasks.filter((t) => t.task === "build").sort((a, b) => b.duration - a.duration);
+
+  console.log(`  ${colors.yellow}Slowest builds (these block downstream tasks):${colors.reset}`);
+  for (const task of buildTasks.slice(0, 5)) {
+    const pct = ((task.duration / totalTime) * 100).toFixed(0);
+    console.log(`    • ${task.package.replace("@inkeep/", "")}: ${formatDuration(task.duration)} (${pct}% of total time)`);
+  }
+
+  // Recommendations
+  console.log(`\n${colors.bright}${colors.magenta}═══ Optimization Recommendations ═══${colors.reset}\n`);
+
+  const docsBuild = tasks.find((t) => t.package === "@inkeep/agents-docs" && t.task === "build");
+  const uiBuild = tasks.find((t) => t.package === "@inkeep/agents-manage-ui" && t.task === "build");
+
+  if (docsBuild && docsBuild.duration > 30) {
+    console.log(`  ${colors.yellow}1. Exclude agents-docs from pre-push hook${colors.reset}`);
+    console.log(`     ${colors.dim}Impact: Save ~${formatDuration(docsBuild.duration)} (docs don't need validation on every push)${colors.reset}`);
+    console.log(`     ${colors.dim}How: Add --filter='!@inkeep/agents-docs' to check:husky${colors.reset}\n`);
+  }
+
+  if (summary.execution.cached === 0) {
+    console.log(`  ${colors.yellow}2. Enable Turbo Remote Caching${colors.reset}`);
+    console.log(`     ${colors.dim}Impact: Subsequent runs with unchanged code will be nearly instant${colors.reset}`);
+    console.log(`     ${colors.dim}How: npx turbo login && npx turbo link${colors.reset}\n`);
+  }
+
+  if (uiBuild && uiBuild.duration > 60) {
+    console.log(`  ${colors.yellow}3. Consider excluding agents-manage-ui from pre-push${colors.reset}`);
+    console.log(`     ${colors.dim}Impact: Save ~${formatDuration(uiBuild.duration)} if UI isn't changing${colors.reset}`);
+    console.log(`     ${colors.dim}How: Add --filter='!@inkeep/agents-manage-ui' to check:husky${colors.reset}\n`);
+  }
+
+  console.log(`  ${colors.yellow}4. Use affected-only checks for faster iterations${colors.reset}`);
+  console.log(`     ${colors.dim}Run: pnpm turbo check:husky --filter='...[origin/main]'${colors.reset}`);
+  console.log(`     ${colors.dim}This only checks packages affected by your changes${colors.reset}\n`);
+
+  // Proposed filter
+  const excludePackages = [];
+  if (docsBuild && docsBuild.duration > 30) excludePackages.push("@inkeep/agents-docs");
+
+  if (excludePackages.length > 0) {
+    const filterStr = excludePackages.map((p) => `--filter='!${p}'`).join(" ");
+    console.log(`${colors.bright}${colors.green}═══ Suggested check:husky Command ═══${colors.reset}\n`);
+    console.log(`  turbo check:husky --filter='!agents-cookbook-templates' ${filterStr}\n`);
+  }
+}
+
+function runProfile() {
+  console.log(`${colors.cyan}Running check:husky with profiling...${colors.reset}\n`);
+
+  try {
+    execSync("TURBO_UI=stream pnpm turbo check:husky --filter='!agents-cookbook-templates' --summarize", {
+      stdio: "inherit",
+      cwd: process.cwd(),
+    });
+  } catch (error) {
+    console.error(`${colors.red}check:husky failed${colors.reset}`);
+    process.exit(1);
+  }
+}
+
+// Main
+if (values.help) {
+  console.log(`
+Profile pre-push hook (check:husky) performance
+
+Usage: node scripts/profile-prepush.mjs [options]
+
+Options:
+  --run     Run check:husky first, then analyze
+  -h, --help  Show this help message
+
+Without --run, analyzes the most recent turbo run summary.
+`);
+  process.exit(0);
+}
+
+if (values.run) {
+  runProfile();
+}
+
+const summaryPath = findLatestSummary();
+if (!summaryPath) {
+  console.error(`${colors.red}No turbo run summary found. Run with --run flag or run check:husky first.${colors.reset}`);
+  process.exit(1);
+}
+
+console.log(`${colors.dim}Analyzing: ${summaryPath}${colors.reset}`);
+analyzeSummary(summaryPath);

--- a/scripts/setup-turbo-cache.sh
+++ b/scripts/setup-turbo-cache.sh
@@ -1,0 +1,68 @@
+#!/bin/bash
+# Setup Turbo Remote Caching
+#
+# This script configures turbo remote caching via Vercel.
+# Remote caching dramatically speeds up builds by sharing cache across:
+#   - Your local machine (subsequent runs)
+#   - CI/CD pipelines
+#   - Team members
+#
+# Prerequisites:
+#   - A Vercel account (free tier works)
+#   - Access to the team's Vercel organization (for shared caching)
+
+set -e
+
+echo "🚀 Setting up Turbo Remote Caching"
+echo ""
+
+# Check if already configured
+if [ -n "$TURBO_TOKEN" ] && [ -n "$TURBO_TEAM" ]; then
+  echo "✅ Remote caching already configured!"
+  echo "   Team: $TURBO_TEAM"
+  echo ""
+  echo "To reconfigure, unset TURBO_TOKEN and TURBO_TEAM and run again."
+  exit 0
+fi
+
+echo "This will:"
+echo "  1. Log you into Vercel (opens browser)"
+echo "  2. Link this repo to your Vercel team"
+echo "  3. Enable remote caching for all turbo commands"
+echo ""
+echo "Benefits:"
+echo "  - Pre-push hooks run in ~1-2s when cache is warm"
+echo "  - CI builds are faster when code hasn't changed"
+echo "  - Team members share build cache"
+echo ""
+read -p "Continue? (y/n) " -n 1 -r
+echo ""
+
+if [[ ! $REPLY =~ ^[Yy]$ ]]; then
+  echo "Cancelled."
+  exit 0
+fi
+
+echo ""
+echo "Step 1: Logging into Vercel..."
+pnpm turbo login
+
+echo ""
+echo "Step 2: Linking to Vercel team..."
+pnpm turbo link
+
+echo ""
+echo "✅ Remote caching is now configured!"
+echo ""
+echo "The following environment variables are now set in your turbo config:"
+echo "  - TURBO_TOKEN: Your personal access token"
+echo "  - TURBO_TEAM: Your team identifier"
+echo ""
+echo "For CI/CD, add these as secrets:"
+echo "  TURBO_TOKEN: (get from 'turbo login' or Vercel dashboard)"
+echo "  TURBO_TEAM: (your team slug, e.g., 'team_xxxxx')"
+echo ""
+echo "To verify caching is working:"
+echo "  1. Run: pnpm check:husky"
+echo "  2. Run again: pnpm check:husky"
+echo "  3. Second run should show 'FULL TURBO' and complete in ~1-2s"


### PR DESCRIPTION
## Summary
- **Adds affected-only filtering** to pre-push hook using `--filter='...[origin/main]'` - only checks packages changed since origin/main
- **Excludes `@inkeep/agents-docs`** from pre-push checks (docs don't need validation on every push, saves ~95s)
- **Adds remote caching setup** with `pnpm turbo:login` command and setup script
- **Adds profiling tool** (`pnpm profile:prepush`) to analyze pre-push performance

## Performance Improvement
| Scenario | Before | After | Improvement |
|----------|--------|-------|-------------|
| Cold cache (all packages) | ~2m 44s | ~57s | **~65% faster** |
| Warm cache | ~2m 44s | ~1-2s | **~99% faster** |

## New Commands
- `pnpm turbo:login` - Login to Vercel and link repo for remote caching
- `pnpm turbo:setup-cache` - Interactive setup with instructions
- `pnpm profile:prepush` - Profile pre-push hook performance

## Test plan
- [x] Verified pre-push hook syntax is valid
- [x] Tested affected-only filtering with `--dry-run`
- [x] Verified remote caching is working (team already linked)
- [x] Profiled performance improvement