### PR TITLE
fix(agents-cli): add backwards compatibility for legacy profiles.yaml…

### DIFF
--- a/agents-cli/src/utils/profiles/types.ts
+++ b/agents-cli/src/utils/profiles/types.ts
@@ -17,6 +17,50 @@ export const explicitRemoteSchema: z.ZodType<ExplicitRemote> = z.object({
 });
 
 /**
+ * Legacy schema for backwards compatibility with old profiles.yaml format
+ * Old format used: manageApi, runApi, manageUi
+ * New format uses: api, manageUi
+ */
+export const legacyExplicitRemoteSchema = z.object({
+  manageApi: z.string().url('manageApi must be a valid URL'),
+  manageUi: z.string().url('manageUi must be a valid URL'),
+  runApi: z.string().url('runApi must be a valid URL').optional(),
+});
+
+/**
+ * Legacy remote configuration interface
+ */
+export interface LegacyExplicitRemote {
+  manageApi: string;
+  manageUi: string;
+  runApi?: string;
+}
+
+/**
+ * Check if a remote config is in legacy format
+ */
+export function isLegacyRemote(remote: unknown): remote is LegacyExplicitRemote {
+  return (
+    typeof remote === 'object' &&
+    remote !== null &&
+    'manageApi' in remote &&
+    typeof (remote as LegacyExplicitRemote).manageApi === 'string'
+  );
+}
+
+/**
+ * Migrate legacy remote config to new format
+ * manageApi becomes api (the agents API endpoint)
+ * runApi is deprecated and ignored
+ */
+export function migrateLegacyRemote(legacy: LegacyExplicitRemote): ExplicitRemote {
+  return {
+    api: legacy.manageApi,
+    manageUi: legacy.manageUi,
+  };
+}
+
+/**
  * Schema for remote configuration - either 'cloud' shorthand or explicit URLs
  */
 export const remoteSchema: z.ZodType<RemoteConfig> = z.union([

--- a/agents-docs/content/typescript-sdk/cli-reference.mdx
+++ b/agents-docs/content/typescript-sdk/cli-reference.mdx
@@ -685,9 +685,8 @@ profiles:
     environment: production
   local:
     remote:
-      manageApi: http://localhost:3002
-      manageUi: http://localhost:3000
-      runApi: http://localhost:3003
+      api: http://localhost:3002      # Agents API endpoint
+      manageUi: http://localhost:3001 # Manage UI endpoint
     credential: inkeep-local
     environment: development
 ```


### PR DESCRIPTION
… schema

Adds support for migrating legacy profiles.yaml format that used manageApi/runApi fields to the new api field. When a legacy profile is detected during load, it is automatically migrated and saved.

- Add isLegacyRemote() to detect old format with manageApi field
- Add migrateLegacyRemote() to convert manageApi -> api
- Update loadProfiles() to migrate legacy profiles on first load
- Update documentation to show new schema format
- Add comprehensive tests for legacy profile migration