### PR TITLE
fix(manage-api): run initialization in non-test environments to create default org

### DIFF
--- a/agents-manage-api/src/index.ts
+++ b/agents-manage-api/src/index.ts
@@ -84,8 +84,9 @@ export const auth = createManagementAuth({
 
 const app: Hono = createManagementHono(defaultConfig, defaultRegistry, auth);
 
-// Initialize default user for development environment only
-if (env.ENVIRONMENT === 'development') {
+// Initialize default user unless in test environment
+// This ensures the default organization is created for projects to reference
+if (env.ENVIRONMENT !== 'test') {
   void initializeDefaultUser(auth);
 }
 


### PR DESCRIPTION
## Summary

- Fixed Cypress E2E CI failure where project push fails with foreign key constraint error
- The `initializeDefaultUser` function was only called when `ENVIRONMENT=development`, but in CI the variable is not set
- Updated condition to run initialization unless in test environment (matching `factory.ts` behavior)

## Problem

The Cypress CI was failing at the "Push Weather Example Project" step:
```
Failed query: insert into "projects" ("tenant_id", "id", "name", "description", "models", "stop_w...
```

This happened because the `organization` table (referenced by `projects.tenant_id` foreign key) never had a row created for the default tenant.

## Solution

Changed the initialization condition from:
```typescript
if (env.ENVIRONMENT === 'development')
```
to:
```typescript
if (env.ENVIRONMENT !== 'test')
```

This ensures the default organization is created in CI environments where `ENVIRONMENT` is not explicitly set.

## Test plan

- [ ] Cypress CI tests should pass
- [ ] Local development still works with `pnpm dev`
- [ ] Tests still run properly (initialization skipped in test environment)