### PR TITLE
feat(triggers): Clarify mutually exclusive transform options in UI and docs

### DIFF
--- a/.changeset/passive-beige-lobster.md
+++ b/.changeset/passive-beige-lobster.md
@@ -1,0 +1,5 @@
+---
+"@inkeep/agents-manage-ui": patch
+---
+
+Improve trigger form to show transform type selector with clear guidance on when to use Object Transformation vs JMESPath

--- a/agents-docs/content/talk-to-your-agents/triggers.mdx
+++ b/agents-docs/content/talk-to-your-agents/triggers.mdx
@@ -61,7 +61,9 @@ Each trigger is configured with:
 - **Input Schema**: JSON Schema to validate incoming payloads
 - **Authentication**: API key, bearer token, or basic auth
 - **Signing Secret**: HMAC-SHA256 signature verification (for GitHub, Slack, etc.)
-- **Output Transform**: JMESPath or object mapping to reshape payloads
+- **Output Transform**: Reshape payloads before interpolating the message template. Choose one approach:
+  - **Object Transformation**: Simple field remapping (recommended for basic use cases)
+  - **JMESPath**: Complex transformations like filtering arrays or restructuring nested data
 
 ## Authentication Options
 

--- a/agents-docs/content/typescript-sdk/triggers.mdx
+++ b/agents-docs/content/typescript-sdk/triggers.mdx
@@ -159,20 +159,22 @@ Nested properties are accessed with dot notation (`{{customer.email}}`). Array l
 
 ### Payload Transformation
 
-Transform incoming payloads before they reach the message template:
+Transform incoming payloads before they reach the message template using `outputTransform`. You can choose between two approaches:
+
+| Approach | Best For | Complexity |
+| --- | --- | --- |
+| **Object Transformation** | Simple field remapping | Low |
+| **JMESPath** | Complex filtering, restructuring, array operations | High |
+
+<Note>
+These options are **mutually exclusive**. Use either `jmespath` OR `objectTransformation`, not both. If both are provided, `jmespath` takes priority.
+</Note>
+
+#### Object Transformation (Recommended for Simple Cases)
+
+Use `objectTransformation` when you just need to remap fields from the payload. Each key becomes a field in the transformed output, and each value is a JMESPath path to extract from the input:
 
 ```typescript
-const transformingTrigger = trigger({
-  name: "Transformed Webhook",
-  messageTemplate: "Event: {{eventType}} - {{summary}}",
-  outputTransform: {
-    // JMESPath expression for complex transformations
-    jmespath: "{ eventType: type, summary: data.description }",
-  },
-  authentication: { type: "none" },
-});
-
-// Or use simple object mapping
 const mappingTrigger = trigger({
   name: "Mapped Webhook",
   messageTemplate: "User {{userName}} performed {{actionName}}",
@@ -184,7 +186,51 @@ const mappingTrigger = trigger({
   },
   authentication: { type: "none" },
 });
+
+// Input: { payload: { user: { display_name: "Alice" }, action: { type: "click" } } }
+// Transformed: { userName: "Alice", actionName: "click" }
+// Message: "User Alice performed click"
 ```
+
+#### JMESPath (For Complex Transformations)
+
+Use `jmespath` when you need more powerful transformations like filtering arrays, conditional logic, or complex restructuring. [JMESPath](https://jmespath.org/) is a query language for JSON:
+
+```typescript
+const transformingTrigger = trigger({
+  name: "Transformed Webhook",
+  messageTemplate: "Event: {{eventType}} - {{summary}}",
+  outputTransform: {
+    jmespath: "{ eventType: type, summary: data.description }",
+  },
+  authentication: { type: "none" },
+});
+
+// Input: { type: "alert", data: { description: "Server down" } }
+// Transformed: { eventType: "alert", summary: "Server down" }
+// Message: "Event: alert - Server down"
+```
+
+**Advanced JMESPath example** - filtering and projecting arrays:
+
+```typescript
+const advancedTrigger = trigger({
+  name: "Active Users Alert",
+  messageTemplate: "Active users: {{activeUserNames}}",
+  outputTransform: {
+    jmespath: "{ activeUserNames: join(', ', users[?active==`true`].name) }",
+  },
+  authentication: { type: "none" },
+});
+
+// Input: { users: [{ name: "Alice", active: true }, { name: "Bob", active: false }] }
+// Transformed: { activeUserNames: "Alice" }
+// Message: "Active users: Alice"
+```
+
+<Tip>
+Object Transformation is converted to JMESPath under the hood. For example, `{ userName: "user.name" }` becomes the JMESPath expression `{ userName: user.name }`.
+</Tip>
 
 ### Signature Verification
 


### PR DESCRIPTION
## Summary

Updates the trigger configuration UI and documentation to clarify that JMESPath and Object Transformation are **mutually exclusive** options for payload transformation.

## Changes

### UI Changes (`agents-manage-ui`)
- Added a **Transform Type** dropdown selector with three options:
  - None (no transformation)
  - Object Transformation (Simple) - for basic field remapping
  - JMESPath (Advanced) - for complex transformations
- Conditionally renders only the relevant input field based on selection
- Added helpful descriptions for each option
- Fixed the Object Transformation placeholder from incorrect Mustache syntax (`{{issue.title}}`) to correct JMESPath syntax (`issue.title`)

### Documentation Changes (`agents-docs`)

**SDK Triggers docs:**
- Added comparison table showing when to use each approach
- Added `<Note>` callout clarifying mutual exclusivity
- Separated examples with clear input/output comments
- Added `<Tip>` explaining Object Transformation converts to JMESPath

**Conceptual Triggers docs:**
- Expanded Output Transform bullet point to show the two options with guidance

## Why

Previously, both options were shown side-by-side without indication that only one should be used. JMESPath takes priority if both are provided, which could lead to confusion. This change makes the relationship clear and guides users to the right option for their use case.