### PR TITLE
feat(mcp-generator): use tsup to bundle zod and avoid version conflicts

### DIFF
--- a/scripts/README-MCP-GENERATOR.md
+++ b/scripts/README-MCP-GENERATOR.md
@@ -16,20 +16,17 @@ node scripts/generate-mcp-package.mjs <api-name>
 ```
 
 **Available API names:**
-- `eval-api` - Evaluation API (port 3005)
 - `manage-api` - Manage API (port 3002)
-
-> **Note**: The Run API (port 3003) already has a built-in `/mcp` endpoint and doesn't need a separate MCP package.
 
 ### Example
 
 ```bash
-# Generate MCP package for the Evaluation API
-node scripts/generate-mcp-package.mjs eval-api
+# Generate MCP package for the Manage API
+node scripts/generate-mcp-package.mjs manage-api
 ```
 
 This will:
-1. Create `packages/agents-eval-api-mcp/` with all necessary files
+1. Create `packages/agents-manage-mcp/` with all necessary files
 2. Install dependencies via pnpm
 3. Add the package to the workspace
 4. Display next steps for completing the setup
@@ -39,9 +36,10 @@ This will:
 The generator creates a complete package structure:
 
 ```
-packages/agents-{apiname}-mcp/
+packages/agents-{service}-mcp/
 ├── package.json              # Package manifest with MCP-specific config
 ├── tsconfig.json            # TypeScript configuration
+├── tsup.config.ts           # Build configuration
 ├── eslint.config.mjs        # ESLint configuration
 ├── README.md                # Package documentation
 ├── scripts/
@@ -70,7 +68,7 @@ After generating a package, follow this workflow to complete the setup:
 ### 1. Navigate to Package
 
 ```bash
-cd packages/agents-{apiname}-mcp
+cd packages/agents-{service}-mcp
 ```
 
 ### 2. Fetch OpenAPI Specification
@@ -135,13 +133,13 @@ pnpm --filter @inkeep/agents-{apiname} dev
 
 **Terminal 2** - Watch for API changes:
 ```bash
-cd packages/agents-{apiname}-mcp
+cd packages/agents-{service}-mcp
 pnpm watch
 ```
 
 **Terminal 3** - Watch for OpenAPI changes:
 ```bash
-cd packages/agents-{apiname}-mcp
+cd packages/agents-{service}-mcp
 speakeasy run --watch
 ```
 
@@ -161,6 +159,7 @@ All templates are stored in `scripts/mcp-templates/`:
 - `package.json.template`
 - `README.md.template`
 - `tsconfig.json.template`
+- `tsup.config.ts.template`
 - `eslint.config.mjs.template`
 - `scripts/*.template`
 
@@ -170,13 +169,13 @@ Templates use these replacement tokens:
 
 | Token | Example Value | Description |
 |-------|---------------|-------------|
-| `{{API_NAME}}` | `eval-api` | API name (kebab-case) |
-| `{{API_NAME_UPPER}}` | `EVAL_API` | API name (uppercase, underscores) |
-| `{{PACKAGE_NAME}}` | `agents-eval-api-mcp` | Full package name |
-| `{{API_PORT}}` | `3001` | Default API port |
-| `{{API_TITLE}}` | `Evaluation API` | Human-readable API title |
-| `{{API_TITLE_COMPACT}}` | `EvalAPI` | Compact API title (no spaces) |
-| `{{API_DESCRIPTION}}` | `handles evaluations...` | API description |
+| `{{API_NAME}}` | `manage-api` | API name (kebab-case) |
+| `{{API_NAME_UPPER}}` | `MANAGE_API` | API name (uppercase, underscores) |
+| `{{PACKAGE_NAME}}` | `agents-manage-mcp` | Full package name |
+| `{{API_PORT}}` | `3002` | Default API port |
+| `{{API_TITLE}}` | `Manage API` | Human-readable API title |
+| `{{API_TITLE_COMPACT}}` | `ManageAPI` | Compact API title (no spaces) |
+| `{{API_DESCRIPTION}}` | `handles CRUD...` | API description |
 
 ### Modifying Templates
 
