### PR TITLE
fix: resolve create-agents test mock for node:util module

### DIFF
--- a/.changeset/giant-black-magpie.md
+++ b/.changeset/giant-black-magpie.md
@@ -1,0 +1,12 @@
+---
+"@inkeep/agents-cli": patch
+"@inkeep/agents-core": patch
+"@inkeep/agents-manage-api": patch
+"@inkeep/agents-manage-ui": patch
+"@inkeep/agents-run-api": patch
+"@inkeep/agents-sdk": patch
+"@inkeep/create-agents": patch
+"@inkeep/ai-sdk-provider": patch
+---
+
+fix: resolve create-agents test mock issue with node:util and node:child_process module paths

--- a/packages/create-agents/src/__tests__/utils.test.ts
+++ b/packages/create-agents/src/__tests__/utils.test.ts
@@ -4,12 +4,27 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { cloneTemplate, cloneTemplateLocal, getAvailableTemplates } from '../templates';
 import { createAgents } from '../utils';
 
+// Create the mock execAsync function that will be used by promisify - hoisted so it's available in mocks
+const { mockExecAsync } = vi.hoisted(() => ({
+  mockExecAsync: vi.fn().mockResolvedValue({ stdout: '', stderr: '' }),
+}));
+
 // Mock all dependencies
 vi.mock('fs-extra');
 vi.mock('../templates');
 vi.mock('@clack/prompts');
-vi.mock('child_process');
-vi.mock('util');
+vi.mock('node:child_process', () => ({
+  exec: vi.fn(),
+  spawn: vi.fn(() => ({
+    pid: 12345,
+    stdio: ['pipe', 'pipe', 'pipe'],
+    on: vi.fn(),
+    kill: vi.fn(),
+  })),
+}));
+vi.mock('node:util', () => ({
+  promisify: vi.fn(() => mockExecAsync),
+}));
 
 // Setup default mocks
 const mockSpinner = {
@@ -24,6 +39,9 @@ describe('createAgents - Template and Project ID Logic', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+
+    // Reset the mockExecAsync to default behavior
+    mockExecAsync.mockResolvedValue({ stdout: '', stderr: '' });
 
     // Mock process methods
     processExitSpy = vi.spyOn(process, 'exit').mockImplementation((code) => {
@@ -66,20 +84,6 @@ describe('createAgents - Template and Project ID Logic', () => {
     ]);
     vi.mocked(cloneTemplate).mockResolvedValue(undefined);
     vi.mocked(cloneTemplateLocal).mockResolvedValue(undefined);
-
-    // Mock util.promisify to return a mock exec function
-    const mockExecAsync = vi.fn().mockResolvedValue({ stdout: '', stderr: '' });
-    const util = require('node:util');
-    util.promisify = vi.fn(() => mockExecAsync);
-
-    // Mock child_process.spawn
-    const childProcess = require('node:child_process');
-    childProcess.spawn = vi.fn(() => ({
-      pid: 12345,
-      stdio: ['pipe', 'pipe', 'pipe'],
-      on: vi.fn(),
-      kill: vi.fn(),
-    }));
   });
 
   afterEach(() => {
@@ -480,4 +484,6 @@ function setupDefaultMocks() {
   vi.mocked(getAvailableTemplates).mockResolvedValue(['event-planner', 'chatbot', 'data-analysis']);
   vi.mocked(cloneTemplate).mockResolvedValue(undefined);
   vi.mocked(cloneTemplateLocal).mockResolvedValue(undefined);
+  // Reset mockExecAsync for tests that clear mocks
+  mockExecAsync.mockResolvedValue({ stdout: '', stderr: '' });
 }


### PR DESCRIPTION
## Summary
Fix flaky CI test failures in `create-agents` package where tests were failing with `execAsync is not a function`.

## Changes
- Fixed test mocking strategy in `packages/create-agents/src/__tests__/utils.test.ts`:
  - Changed `vi.mock('util')` to `vi.mock('node:util')` to match the import path in source code
  - Changed `vi.mock('child_process')` to `vi.mock('node:child_process')` to match the import path
  - Used `vi.hoisted()` to create `mockExecAsync` function before module loading
  - Removed manual mocking in `beforeEach` that was too late to affect module-level assignments
  - Added `mockExecAsync.mockResolvedValue()` reset in both `beforeEach` and `setupDefaultMocks()`

## Context
The root cause was a timing issue with Vitest mocks:
1. The source code (`utils.ts`) imports from `node:util` and assigns `execAsync = promisify(exec)` at module load time
2. The test was mocking `util` (without the `node:` prefix) which doesn't intercept `node:util` imports
3. Even with the correct path, the mock setup in `beforeEach` runs after the module has already loaded and assigned `execAsync`

The fix uses `vi.hoisted()` to ensure the mock function is available when `vi.mock()` factory runs (since mocks are hoisted to the top of the file).

## Testing
- [x] Unit tests passing locally (`pnpm --filter create-agents test`)
- [x] All 25 tests in the create-agents package pass
- [x] Full test suite passes

## Changeset
- [x] Changeset notes created with `pnpm cs patch`
- [x] Appropriate semver level selected (patch - bug fix)
- [x] Changelog message is clear and descriptive