### PR TITLE
override table styles in docs

### DIFF
--- a/agents-docs/src/app/global.css
+++ b/agents-docs/src/app/global.css
@@ -99,3 +99,24 @@
     cursor: pointer;
   }
 }
+
+/* tailwind typography overrides */
+@utility prose {
+  th {
+    border-inline-start: none;
+    @apply bg-transparent;
+  }
+
+  table {
+    @apply bg-transparent;
+  }
+
+  td {
+    border-inline-start: none;
+    @apply border-gray-100 dark:border-gray-800;
+  }
+
+  table {
+    @apply border-none;
+  }
+}


### PR DESCRIPTION
@nick-inkeep asked to revert table styles from prev docs

## before (what should be)

<img width="866" height="634" alt="image" src="https://github.com/user-attachments/assets/9b46e777-1bf7-4577-8dc4-fb7eb3dca9b7" />


## now

<img width="898" height="659" alt="image" src="https://github.com/user-attachments/assets/26117102-62c6-4e96-a16e-c85c283aebe5" />
