### PR TITLE
fix(agents-manage-ui): improve text contrast in approval dialogs for dark mode

### DIFF
--- a/.changeset/fix-approval-text-contrast.md
+++ b/.changeset/fix-approval-text-contrast.md
@@ -1,0 +1,5 @@
+---
+"@inkeep/agents-manage-ui": patch
+---
+
+Fix text contrast in approval dialogs and Monaco editor wrappers for dark mode

--- a/agents-manage-ui/src/components/agent/copilot/components/code-diff.tsx
+++ b/agents-manage-ui/src/components/agent/copilot/components/code-diff.tsx
@@ -178,7 +178,7 @@ export const CodeDiff: FC<CodeDiffProps> = ({
     <div
       className={cn(
         'w-full',
-        'rounded-md relative dark:bg-input/30 transition-colors',
+        'rounded-md relative dark:bg-input/30 transition-colors text-foreground',
         'border border-input shadow-xs',
         className,
         !monaco && 'px-3 py-4',

--- a/agents-manage-ui/src/components/agent/copilot/components/diff-viewer.tsx
+++ b/agents-manage-ui/src/components/agent/copilot/components/diff-viewer.tsx
@@ -3,7 +3,7 @@ import { CodeDiff } from './code-diff';
 import { TextDiff } from './text-diff';
 
 export const FieldLabel = ({ children }: { children: React.ReactNode }) => {
-  return <div className="text-sm font-medium mb-2">{children}</div>;
+  return <div className="text-sm font-medium mb-2 text-foreground">{children}</div>;
 };
 
 interface DiffFieldProps {

--- a/agents-manage-ui/src/components/agent/copilot/message-parts/tool-approval.tsx
+++ b/agents-manage-ui/src/components/agent/copilot/message-parts/tool-approval.tsx
@@ -85,7 +85,11 @@ export const DiffApproval = ({ diffs }: { diffs: FieldDiff[] }) => {
 };
 
 const ApprovalWrapper = ({ children }: { children: React.ReactNode }) => {
-  return <div className="flex flex-col rounded-lg border px-4 py-3 gap-5 my-3">{children}</div>;
+  return (
+    <div className="flex flex-col rounded-lg border px-4 py-3 gap-5 my-3 text-foreground">
+      {children}
+    </div>
+  );
 };
 
 export const ToolApproval = ({

--- a/agents-manage-ui/src/components/editors/monaco-editor.tsx
+++ b/agents-manage-ui/src/components/editors/monaco-editor.tsx
@@ -200,7 +200,7 @@ export const MonacoEditor: FC<MonacoEditorProps> = ({
       className={cn(
         'max-h-screen', // set fixed max height, otherwise page freezes up / lags when clicking into it
         !hasDynamicHeight && 'h-full',
-        'rounded-md relative dark:bg-input/30 transition-colors',
+        'rounded-md relative dark:bg-input/30 transition-colors text-foreground',
         'border border-input shadow-xs',
         disabled
           ? 'cursor-not-allowed opacity-50 bg-muted [&>.monaco-editor]:pointer-events-none'


### PR DESCRIPTION
## Summary

- Add `text-foreground` class to `MonacoEditor` and `CodeDiff` wrapper components to ensure proper text contrast in dark mode
- Add `text-foreground` to `FieldLabel` and `ApprovalWrapper` components for approval dialogs
- This ensures any usage of Monaco editors across the app will have proper text contrast regardless of parent context

## Test plan

- [ ] Open an agent in the visual builder
- [ ] Trigger a tool approval dialog (e.g., update agent model)
- [ ] Verify "Models" label and JSON content are readable in dark mode