### PR TITLE
Update format-date.ts to show seconds

### DIFF
--- a/agents-manage-ui/src/app/utils/format-date.ts
+++ b/agents-manage-ui/src/app/utils/format-date.ts
@@ -124,12 +124,16 @@ export function formatDateAgo(dateString: string) {
 }
 
 export function formatDuration(durationMs: number): string {
-  const totalMinutes = Math.round(durationMs / 1000 / 60);
-  const hours = Math.floor(totalMinutes / 60);
-  const minutes = totalMinutes % 60;
+  const totalSeconds = Math.round(durationMs / 1000);
+  const hours = Math.floor(totalSeconds / 3600);
+  const minutes = Math.floor((totalSeconds % 3600) / 60);
+  const seconds = totalSeconds % 60;
 
   if (hours > 0) {
-    return `${hours}h ${minutes}m`;
+    return `${hours}h ${minutes}m ${seconds}s`;
   }
-  return `${minutes}m`;
+  if (minutes > 0) {
+    return `${minutes}m ${seconds}s`;
+  }
+  return `${seconds}s`;
 }


### PR DESCRIPTION
for durations less than a minute, it just shows a 0

this fixes to show seconds
<img width="260" height="210" alt="Screenshot 2026-01-16 at 2 02 31 AM" src="https://github.com/user-attachments/assets/16dfbf35-e9f1-4d3a-ae14-8cccfa2289ed" />

