### PR TITLE
Update PostCSS config to use object syntax for vitest compatibility

### DIFF
--- a/agents-manage-ui/postcss.config.mjs
+++ b/agents-manage-ui/postcss.config.mjs
@@ -1,5 +1,5 @@
-const config = {
-  plugins: ['@tailwindcss/postcss'],
+export default {
+  plugins: {
+    '@tailwindcss/postcss': {},
+  },
 };
-// Fixes in vitest [TypeError] Invalid PostCSS Plugin found at: plugins[0]
-export default process.env.VITEST === 'true' ? {} : config;


### PR DESCRIPTION
this fix vitest error

```
 FAIL   agents-manage-ui  src/lib/__tests__/monaco-utils.test.tsx [ src/lib/__tests__/monaco-utils.test.tsx ]
Failed to load PostCSS config: Failed to load PostCSS config (searchPath: /Users/Inkeep/Desktop/agents/agents-manage-ui): [TypeError] Invalid PostCSS Plugin found at: plugins[0]

(@/Users/Inkeep/Desktop/agents/agents-manage-ui/postcss.config.mjs)
TypeError: Invalid PostCSS Plugin found at: plugins[0]
                                                                                                                                                                                                                                 
(@/Users/Inkeep/Desktop/agents/agents-manage-ui/postcss.config.mjs)   
```