### PR TITLE
Add turbo.json test config for @inkeep/ai-sdk-provider

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -80,6 +80,11 @@
       "inputs": ["$TURBO_DEFAULT$", "**/*.{test,spec}.{js,jsx,ts,tsx}"],
       "outputs": []
     },
+    "@inkeep/ai-sdk-provider#test": {
+      "dependsOn": ["build"],
+      "inputs": ["$TURBO_DEFAULT$", "**/*.{test,spec}.{js,jsx,ts,tsx}"],
+      "outputs": []
+    },
     "@inkeep/agents-ui#test": {
       "dependsOn": ["build"],
       "inputs": ["$TURBO_DEFAULT$", "**/*.{test,spec}.{js,jsx,ts,tsx}"],


### PR DESCRIPTION
## Summary
- Add explicit test task configuration for `@inkeep/ai-sdk-provider` in `turbo.json`
- Fixes the warning: `WARNING no output files found for task @inkeep/ai-sdk-provider#test`
- Follows the same pattern used by other packages (`@inkeep/agents-sdk`, `@inkeep/agents-core`, etc.)

## Test plan
- [x] Verified `pnpm test --filter=@inkeep/ai-sdk-provider` passes without warnings
- [x] All 34 tests in ai-sdk-provider pass successfully