@@ -198,7 +197,6 @@ const API_CONFIGS = {
     titleCompact: 'NewAPI',
     description: 'description of what it does',
   },
-  'eval-api': { port: 3005, title: 'Evaluation API', ... },
   'manage-api': { port: 3002, title: 'Manage API', ... }
 };
 ```
@@ -247,10 +245,10 @@ Each API has these configuration properties:
 
 ```javascript
 {
-  port: 3005,                    // Default API port
-  title: 'Evaluation API',       // Human-readable name
-  titleCompact: 'EvalAPI',       // No-space version for identifiers
-  description: 'handles eval...' // Brief description
+  port: 3002,                    // Default API port
+  title: 'Manage API',           // Human-readable name
+  titleCompact: 'ManageAPI',     // No-space version for identifiers
+  description: 'handles CRUD...' // Brief description
 }
 ```
 
@@ -259,7 +257,7 @@ Each API has these configuration properties:
 Generated packages support these environment variables:
 
 - `INKEEP_AGENTS_{API_NAME_UPPER}_API_URL` - Override default API URL
-  - Example: `INKEEP_AGENTS_EVAL_API_API_URL=http://localhost:3001`
+  - Example: `INKEEP_AGENTS_MANAGE_API_API_URL=http://localhost:3002`
 
 ## Troubleshooting
 
@@ -267,7 +265,7 @@ Generated packages support these environment variables:
 
 If you see "Target package already exists":
 ```bash
-rm -rf packages/agents-{apiname}-mcp
+rm -rf packages/agents-{service}-mcp
 node scripts/generate-mcp-package.mjs {apiname}
 ```
 
@@ -374,7 +372,7 @@ Regenerate the MCP package when:
 Override the default API URL when fetching:
 
 ```bash
-INKEEP_AGENTS_EVAL_API_API_URL=http://custom-host:8080 pnpm fetch-openapi
+INKEEP_AGENTS_MANAGE_API_API_URL=http://custom-host:8080 pnpm fetch-openapi
 ```
 
 ### Skip Auto-Start
@@ -383,10 +381,10 @@ If you want to manage the API yourself:
 
 ```bash
 # Terminal 1: Start API manually
-pnpm --filter @inkeep/agents-eval-api dev
+pnpm --filter @inkeep/agents-manage-api dev
 
 # Terminal 2: Fetch OpenAPI (won't auto-start)
-cd packages/agents-eval-api-mcp
+cd packages/agents-manage-mcp
 pnpm fetch-openapi
 ```
 
@@ -395,7 +393,7 @@ pnpm fetch-openapi
 For more control over Speakeasy:
 
 ```bash
-cd packages/agents-eval-api-mcp
+cd packages/agents-manage-mcp
 speakeasy run --target typescript --schema openapi.json
 ```
 
@@ -404,7 +402,7 @@ speakeasy run --target typescript --schema openapi.json
 Use the MCP Inspector to test:
 
 ```bash
-cd packages/agents-eval-api-mcp
+cd packages/agents-manage-mcp
 pnpm build
 npx @modelcontextprotocol/inspector node ./bin/mcp-server.js start
 ```
@@ -444,4 +442,3 @@ Potential improvements for the generator:
 - CI/CD integration
 - Multi-API package generation
 - Template versioning
-

