### PR TITLE
fix modelcontextprotocol version

### DIFF
--- a/.changeset/late-bugs-hug.md
+++ b/.changeset/late-bugs-hug.md
@@ -1,0 +1,5 @@
+---
+"@inkeep/create-agents": patch
+---
+
+pin mcp sdk

--- a/create-agents-template/package.json
+++ b/create-agents-template/package.json
@@ -42,7 +42,8 @@
   "packageManager": "pnpm@10.10.0",
   "pnpm": {
     "overrides": {
-      "next": "^16.0.8"
+      "next": "^16.0.8",
+      "@modelcontextprotocol/sdk": "1.24.3"
     },
     "onlyBuiltDependencies": [
       "keytar"

--- a/create-agents-template/pnpm-lock.yaml
+++ b/create-agents-template/pnpm-lock.yaml
@@ -6,6 +6,7 @@ settings:
 
 overrides:
   next: ^16.0.8
+  '@modelcontextprotocol/sdk': 1.24.3
 
 importers:
 
@@ -157,7 +158,7 @@ importers:
         version: 19.2.7
       mcp-handler:
         specifier: ^1.0.3
-        version: 1.0.4(@modelcontextprotocol/sdk@1.22.0)(next@16.0.8(@opentelemetry/api@1.9.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))
+        version: 1.0.4(@modelcontextprotocol/sdk@1.24.3(zod@3.25.76))(next@16.0.8(@opentelemetry/api@1.9.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))
       next:
         specifier: ^16.0.8
         version: 16.0.8(@opentelemetry/api@1.9.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
@@ -1199,7 +1200,7 @@ packages:
   '@hono/mcp@0.1.5':
     resolution: {integrity: sha512-q6Yurx9VUwVEpqnwVXtzIYaq4kgQgWWq9lYLM7NFS2W0sg1RzL+RdKh6jO4/dGyvBLKrahPd2v+NC6rr0XWBvQ==}
     peerDependencies:
-      '@modelcontextprotocol/sdk': ^1.12.0
+      '@modelcontextprotocol/sdk': 1.24.3
       hono: '>=4.0.0'
 
   '@hono/node-server@1.19.6':
@@ -1549,11 +1550,12 @@ packages:
   '@mermaid-js/parser@0.6.3':
     resolution: {integrity: sha512-lnjOhe7zyHjc+If7yT4zoedx2vo4sHaTmtkl1+or8BRTnCtDmcTpAjpzDSfCZrshM5bCoz0GyidzadJAH1xobA==}
 
-  '@modelcontextprotocol/sdk@1.22.0':
-    resolution: {integrity: sha512-VUpl106XVTCpDmTBil2ehgJZjhyLY2QZikzF8NvTXtLRF1CvO5iEE2UNZdVIUer35vFOwMKYeUGbjJtvPWan3g==}
+  '@modelcontextprotocol/sdk@1.24.3':
+    resolution: {integrity: sha512-YgSHW29fuzKKAHTGe9zjNoo+yF8KaQPzDC2W9Pv41E7/57IfY+AMGJ/aDFlgTLcVVELoggKE4syABCE75u3NCw==}
     engines: {node: '>=18'}
     peerDependencies:
       '@cfworker/json-schema': ^4.1.1
+      zod: ^3.25 || ^4.0
     peerDependenciesMeta:
       '@cfworker/json-schema':
         optional: true
@@ -6240,7 +6242,7 @@ packages:
     resolution: {integrity: sha512-bp5Xp6jKF8H3vh3Xadr83YZxHekKCXcbenTIej3DR0MK8GpQDMHNU/RDBvIRbs/7VRViPPkjMcWLsx+WYVICNw==}
     hasBin: true
     peerDependencies:
-      '@modelcontextprotocol/sdk': ^1.22.0
+      '@modelcontextprotocol/sdk': 1.24.3
       next: ^16.0.8
     peerDependenciesMeta:
       next:
@@ -8956,9 +8958,9 @@ snapshots:
       protobufjs: 7.5.4
       yargs: 17.7.2
 
-  '@hono/mcp@0.1.5(@modelcontextprotocol/sdk@1.22.0)(hono@4.10.7)':
+  '@hono/mcp@0.1.5(@modelcontextprotocol/sdk@1.24.3(zod@4.1.13))(hono@4.10.7)':
     dependencies:
-      '@modelcontextprotocol/sdk': 1.22.0
+      '@modelcontextprotocol/sdk': 1.24.3(zod@4.1.13)
       hono: 4.10.7
 
   '@hono/node-server@1.19.6(hono@4.10.7)':
@@ -9220,7 +9222,7 @@ snapshots:
       '@electric-sql/pglite': 0.3.14
       '@hono/node-server': 1.19.6(hono@4.10.7)
       '@hono/zod-openapi': 1.1.5(hono@4.10.7)(zod@4.1.13)
-      '@modelcontextprotocol/sdk': 1.22.0
+      '@modelcontextprotocol/sdk': 1.24.3(zod@4.1.13)
       '@nangohq/node': 0.69.14
       '@nangohq/types': 0.69.14
       '@openrouter/ai-sdk-provider': 1.2.5(ai@5.0.11(zod@4.1.13))(zod@4.1.13)
@@ -9300,13 +9302,13 @@ snapshots:
   '@inkeep/agents-manage-api@0.37.2(@electric-sql/pglite@0.3.14)(@hono/zod-openapi@1.1.5(hono@4.10.7)(zod@4.1.13))(@libsql/client@0.15.15)(@opentelemetry/api@1.9.0)(@opentelemetry/core@2.2.0(@opentelemetry/api@1.9.0))(@types/pg@8.15.5)(kysely@0.28.8)(next@16.0.8(@opentelemetry/api@1.9.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(pg@8.16.3)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(ws@8.18.3)(zod@4.1.13)':
     dependencies:
       '@composio/core': 0.2.5(ws@8.18.3)(zod@4.1.13)
-      '@hono/mcp': 0.1.5(@modelcontextprotocol/sdk@1.22.0)(hono@4.10.7)
+      '@hono/mcp': 0.1.5(@modelcontextprotocol/sdk@1.24.3(zod@4.1.13))(hono@4.10.7)
       '@hono/node-server': 1.19.6(hono@4.10.7)
       '@hono/swagger-ui': 0.5.2(hono@4.10.7)
       '@hono/zod-openapi': 1.1.5(hono@4.10.7)(zod@4.1.13)
       '@inkeep/agents-core': 0.37.2(@hono/zod-openapi@1.1.5(hono@4.10.7)(zod@4.1.13))(@libsql/client@0.15.15)(@opentelemetry/core@2.2.0(@opentelemetry/api@1.9.0))(@types/pg@8.15.5)(kysely@0.28.8)(next@16.0.8(@opentelemetry/api@1.9.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(ws@8.18.3)(zod@4.1.13)
       '@inkeep/agents-manage-mcp': 0.37.2
-      '@modelcontextprotocol/sdk': 1.22.0
+      '@modelcontextprotocol/sdk': 1.24.3(zod@4.1.13)
       '@nangohq/node': 0.69.14
       '@nangohq/types': 0.69.14
       dotenv: 17.2.3
@@ -9368,7 +9370,7 @@ snapshots:
 
   '@inkeep/agents-manage-mcp@0.37.2':
     dependencies:
-      '@modelcontextprotocol/sdk': 1.22.0
+      '@modelcontextprotocol/sdk': 1.24.3(zod@3.25.76)
       '@stricli/core': 1.2.4
       bun: 1.3.3
       express: 5.2.1
@@ -9830,7 +9832,7 @@ snapshots:
     dependencies:
       langium: 3.3.1
 
-  '@modelcontextprotocol/sdk@1.22.0':
+  '@modelcontextprotocol/sdk@1.24.3(zod@3.25.76)':
     dependencies:
       ajv: 8.17.1
       ajv-formats: 3.0.1(ajv@8.17.1)
@@ -9839,12 +9841,32 @@ snapshots:
       cross-spawn: 7.0.6
       eventsource: 3.0.7
       eventsource-parser: 3.0.6
-      express: 5.1.0
-      express-rate-limit: 7.5.1(express@5.1.0)
+      express: 5.2.1
+      express-rate-limit: 7.5.1(express@5.2.1)
+      jose: 6.1.2
       pkce-challenge: 5.0.1
       raw-body: 3.0.2
       zod: 3.25.76
       zod-to-json-schema: 3.25.0(zod@3.25.76)
+    transitivePeerDependencies:
+      - supports-color
+
+  '@modelcontextprotocol/sdk@1.24.3(zod@4.1.13)':
+    dependencies:
+      ajv: 8.17.1
+      ajv-formats: 3.0.1(ajv@8.17.1)
+      content-type: 1.0.5
+      cors: 2.8.5
+      cross-spawn: 7.0.6
+      eventsource: 3.0.7
+      eventsource-parser: 3.0.6
+      express: 5.2.1
+      express-rate-limit: 7.5.1(express@5.2.1)
+      jose: 6.1.2
+      pkce-challenge: 5.0.1
+      raw-body: 3.0.2
+      zod: 4.1.13
+      zod-to-json-schema: 3.25.0(zod@4.1.13)
     transitivePeerDependencies:
       - supports-color
 
@@ -14154,6 +14176,10 @@ snapshots:
     dependencies:
       express: 5.1.0
 
+  express-rate-limit@7.5.1(express@5.2.1):
+    dependencies:
+      express: 5.2.1
+
   express@5.1.0:
     dependencies:
       accepts: 2.0.0
@@ -15092,9 +15118,9 @@ snapshots:
 
   math-intrinsics@1.1.0: {}
 
-  mcp-handler@1.0.4(@modelcontextprotocol/sdk@1.22.0)(next@16.0.8(@opentelemetry/api@1.9.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)):
+  mcp-handler@1.0.4(@modelcontextprotocol/sdk@1.24.3(zod@3.25.76))(next@16.0.8(@opentelemetry/api@1.9.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)):
     dependencies:
-      '@modelcontextprotocol/sdk': 1.22.0
+      '@modelcontextprotocol/sdk': 1.24.3(zod@3.25.76)
       chalk: 5.6.2
       commander: 11.1.0
       redis: 4.7.1


### PR DESCRIPTION
there was a breaking change in modelcontextprotocol and hono/mcp had this as peer dependency:
      '@modelcontextprotocol/sdk': ^1.12.0


and there is an error throwing saying isJSONRPCError does not exist
