### PR TITLE
feat(agents): enhance function tool management with relationship ID mapping

### DIFF
--- a/agents-api/src/domains/run/agents/Agent.ts
+++ b/agents-api/src/domains/run/agents/Agent.ts
@@ -203,6 +203,7 @@ export class Agent {
   private mcpConnectionLocks: Map<string, Promise<McpClient>> = new Map();
   private currentCompressor: MidGenerationCompressor | null = null;
   private executionContext: FullExecutionContext;
+  private functionToolRelationshipIdByName: Map<string, string> = new Map();
 
   constructor(
     config: AgentConfig,
@@ -331,6 +332,10 @@ export class Agent {
       });
 
       return matchingTool?.relationshipId;
+    }
+
+    if (toolType === 'tool') {
+      return this.functionToolRelationshipIdByName.get(toolName);
     }
 
     if (toolType === 'delegation') {
@@ -1252,6 +1257,12 @@ export class Agent {
       if (functionToolsData.length === 0) {
         return functionTools;
       }
+
+      this.functionToolRelationshipIdByName = new Map(
+        (functionToolsData as Array<{ name: string; relationshipId?: string }>).flatMap((t) => {
+          return t.relationshipId ? ([[t.name, t.relationshipId]] as Array<[string, string]>) : [];
+        })
+      );
 
       const { SandboxExecutorFactory } = await import('../tools/SandboxExecutorFactory');
       const sandboxExecutor = SandboxExecutorFactory.getInstance();

--- a/packages/agents-core/src/validation/schemas.ts
+++ b/packages/agents-core/src/validation/schemas.ts
@@ -1324,7 +1324,11 @@ export const FunctionToolInsertSchema = createInsertSchema(functionTools).extend
 export const FunctionToolUpdateSchema = FunctionToolInsertSchema.partial();
 
 export const FunctionToolApiSelectSchema =
-  createApiSchema(FunctionToolSelectSchema).openapi('FunctionTool');
+  createApiSchema(FunctionToolSelectSchema)
+    .extend({
+      relationshipId: z.string().optional(),
+    })
+    .openapi('FunctionTool');
 export const FunctionToolApiInsertSchema =
   createAgentScopedApiInsertSchema(FunctionToolInsertSchema).openapi('FunctionToolCreate');
 export const FunctionToolApiUpdateSchema =


### PR DESCRIPTION
- Added `functionToolRelationshipIdByName` to the `Agent` class for better tool relationship management.
- Updated `getFunctionToolsForSubAgent` to support pagination and return function tools with their relationship IDs.
- Extended `FunctionToolApiSelectSchema` to include optional `relationshipId` field for API responses.


Closes PRD-5759