### PR TITLE
fix: correct test data structure for introspect-generator tests

### DIFF
--- a/agents-cli/src/commands/pull-v3/__tests__/introspect-generator.test.ts
+++ b/agents-cli/src/commands/pull-v3/__tests__/introspect-generator.test.ts
@@ -71,11 +71,17 @@ describe('Introspect Generator - End-to-End', () => {
         retrievalParams: { username: 'db-user', password: 'db-pass' },
       },
     },
-    functions: {
+    functionTools: {
       'calculate-priority': {
         id: 'calculate-priority',
         name: 'Calculate Priority',
         description: 'Calculate ticket priority based on customer tier and issue type',
+        functionId: 'calculate-priority',
+      },
+    },
+    functions: {
+      'calculate-priority': {
+        id: 'calculate-priority',
         inputSchema: {
           type: 'object',
           properties: {
@@ -207,6 +213,7 @@ describe('Introspect Generator - End-to-End', () => {
           },
         },
         contextConfig: {
+          id: 'support-agent-context',
           headers: 'supportHeaders',
           headersSchema: {
             type: 'object',


### PR DESCRIPTION
## Summary
- Fixed test mock data structure in `introspect-generator.test.ts` that was causing CI failures
- Moved `calculate-priority` function tool from `functions` to `functionTools` collection with proper `functionId` reference
- Added required `id` field to `contextConfig` to eliminate warning

## Root Cause
The component registry only registers tools from the `functionTools` collection (not `functions`). When the sub-agent generator tried to resolve `{ toolId: 'calculate-priority' }` in the `canUse` array, it failed because the tool was never registered in the correct collection.

## Test Plan
- [x] All 597 tests pass in agents-cli package
- [x] Lint passes
- [x] CI should now pass for the introspect-generator tests