### PR TITLE
Remove Sentry webpack configuration

### DIFF
--- a/agents-manage-ui/next.config.ts
+++ b/agents-manage-ui/next.config.ts
@@ -67,19 +67,5 @@ export default process.env.NEXT_PUBLIC_SENTRY_DSN
       // Note: Check that the configured route will not match with your Next.js middleware, otherwise reporting of client-
       // side errors will fail.
       tunnelRoute: '/monitoring',
-
-      webpack: {
-        // Enables automatic instrumentation of Vercel Cron Monitors. (Does not yet work with App Router route handlers.)
-        // See the following for more information:
-        // https://docs.sentry.io/product/crons/
-        // https://vercel.com/docs/cron-jobs
-        automaticVercelMonitors: true,
-
-        // Tree-shaking options for reducing bundle size
-        treeshake: {
-          // Automatically tree-shake Sentry logger statements to reduce bundle size
-          removeDebugLogging: true,
-        },
-      },
     })
   : nextConfig;


### PR DESCRIPTION
we use turbopack for both dev/build and this options says

```ts
    /**
     * Options related to webpack builds, has no effect if you are using Turbopack.
     */
    webpack?: SentryBuildWebpackOptions;
```