### PR TITLE
fix: prevent CI job cancellation on main branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,12 +6,12 @@ on:
       - main
       - master
   pull_request:
-    branches: ['*']
+    branches: ["*"]
   merge_group:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   ci:

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -6,12 +6,12 @@ on:
       - main
       - master
   pull_request:
-    branches: ['*']
+    branches: ["*"]
   merge_group:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   ci:
@@ -31,7 +31,6 @@ jobs:
           --health-retries 5
         ports:
           - 5432:5432
-
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
## Summary
- Only cancel in-progress CI jobs on pull requests, not on pushes to main/master
- This ensures CI runs on main complete fully even when multiple commits are pushed in succession
- Applies to both `ci.yml` and `cypress.yml` workflows

## Changes
- Changed `cancel-in-progress: true` to `cancel-in-progress: ${{ github.event_name == 'pull_request' }}`

## Test plan
- [x] Verify workflows still cancel on PR branches when new commits are pushed
- [x] Verify workflows do NOT cancel on main branch pushes