### PR TITLE
fix(manage-ui): attach mouse event handlers to outer sidebar div

### DIFF
--- a/agents-manage-ui/src/components/ui/sidebar.tsx
+++ b/agents-manage-ui/src/components/ui/sidebar.tsx
@@ -146,6 +146,8 @@ function Sidebar({
   collapsible = 'offcanvas',
   className,
   children,
+  onMouseEnter,
+  onMouseLeave,
   ...props
 }: React.ComponentProps<'div'> & {
   side?: 'left' | 'right';
@@ -194,12 +196,15 @@ function Sidebar({
 
   return (
     <div
+      role="group"
       className="group peer text-sidebar-foreground hidden md:block"
       data-state={state}
       data-collapsible={state === 'collapsed' ? collapsible : ''}
       data-variant={variant}
       data-side={side}
       data-slot="sidebar"
+      onMouseEnter={onMouseEnter}
+      onMouseLeave={onMouseLeave}
     >
       {/* This is what handles the sidebar gap on desktop */}
       <div


### PR DESCRIPTION
## Summary

- Fix the Cypress test "should temporarily expands on hover and collapses again on blur" by attaching `onMouseEnter`/`onMouseLeave` handlers to the correct element
- The handlers were being spread via `{...props}` onto the inner `sidebar-container` div, but the test triggers `mouseenter` on `[data-slot=sidebar]` (the outer div)
- Since `mouseenter` doesn't bubble, the handler never fired
- Added `role="group"` to satisfy accessibility lint rules

## Test plan

- [ ] Cypress tests pass in CI (specifically `sidebar.cy.ts`)