### PR TITLE
fix(triggers): Auth headers not being deleted properly from trigger

### DIFF
--- a/agents-manage-ui/src/components/triggers/trigger-form.tsx
+++ b/agents-manage-ui/src/components/triggers/trigger-form.tsx
@@ -211,16 +211,16 @@ export function TriggerForm({ tenantId, projectId, agentId, trigger, mode }: Tri
       }
 
       // Build authentication payload
-      const authentication =
-        headersToSend.length > 0
-          ? {
-              headers: headersToSend.map((h) => ({
-                name: h.name,
-                value: h.value,
-                keepExisting: h.keepExisting,
-              })),
-            }
-          : undefined;
+      // Always send { headers: [...] } to ensure explicit update:
+      // - Non-empty array: update with new headers
+      // - Empty array: clear all authentication headers
+      const authentication = {
+        headers: headersToSend.map((h) => ({
+          name: h.name,
+          value: h.value,
+          keepExisting: h.keepExisting,
+        })),
+      };
 
       // Handle signing secret - if not provided but existing, keep existing
       const signingSecretPayload = data.signingSecret


### PR DESCRIPTION
## Summary

Fixes [PRD-5774](https://linear.app/inkeep/issue/PRD-5774/headers-and-values-not-being-deleted-properly-from-trigger)

## Problem

When removing all auth headers from a trigger, the headers persisted in the database and reappeared after page reload.

**Root cause:** The frontend was setting `authentication = undefined` when all headers were removed. When serialized to JSON, `undefined` fields are omitted entirely. The backend only processed authentication updates when the field was explicitly present (`body.authentication !== undefined`), so it never updated the column.

## Solution

Changed the frontend to always send an explicit `authentication` object with a `headers` array:

- **Non-empty array**: Update with new headers  
- **Empty array**: Clear all authentication headers

The backend already handles empty arrays correctly - it sets `hashedAuthentication = { headers: [] }` which the auth verification code interprets as "no auth required".

## Testing

1. Go to a trigger with existing auth headers
2. Remove all headers using the trash icon
3. Save the trigger
4. Reload the page
5. Verify the headers are now gone