### PR TITLE
fix: correct turbo cache outputs for agents-manage-mcp

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -93,7 +93,7 @@
     "@inkeep/agents-manage-mcp#build": {
       "dependsOn": ["^build", "sync:licenses"],
       "inputs": ["$TURBO_DEFAULT$", ".env*"],
-      "outputs": ["esm/**", "bin/**", ".tsbuildinfo"]
+      "outputs": ["dist/**", "bin/**", ".tsbuildinfo"]
     },
     "chat-widget#test": {
       "dependsOn": ["build"],


### PR DESCRIPTION
## Summary
- Fixed turbo.json cache configuration for `@inkeep/agents-manage-mcp#build` task
- Changed outputs from `esm/**` to `dist/**` to match actual build output directory

## Problem
The Vercel build was failing because turbo was caching the wrong directory. The `agents-manage-mcp` package outputs to `dist/`, but turbo was configured to cache `esm/`. When the cache was restored, the `dist/` folder was missing, causing `agents-manage-api` to fail with:

```
Could not resolve "@inkeep/agents-manage-mcp"
The module "./dist/index.js" was not found on the file system
```

## Test plan
- [ ] Verify Vercel deployment succeeds after merge