--- a/scripts/generate-mcp-package.mjs
+++ b/scripts/generate-mcp-package.mjs
@@ -9,12 +9,6 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
 const API_CONFIGS = {
-  'eval-api': {
-    port: 3005,
-    title: 'Evaluation API',
-    titleCompact: 'EvalAPI',
-    description: 'handles evaluations, datasets, and evaluation runs',
-  },
   'manage-api': {
     port: 3002,
     title: 'Manage API',
@@ -132,6 +126,7 @@ async function main() {
     { src: 'package.json.template', dest: 'package.json' },
     { src: 'README.md.template', dest: 'README.md' },
     { src: 'tsconfig.json.template', dest: 'tsconfig.json' },
+    { src: 'tsup.config.ts.template', dest: 'tsup.config.ts' },
     { src: 'eslint.config.mjs.template', dest: 'eslint.config.mjs' },
     { src: '.npmrc.template', dest: '.npmrc' },
     { src: 'scripts/fetch-openapi.mjs.template', dest: 'scripts/fetch-openapi.mjs' },

--- a/scripts/mcp-templates/package.json.template
+++ b/scripts/mcp-templates/package.json.template
@@ -9,7 +9,7 @@
     "mcp": "bin/mcp-server.js"
   },
   "scripts": {
-    "build": "bun i && bun src/mcp-server/build.mts && tsc",
+    "build": "bun i && bun src/mcp-server/build.mts && tsup",
     "check": "npm run lint",
     "lint": "eslint --cache --max-warnings=0 src",
     "format": "biome format --write src",
@@ -23,8 +23,7 @@
     "@modelcontextprotocol/sdk": "^1.17.0",
     "@stricli/core": "^1.1.2",
     "bun": "^1.2.12",
-    "express": "^5.1.0",
-    "zod": "^3.25.7"
+    "express": "^5.1.0"
   },
   "devDependencies": {
     "@anthropic-ai/mcpb": "^1.2.0",
@@ -32,20 +31,32 @@
     "@types/bun": "^1.2.13",
     "@types/express": "^5.0.1",
     "@types/node": "^22.15.20",
+    "dotenv": "^16.4.7",
     "eslint": "^9.26.0",
+    "find-up": "^7.0.0",
     "globals": "^16.0.0",
+    "tsup": "^8.5.0",
     "typescript": "~5.8.3",
     "typescript-eslint": "^8.31.1",
-    "dotenv": "^16.4.7",
-    "find-up": "^7.0.0"
+    "zod": "^3.25.7"
   },
-  "main": "./esm/index.js",
-  "types": "./esm/index.d.ts",
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
   "exports": {
     ".": {
-      "types": "./esm/index.d.ts",
-      "import": "./esm/index.js"
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs"
     }
+  },
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org/"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/inkeep/agents.git",
+    "directory": "packages/{{PACKAGE_NAME}}"
   }
 }
-

--- a/scripts/mcp-templates/tsconfig.json.template
+++ b/scripts/mcp-templates/tsconfig.json.template
@@ -11,7 +11,7 @@
     "forceConsistentCasingInFileNames": true,
     "incremental": true,
     "isolatedModules": true,
-    "lib": ["dom", "dom.iterable", "es2023", "esnext.weakref"],
+    "lib": ["dom", "dom.iterable", "es2024"],
     "module": "nodenext",
     "moduleResolution": "node16",
     "noFallthroughCasesInSwitch": true,

--- a/scripts/mcp-templates/tsup.config.ts.template
+++ b/scripts/mcp-templates/tsup.config.ts.template
@@ -1,0 +1,11 @@
+import { defineConfig } from 'tsup';
+
+export default defineConfig({
+  entry: ['src/index.ts'],
+  format: ['cjs', 'esm'],
+  dts: true,
+  clean: true,
+  // Bundle zod INTO the package output to avoid version conflicts
+  // with consumers that use Zod v4
+  noExternal: ['zod'],
+});


### PR DESCRIPTION
## Summary
- Adds tsup build configuration to bundle zod into the MCP package output, avoiding version conflicts with consumers using Zod v4
- Updates package.json.template with dual CJS/ESM exports via tsup
- Cleans up README to focus on manage-api (removes deprecated eval-api references)

## Test plan
- [ ] Verify generated MCP packages build correctly with `pnpm build`
- [ ] Test that bundled zod doesn't conflict with consumer's Zod version