### PR TITLE
fix(agents-cli): resolve flaky auth credential expiry test

### DIFF
--- a/agents-cli/src/__tests__/commands/auth.test.ts
+++ b/agents-cli/src/__tests__/commands/auth.test.ts
@@ -61,13 +61,15 @@ describe('CLI Authentication', () => {
     });
 
     it('should get credential expiry info for valid credentials', () => {
+      // Use 2.5 hours to ensure we get '2h' even with timing variations
+      // (Math.floor of ms could give 1h if exactly 2 hours due to ms precision)
       const expiresIn2Hours: CLICredentials = {
         accessToken: 'token',
         userId: 'user',
         userEmail: 'test@example.com',
         organizationId: 'org',
         createdAt: new Date().toISOString(),
-        expiresAt: new Date(Date.now() + 2 * 3600000).toISOString(),
+        expiresAt: new Date(Date.now() + 2.5 * 3600000).toISOString(),
       };
 
       const info = getCredentialExpiryInfo(expiresIn2Hours);


### PR DESCRIPTION
## Summary
- Fixed flaky test in `agents-cli/src/__tests__/commands/auth.test.ts` at line 75
- The test was using exactly 2 hours for the credential expiry time, but due to timing between `Date.now()` call and assertion execution, the actual time remaining could drop below 2 hours (e.g., 1h 59m 59s), causing `Math.floor` to return `1h` instead of `2h`
- Changed to use 2.5 hours to ensure the test consistently returns `'2h'`, following the same pattern as the existing "should format expiry in days for long durations" test which uses 3.5 days

## Test plan
- [x] Run the auth tests multiple times to verify consistency
- [x] Verified CI should pass as the test now accounts for timing variations