### PR TITLE
claude/fix-ci-action-error-EAuKy

### DIFF
--- a/agents-docs/src/components/expandable-row.tsx
+++ b/agents-docs/src/components/expandable-row.tsx
@@ -39,11 +39,12 @@ export function ExpandableRow({
                     : 'bg-fd-muted/40 text-fd-muted-foreground group-hover:bg-fd-primary/10 group-hover:text-fd-primary'
                 }`}
               >
-                <svg 
-                  width="12" 
-                  height="12" 
-                  viewBox="0 0 12 12" 
-                  fill="none" 
+                <svg
+                  width="12"
+                  height="12"
+                  viewBox="0 0 12 12"
+                  fill="none"
+                  aria-hidden="true"
                   className="transition-transform duration-300"
                 >
                   <path 


### PR DESCRIPTION
Add aria-hidden="true" to the chevron SVG in expandable-row component to fix biome a11y/noSvgWithoutTitle lint error. The SVG is decorative and accompanies text, so hiding it from screen readers is appropriate.