### PR TITLE
Skip flaky sidebar Cypress tests

### DIFF
--- a/agents-manage-ui/cypress/e2e/sidebar.cy.ts
+++ b/agents-manage-ui/cypress/e2e/sidebar.cy.ts
@@ -1,6 +1,8 @@
 /// <reference types="cypress" />
 
-describe('Sidebar', () => {
+// TODO: Re-enable these tests once sidebar behavior is stabilized
+// These tests are flaky and fail intermittently in CI
+describe.skip('Sidebar', () => {
   describe('Collapsing/Expanding', () => {
     const projectUrl = '/default/projects/my-weather-project';
 


### PR DESCRIPTION
## Summary
- Skip the sidebar Cypress tests that are failing intermittently in CI
- Uses `describe.skip` to disable tests without removing them
- Tests can be re-enabled once the underlying issues are fixed

## Test plan
- [ ] Verify CI passes without the sidebar tests running
- [ ] Sidebar tests are marked as skipped (pending) rather than failing