### PR TITLE
fix: increase default page size to 100 for all list endpoints

### DIFF
--- a/.changeset/comprehensive-coral-flyingfish.md
+++ b/.changeset/comprehensive-coral-flyingfish.md
@@ -1,0 +1,12 @@
+---
+"@inkeep/agents-cli": patch
+"@inkeep/agents-core": patch
+"@inkeep/agents-manage-api": patch
+"@inkeep/agents-manage-ui": patch
+"@inkeep/agents-run-api": patch
+"@inkeep/agents-sdk": patch
+"@inkeep/create-agents": patch
+"@inkeep/ai-sdk-provider": patch
+---
+
+Increase default page size to 100 (API max) for all list endpoints to show more resources without full pagination

--- a/agents-cli/src/api.ts
+++ b/agents-cli/src/api.ts
@@ -117,7 +117,7 @@ export class ManagementApiClient extends BaseApiClient {
     const projectId = this.getProjectId();
 
     const response = await this.authenticatedFetch(
-      `${this.apiUrl}/tenants/${tenantId}/projects/${projectId}/agents`,
+      `${this.apiUrl}/tenants/${tenantId}/projects/${projectId}/agents?limit=100`,
       {
         method: 'GET',
       }

--- a/agents-manage-ui/src/lib/api/agent-full-client.ts
+++ b/agents-manage-ui/src/lib/api/agent-full-client.ts
@@ -28,7 +28,7 @@ export async function fetchAgents(
   validateProjectId(projectId);
 
   return makeManagementApiRequest<ListResponse<Agent>>(
-    `tenants/${tenantId}/projects/${projectId}/agents`
+    `tenants/${tenantId}/projects/${projectId}/agents?limit=100`
   );
 }
 

--- a/agents-manage-ui/src/lib/api/api-keys.ts
+++ b/agents-manage-ui/src/lib/api/api-keys.ts
@@ -37,7 +37,7 @@ export async function fetchApiKeys(
   validateProjectId(projectId);
 
   const response = await makeManagementApiRequest<ListResponse<ApiKeyApiSelect>>(
-    `tenants/${tenantId}/projects/${projectId}/api-keys`
+    `tenants/${tenantId}/projects/${projectId}/api-keys?limit=100`
   );
 
   // Transform the response to convert nulls to undefined

--- a/agents-manage-ui/src/lib/api/artifact-components.ts
+++ b/agents-manage-ui/src/lib/api/artifact-components.ts
@@ -32,7 +32,7 @@ export async function fetchArtifactComponents(
   validateProjectId(projectId);
 
   const response = await makeManagementApiRequest<ListResponse<ArtifactComponentApiSelect>>(
-    `tenants/${tenantId}/projects/${projectId}/artifact-components`
+    `tenants/${tenantId}/projects/${projectId}/artifact-components?limit=100`
   );
 
   return response;

--- a/agents-manage-ui/src/lib/api/credentials.ts
+++ b/agents-manage-ui/src/lib/api/credentials.ts
@@ -25,7 +25,7 @@ export async function fetchCredentials(
   tenantId: string,
   projectId: string,
   page = 1,
-  pageSize = 50
+  pageSize = 100
 ): Promise<Credential[]> {
   validateTenantId(tenantId);
   validateProjectId(projectId);

--- a/agents-manage-ui/src/lib/api/data-components.ts
+++ b/agents-manage-ui/src/lib/api/data-components.ts
@@ -38,7 +38,7 @@ export async function fetchDataComponents(
   validateProjectId(projectId);
 
   const response = await makeManagementApiRequest<ListResponse<DataComponentApiSelect>>(
-    `tenants/${tenantId}/projects/${projectId}/data-components`
+    `tenants/${tenantId}/projects/${projectId}/data-components?limit=100`
   );
 
   // Transform the response to ensure props is non-nullable

--- a/agents-manage-ui/src/lib/api/external-agents.ts
+++ b/agents-manage-ui/src/lib/api/external-agents.ts
@@ -21,7 +21,7 @@ export async function fetchExternalAgents(
   tenantId: string,
   projectId: string,
   page = 1,
-  pageSize = 50
+  pageSize = 100
 ): Promise<ExternalAgent[]> {
   validateTenantId(tenantId);
   validateProjectId(projectId);

--- a/agents-manage-ui/src/lib/api/projects.ts
+++ b/agents-manage-ui/src/lib/api/projects.ts
@@ -10,7 +10,7 @@ export async function fetchProjects(tenantId: string): Promise<ListResponse<Proj
   validateTenantId(tenantId);
 
   const response = await makeManagementApiRequest<ListResponse<any>>(
-    `tenants/${tenantId}/projects`
+    `tenants/${tenantId}/projects?limit=100`
   );
 
   if (response.data) {

--- a/agents-manage-ui/src/lib/api/tools.ts
+++ b/agents-manage-ui/src/lib/api/tools.ts
@@ -26,7 +26,7 @@ export async function fetchMCPTools(
   tenantId: string,
   projectId: string,
   page = 1,
-  pageSize = 50,
+  pageSize = 100,
   status?: McpTool['status']
 ): Promise<McpTool[]> {
   validateTenantId(tenantId);


### PR DESCRIPTION
## Summary
Increase the default page size from 50 to 100 (the API's maximum limit) for all list endpoints in `agents-manage-ui` and `agents-cli` to show more resources without requiring full pagination implementation.

## Changes

### agents-manage-ui
- **Bumped pageSize from 50 to 100:**
  - `src/lib/api/credentials.ts` - `fetchCredentials()`
  - `src/lib/api/tools.ts` - `fetchMCPTools()`
  - `src/lib/api/external-agents.ts` - `fetchExternalAgents()`

- **Added `?limit=100` to endpoints missing pagination:**
  - `src/lib/api/projects.ts` - `fetchProjects()`
  - `src/lib/api/data-components.ts` - `fetchDataComponents()`
  - `src/lib/api/artifact-components.ts` - `fetchArtifactComponents()`
  - `src/lib/api/api-keys.ts` - `fetchApiKeys()`
  - `src/lib/api/agent-full-client.ts` - `fetchAgents()`

### agents-cli
- **Added `?limit=100` to endpoint missing pagination:**
  - `src/api.ts` - `listAgents()`

Note: `listProjects()` already had `limit: number = 100` so no change was needed.

## Context
The API clients weren't always paginating, and some endpoints were using the default page size of 10 or 50. This quick fix bumps the page size to the API's max (100) to show more resources. A more thorough pagination implementation using a typed Speakeasy-generated SDK will be implemented later.

## Testing
- [x] No linter errors
- [x] Changes are straightforward parameter updates

## Changeset
- [x] Changeset notes created with `pnpm cs patch`
- [x] Appropriate semver level selected (patch - additive improvement)
- [x] Changelog message is clear and descriptive