### PR TITLE
feat(manage-ui): improve trigger authentication UI

### DIFF
--- a/agents-manage-ui/src/components/triggers/trigger-form.tsx
+++ b/agents-manage-ui/src/components/triggers/trigger-form.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { zodResolver } from '@hookform/resolvers/zod';
-import { ArrowDown, ArrowUp, Check, ChevronDown, KeyRound, Plus, Trash2, X } from 'lucide-react';
+import { ArrowDown, ArrowUp, Check, ChevronDown, KeyRound, Plus, Trash2 } from 'lucide-react';
 import { useRouter } from 'next/navigation';
 import { useEffect, useMemo, useState } from 'react';
 import { useFieldArray, useForm } from 'react-hook-form';
@@ -28,13 +28,6 @@ import {
   FormMessage,
 } from '@/components/ui/form';
 import { Input } from '@/components/ui/input';
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from '@/components/ui/select';
 import { Switch } from '@/components/ui/switch';
 import { fetchCredentialsAction } from '@/lib/actions/credentials';
 import { createTriggerAction, updateTriggerAction } from '@/lib/actions/triggers';
@@ -208,6 +201,8 @@ const triggerFormSchema = z.object({
       })
     )
     .default([]),
+  // Signature verification toggle
+  signatureVerificationEnabled: z.boolean().default(false),
   // Credential reference for signing secret
   signingSecretCredentialReferenceId: z.string().optional(),
   // Signature verification algorithm and encoding
@@ -299,6 +294,7 @@ export function TriggerForm({ tenantId, projectId, agentId, trigger, mode }: Tri
         jmespath: '',
         objectTransformationJson: '',
         authHeaders: [],
+        signatureVerificationEnabled: false,
         signingSecretCredentialReferenceId: undefined,
         signatureAlgorithm: 'sha256',
         signatureEncoding: 'hex',
@@ -350,6 +346,10 @@ export function TriggerForm({ tenantId, projectId, agentId, trigger, mode }: Tri
 
     // Extract signature verification config from trigger
     const signatureVerification = (trigger as any).signatureVerification;
+    const hasSigningCredential = !!(trigger as any).signingSecretCredentialReferenceId;
+
+    // Signature verification is enabled if there's a signing credential configured
+    const signatureVerificationEnabled = hasSigningCredential || !!signatureVerification;
 
     return {
       id: trigger.id,
@@ -364,6 +364,7 @@ export function TriggerForm({ tenantId, projectId, agentId, trigger, mode }: Tri
         ? JSON.stringify(outputTransform.objectTransformation, null, 2)
         : '',
       authHeaders,
+      signatureVerificationEnabled,
       signingSecretCredentialReferenceId:
         (trigger as any).signingSecretCredentialReferenceId || undefined,
       signatureAlgorithm: signatureVerification?.algorithm || 'sha256',
@@ -470,8 +471,9 @@ export function TriggerForm({ tenantId, projectId, agentId, trigger, mode }: Tri
     toast.success(`Applied ${preset.name} preset`);
   };
 
-  // Watch specific fields for request preview
+  // Watch specific fields for request preview and conditional rendering
   const watchedAuthHeaders = form.watch('authHeaders');
+  const watchedSignatureVerificationEnabled = form.watch('signatureVerificationEnabled');
   const watchedSigningCredential = form.watch('signingSecretCredentialReferenceId');
   const watchedSignatureKey = form.watch('signatureKey');
   const watchedSignaturePrefix = form.watch('signaturePrefix');
@@ -483,6 +485,7 @@ export function TriggerForm({ tenantId, projectId, agentId, trigger, mode }: Tri
   // Generate request preview based on current form values
   const generateRequestPreview = useMemo(() => {
     const authHeaders = watchedAuthHeaders || [];
+    const signatureVerificationEnabled = watchedSignatureVerificationEnabled;
     const signingCredential = watchedSigningCredential;
     const signatureKey = watchedSignatureKey;
     const signaturePrefix = watchedSignaturePrefix || '';
@@ -504,8 +507,8 @@ export function TriggerForm({ tenantId, projectId, agentId, trigger, mode }: Tri
       }
     }
 
-    // Signature header if configured
-    if (signingCredential && signatureKey) {
+    // Signature header if configured and enabled
+    if (signatureVerificationEnabled && signingCredential && signatureKey) {
       lines.push(`${signatureKey}: ${signaturePrefix}<${signatureAlgorithm}-hmac>`);
 
       // Add any timestamp headers from signed components
@@ -522,8 +525,8 @@ export function TriggerForm({ tenantId, projectId, agentId, trigger, mode }: Tri
     lines.push('  "data": { ... }');
     lines.push('}');
 
-    // Add signature computation explanation if configured
-    if (signingCredential && signedComponents.length > 0) {
+    // Add signature computation explanation if configured and enabled
+    if (signatureVerificationEnabled && signingCredential && signedComponents.length > 0) {
       lines.push('');
       lines.push('---');
       lines.push('Signature computed from:');
@@ -541,6 +544,7 @@ export function TriggerForm({ tenantId, projectId, agentId, trigger, mode }: Tri
     return lines.join('\n');
   }, [
     watchedAuthHeaders,
+    watchedSignatureVerificationEnabled,
     watchedSigningCredential,
     watchedSignatureKey,
     watchedSignaturePrefix,
@@ -616,9 +620,10 @@ export function TriggerForm({ tenantId, projectId, agentId, trigger, mode }: Tri
       // Trim messageTemplate to match backend validation behavior
       const trimmedMessageTemplate = data.messageTemplate?.trim() || '';
 
-      // Build signature verification config
+      // Build signature verification config (only if enabled)
       let signatureVerification: any;
       if (
+        data.signatureVerificationEnabled &&
         data.signingSecretCredentialReferenceId &&
         data.signatureAlgorithm &&
         data.signatureEncoding &&
@@ -681,9 +686,11 @@ export function TriggerForm({ tenantId, projectId, agentId, trigger, mode }: Tri
         outputTransform,
         // Only include auth-related fields when they have actual values
         ...(headersToSend.length > 0 && { authentication }),
-        ...(data.signingSecretCredentialReferenceId && {
-          signingSecretCredentialReferenceId: data.signingSecretCredentialReferenceId,
-        }),
+        // Only include signing credential and verification when enabled
+        ...(data.signatureVerificationEnabled &&
+          data.signingSecretCredentialReferenceId && {
+            signingSecretCredentialReferenceId: data.signingSecretCredentialReferenceId,
+          }),
         ...(signatureVerification && { signatureVerification }),
       };
 
@@ -871,10 +878,10 @@ export function TriggerForm({ tenantId, projectId, agentId, trigger, mode }: Tri
           </CardContent>
         </Card>
 
-        {/* Authentication */}
+        {/* Authentication Headers */}
         <Card>
           <CardHeader>
-            <CardTitle>Authentication</CardTitle>
+            <CardTitle>Authentication Headers (Optional)</CardTitle>
             <CardDescription>
               Configure header-based authentication for incoming webhook requests. Add one or more
               headers that must be present and match the expected values.
@@ -961,616 +968,619 @@ export function TriggerForm({ tenantId, projectId, agentId, trigger, mode }: Tri
               <Plus className="h-4 w-4 mr-2" />
               Add Required Header
             </Button>
+          </CardContent>
+        </Card>
 
-            <div className="pt-4 border-t space-y-3">
-              {/* Signing Secret Credential with clearable select */}
-              <FormField
-                control={form.control}
-                name="signingSecretCredentialReferenceId"
-                render={({ field }) => (
-                  <FormItem>
-                    <FormLabel>Signing Secret Credential (Optional)</FormLabel>
-                    <div className="flex gap-2">
-                      <Select
-                        value={field.value || ''}
-                        onValueChange={(value) => field.onChange(value || undefined)}
-                        disabled={loadingCredentials}
-                      >
-                        <SelectTrigger className="flex-1">
-                          <SelectValue
-                            placeholder={
-                              loadingCredentials
-                                ? 'Loading credentials...'
-                                : credentials.length === 0
-                                  ? 'No project-scoped credentials available'
-                                  : 'Select a credential'
-                            }
-                          />
-                        </SelectTrigger>
-                        <SelectContent>
-                          {credentials.map((option) => (
-                            <SelectItem key={option.value} value={option.value}>
-                              {option.label}
-                            </SelectItem>
-                          ))}
-                        </SelectContent>
-                      </Select>
-                      {field.value && (
-                        <Button
-                          type="button"
-                          variant="ghost"
-                          size="icon"
-                          onClick={() => field.onChange(undefined)}
-                          className="shrink-0"
-                        >
-                          <X className="h-4 w-4" />
-                        </Button>
+        {/* Signature Verification */}
+        <Card>
+          <CardHeader>
+            <CardTitle>Signature Verification</CardTitle>
+            <CardDescription>
+              Enable HMAC signature verification to ensure webhook requests are authentic and
+              haven't been tampered with.
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            {/* Enable/Disable Toggle */}
+            <FormField
+              control={form.control}
+              name="signatureVerificationEnabled"
+              render={({ field }) => (
+                <FormItem className="flex flex-row items-center justify-between rounded-lg border p-4">
+                  <div className="space-y-0.5">
+                    <FormLabel className="text-base">Enable Signature Verification</FormLabel>
+                    <FormDescription>
+                      When enabled, incoming webhook requests must include a valid HMAC signature.
+                    </FormDescription>
+                  </div>
+                  <FormControl>
+                    <Switch checked={field.value} onCheckedChange={field.onChange} />
+                  </FormControl>
+                </FormItem>
+              )}
+            />
+
+            {/* Signature Verification Configuration - only shown when enabled */}
+            {watchedSignatureVerificationEnabled && (
+              <div className="space-y-4 pt-4 border-t">
+                {/* Provider Presets */}
+                <Collapsible
+                  open={presetsExpanded}
+                  onOpenChange={setPresetsExpanded}
+                  className="rounded-lg border p-4"
+                >
+                  <div className="flex items-center justify-between">
+                    <div className="flex items-center gap-2">
+                      <h4 className="text-sm font-medium">Quick Setup Presets</h4>
+                      {appliedPreset && (
+                        <Badge variant="secondary" className="text-xs gap-1">
+                          <Check className="h-3 w-3" />
+                          {providerPresets[appliedPreset]?.name}
+                        </Badge>
                       )}
                     </div>
-                    <FormMessage />
-                  </FormItem>
-                )}
-              />
-              <FormDescription>
-                Select a project-scoped credential that contains the HMAC signing secret for webhook
-                signature verification. If provided, webhook requests must include a valid signature
-                header. Only project-scoped credentials can be used with triggers; user-scoped
-                credentials are not supported.
-              </FormDescription>
-
-              {/* Provider Presets */}
-              <Collapsible
-                open={presetsExpanded}
-                onOpenChange={setPresetsExpanded}
-                className="pt-4 border-t"
-              >
-                <div className="flex items-center justify-between">
-                  <div className="flex items-center gap-2">
-                    <h4 className="text-sm font-medium">Quick Setup Presets</h4>
-                    {appliedPreset && (
-                      <Badge variant="secondary" className="text-xs gap-1">
-                        <Check className="h-3 w-3" />
-                        {providerPresets[appliedPreset]?.name}
-                      </Badge>
-                    )}
-                  </div>
-                  <CollapsibleTrigger asChild>
-                    <Button variant="ghost" size="sm">
-                      <ChevronDown
-                        className={`h-4 w-4 transition-transform ${presetsExpanded ? '' : '-rotate-90'}`}
-                      />
-                    </Button>
-                  </CollapsibleTrigger>
-                </div>
-                <CollapsibleContent className="pt-3 space-y-3">
-                  <FormDescription>
-                    Apply a preset configuration for common webhook providers. This will auto-fill
-                    all signature verification fields.
-                  </FormDescription>
-                  <div className="grid grid-cols-2 gap-2">
-                    <Button
-                      type="button"
-                      variant={appliedPreset === 'github' ? 'secondary' : 'outline'}
-                      size="sm"
-                      onClick={() => applyPreset('github')}
-                      className="justify-start gap-2"
-                    >
-                      <ProviderIcon provider="github" size={16} />
-                      GitHub
-                      {appliedPreset === 'github' && <Check className="h-3 w-3 ml-auto" />}
-                    </Button>
-                    <Button
-                      type="button"
-                      variant={appliedPreset === 'slack' ? 'secondary' : 'outline'}
-                      size="sm"
-                      onClick={() => applyPreset('slack')}
-                      className="justify-start gap-2"
-                    >
-                      <ProviderIcon provider="slack" size={16} />
-                      Slack
-                      {appliedPreset === 'slack' && <Check className="h-3 w-3 ml-auto" />}
-                    </Button>
-                    <Button
-                      type="button"
-                      variant={appliedPreset === 'zendesk' ? 'secondary' : 'outline'}
-                      size="sm"
-                      onClick={() => applyPreset('zendesk')}
-                      className="justify-start gap-2"
-                    >
-                      <ProviderIcon provider="zendesk" size={16} />
-                      Zendesk
-                      {appliedPreset === 'zendesk' && <Check className="h-3 w-3 ml-auto" />}
-                    </Button>
-                    <Button
-                      type="button"
-                      variant={appliedPreset === 'stripe' ? 'secondary' : 'outline'}
-                      size="sm"
-                      onClick={() => applyPreset('stripe')}
-                      className="justify-start gap-2"
-                    >
-                      <ProviderIcon provider="stripe" size={16} />
-                      Stripe
-                      {appliedPreset === 'stripe' && <Check className="h-3 w-3 ml-auto" />}
-                    </Button>
-                  </div>
-                </CollapsibleContent>
-              </Collapsible>
-
-              {/* Algorithm and Encoding selectors */}
-              <div className="grid grid-cols-2 gap-4 pt-4">
-                <FormField
-                  control={form.control}
-                  name="signatureAlgorithm"
-                  render={({ field: _field }) => (
-                    <FormItem>
-                      <FormLabel>HMAC Algorithm</FormLabel>
-                      <GenericSelect
-                        control={form.control}
-                        name="signatureAlgorithm"
-                        label=""
-                        options={algorithmOptions}
-                        placeholder="Select algorithm"
-                      />
-                      <FormDescription>
-                        Choose the HMAC algorithm. SHA-256 is recommended for most use cases.
-                      </FormDescription>
-                      <FormMessage />
-                    </FormItem>
-                  )}
-                />
-                <FormField
-                  control={form.control}
-                  name="signatureEncoding"
-                  render={({ field: _field }) => (
-                    <FormItem>
-                      <FormLabel>Signature Encoding</FormLabel>
-                      <GenericSelect
-                        control={form.control}
-                        name="signatureEncoding"
-                        label=""
-                        options={encodingOptions}
-                        placeholder="Select encoding"
-                      />
-                      <FormDescription>
-                        Choose how the signature is encoded. Hexadecimal is the most common.
-                      </FormDescription>
-                      <FormMessage />
-                    </FormItem>
-                  )}
-                />
-              </div>
-
-              {/* Show deprecation warning for SHA-1 or MD5 */}
-              {(form.watch('signatureAlgorithm') === 'sha1' ||
-                form.watch('signatureAlgorithm') === 'md5') && (
-                <Alert variant="warning">
-                  <AlertDescription>
-                    <strong>Warning:</strong> {form.watch('signatureAlgorithm')?.toUpperCase()} is
-                    deprecated and should only be used for legacy systems. Consider upgrading to
-                    SHA-256 or SHA-512 for better security.
-                  </AlertDescription>
-                </Alert>
-              )}
-
-              {/* Signature Source Configuration */}
-              <div className="pt-4 border-t space-y-3">
-                <h4 className="text-sm font-medium">Signature Location</h4>
-                <FormField
-                  control={form.control}
-                  name="signatureSource"
-                  render={({ field: _field }) => (
-                    <FormItem>
-                      <FormLabel>Signature Source</FormLabel>
-                      <GenericSelect
-                        control={form.control}
-                        name="signatureSource"
-                        label=""
-                        options={signatureSourceOptions}
-                        placeholder="Select signature source"
-                      />
-                      <FormDescription>
-                        Choose where the signature is located in the webhook request. Most providers
-                        send signatures in HTTP headers.
-                      </FormDescription>
-                      <FormMessage />
-                    </FormItem>
-                  )}
-                />
-
-                <FormField
-                  control={form.control}
-                  name="signatureKey"
-                  render={({ field }) => (
-                    <FormItem>
-                      <FormLabel>
-                        {signatureSource === 'header'
-                          ? 'Header Name'
-                          : signatureSource === 'query'
-                            ? 'Query Parameter Name'
-                            : 'JMESPath Expression'}
-                      </FormLabel>
-                      <FormControl>
-                        <Input
-                          {...field}
-                          placeholder={
-                            signatureSource === 'header'
-                              ? 'e.g., X-Hub-Signature-256'
-                              : signatureSource === 'query'
-                                ? 'e.g., signature'
-                                : 'e.g., signature or headers."X-Signature"'
-                          }
-                          onBlur={(e) => {
-                            field.onBlur();
-                            if (signatureSource === 'body') {
-                              const error = validateJMESPath(e.target.value);
-                              setSignatureKeyError(error);
-                            }
-                          }}
-                        />
-                      </FormControl>
-                      <FormDescription>
-                        {signatureSource === 'header'
-                          ? 'The name of the HTTP header containing the signature (case-insensitive by default).'
-                          : signatureSource === 'query'
-                            ? 'The name of the query parameter containing the signature.'
-                            : 'A JMESPath expression to extract the signature from the request body.'}
-                      </FormDescription>
-                      {signatureKeyError && (
-                        <p className="text-sm font-medium text-destructive">{signatureKeyError}</p>
-                      )}
-                      <FormMessage />
-                    </FormItem>
-                  )}
-                />
-
-                <FormField
-                  control={form.control}
-                  name="signaturePrefix"
-                  render={({ field }) => (
-                    <FormItem>
-                      <FormLabel>Signature Prefix (Optional)</FormLabel>
-                      <FormControl>
-                        <Input {...field} placeholder='e.g., "sha256=" or "v0="' />
-                      </FormControl>
-                      <FormDescription>
-                        If the signature includes a prefix (like "sha256=" in GitHub webhooks),
-                        specify it here. The prefix will be stripped before verification.
-                      </FormDescription>
-                      <FormMessage />
-                    </FormItem>
-                  )}
-                />
-
-                <FormField
-                  control={form.control}
-                  name="signatureRegex"
-                  render={({ field }) => (
-                    <FormItem>
-                      <FormLabel>Signature Regex (Optional)</FormLabel>
-                      <FormControl>
-                        <Input
-                          {...field}
-                          placeholder='e.g., "t=\\d+,v1=([a-f0-9]+)"'
-                          onBlur={(e) => {
-                            field.onBlur();
-                            const error = validateRegex(e.target.value);
-                            setSignatureRegexError(error);
-                          }}
-                        />
-                      </FormControl>
-                      <FormDescription>
-                        A regular expression to extract the signature from the value. The first
-                        capture group will be used as the signature. Useful for complex signature
-                        formats like Stripe.
-                      </FormDescription>
-                      {signatureRegexError && (
-                        <p className="text-sm font-medium text-destructive">
-                          {signatureRegexError}
-                        </p>
-                      )}
-                      <FormMessage />
-                    </FormItem>
-                  )}
-                />
-              </div>
-
-              {/* Signed Components Builder */}
-              <div className="pt-4 border-t space-y-3">
-                <h4 className="text-sm font-medium">Signed Components</h4>
-                <FormDescription>
-                  Define the components that are included in the signature. Components are joined in
-                  order to create the signed payload.
-                </FormDescription>
-
-                {/* Signed Components List */}
-                <div className="space-y-3">
-                  {componentFields.map((field, index) => {
-                    const componentSource = form.watch(`signedComponents.${index}.source`);
-
-                    return (
-                      <div key={field.id} className="space-y-2 p-4 border rounded-lg">
-                        <div className="flex items-center justify-between mb-2">
-                          <span className="text-sm font-medium">Component {index + 1}</span>
-                          <div className="flex gap-1">
-                            <Button
-                              type="button"
-                              variant="ghost"
-                              size="icon"
-                              onClick={() => moveComponent(index, index - 1)}
-                              disabled={index === 0}
-                              className="h-7 w-7"
-                            >
-                              <ArrowUp className="h-3 w-3" />
-                            </Button>
-                            <Button
-                              type="button"
-                              variant="ghost"
-                              size="icon"
-                              onClick={() => moveComponent(index, index + 1)}
-                              disabled={index === componentFields.length - 1}
-                              className="h-7 w-7"
-                            >
-                              <ArrowDown className="h-3 w-3" />
-                            </Button>
-                            <Button
-                              type="button"
-                              variant="ghost"
-                              size="icon"
-                              onClick={() => removeComponent(index)}
-                              className="h-7 w-7"
-                            >
-                              <Trash2 className="h-3 w-3" />
-                            </Button>
-                          </div>
-                        </div>
-
-                        <div className="grid grid-cols-2 gap-3">
-                          <FormField
-                            control={form.control}
-                            name={`signedComponents.${index}.source`}
-                            render={({ field: _selectField }) => (
-                              <FormItem>
-                                <FormLabel>Component Source</FormLabel>
-                                <GenericSelect
-                                  control={form.control}
-                                  name={`signedComponents.${index}.source`}
-                                  label=""
-                                  options={componentSourceOptions}
-                                  placeholder="Select source"
-                                />
-                                <FormMessage />
-                              </FormItem>
-                            )}
-                          />
-
-                          {componentSource !== 'literal' && (
-                            <FormField
-                              control={form.control}
-                              name={`signedComponents.${index}.key`}
-                              render={({ field: inputField }) => (
-                                <FormItem>
-                                  <FormLabel>
-                                    {componentSource === 'header'
-                                      ? 'Header Name'
-                                      : 'JMESPath Expression'}
-                                  </FormLabel>
-                                  <FormControl>
-                                    <Input
-                                      {...inputField}
-                                      placeholder={
-                                        componentSource === 'header'
-                                          ? 'e.g., X-Request-Timestamp'
-                                          : 'e.g., timestamp or body.timestamp'
-                                      }
-                                    />
-                                  </FormControl>
-                                  <FormMessage />
-                                </FormItem>
-                              )}
-                            />
-                          )}
-
-                          {componentSource === 'literal' && (
-                            <FormField
-                              control={form.control}
-                              name={`signedComponents.${index}.value`}
-                              render={({ field: inputField }) => (
-                                <FormItem>
-                                  <FormLabel>Literal Value</FormLabel>
-                                  <FormControl>
-                                    <Input {...inputField} placeholder='e.g., "v0"' />
-                                  </FormControl>
-                                  <FormMessage />
-                                </FormItem>
-                              )}
-                            />
-                          )}
-                        </div>
-
-                        <div className="grid grid-cols-2 gap-3">
-                          <FormField
-                            control={form.control}
-                            name={`signedComponents.${index}.regex`}
-                            render={({ field: inputField }) => (
-                              <FormItem>
-                                <FormLabel>Regex Extraction (Optional)</FormLabel>
-                                <FormControl>
-                                  <Input {...inputField} placeholder='e.g., "([a-f0-9]+)"' />
-                                </FormControl>
-                                <FormDescription className="text-xs">
-                                  Extract a portion of the component using a regex capture group.
-                                </FormDescription>
-                                <FormMessage />
-                              </FormItem>
-                            )}
-                          />
-
-                          <FormField
-                            control={form.control}
-                            name={`signedComponents.${index}.required`}
-                            render={({ field }) => (
-                              <FormItem className="flex flex-row items-center justify-between rounded-lg border p-3 mt-2">
-                                <div className="space-y-0.5">
-                                  <FormLabel className="text-sm">Required</FormLabel>
-                                  <FormDescription className="text-xs">
-                                    If unchecked, missing component = empty string
-                                  </FormDescription>
-                                </div>
-                                <FormControl>
-                                  <Switch checked={field.value} onCheckedChange={field.onChange} />
-                                </FormControl>
-                              </FormItem>
-                            )}
-                          />
-                        </div>
-                      </div>
-                    );
-                  })}
-                </div>
-
-                <Button
-                  type="button"
-                  variant="outline"
-                  size="sm"
-                  onClick={() =>
-                    appendComponent({
-                      source: 'header',
-                      key: '',
-                      value: '',
-                      regex: '',
-                      required: true,
-                    })
-                  }
-                >
-                  <Plus className="h-4 w-4 mr-2" />
-                  Add Signed Component
-                </Button>
-
-                {/* Component Join Configuration */}
-                <div className="pt-3 border-t space-y-3">
-                  <h4 className="text-sm font-medium">Component Joining</h4>
-                  <div className="grid grid-cols-2 gap-4">
-                    <FormField
-                      control={form.control}
-                      name="joinStrategy"
-                      render={({ field: _field }) => (
-                        <FormItem>
-                          <FormLabel>Join Strategy</FormLabel>
-                          <GenericSelect
-                            control={form.control}
-                            name="joinStrategy"
-                            label=""
-                            options={joinStrategyOptions}
-                            placeholder="Select strategy"
-                          />
-                          <FormDescription className="text-xs">
-                            Strategy for combining components.
-                          </FormDescription>
-                          <FormMessage />
-                        </FormItem>
-                      )}
-                    />
-
-                    <FormField
-                      control={form.control}
-                      name="joinSeparator"
-                      render={({ field }) => (
-                        <FormItem>
-                          <FormLabel>Separator</FormLabel>
-                          <FormControl>
-                            <Input {...field} placeholder='e.g., ":" or "."' />
-                          </FormControl>
-                          <FormDescription className="text-xs">
-                            String to insert between components.
-                          </FormDescription>
-                          <FormMessage />
-                        </FormItem>
-                      )}
-                    />
-                  </div>
-                </div>
-
-                {/* Advanced Validation Options */}
-                <div className="pt-4 border-t">
-                  <Collapsible>
                     <CollapsibleTrigger asChild>
-                      <Button variant="ghost" size="sm" className="w-full justify-between">
-                        <span className="text-sm font-medium">Advanced Validation Options</span>
-                        <ChevronDown className="h-4 w-4 transition-transform" />
+                      <Button variant="ghost" size="sm">
+                        <ChevronDown
+                          className={`h-4 w-4 transition-transform ${presetsExpanded ? '' : '-rotate-90'}`}
+                        />
                       </Button>
                     </CollapsibleTrigger>
-                    <CollapsibleContent className="pt-3 space-y-3">
-                      <FormDescription>
-                        Configure advanced options for signature validation behavior.
-                      </FormDescription>
+                  </div>
+                  <CollapsibleContent className="pt-3 space-y-3">
+                    <FormDescription>
+                      Apply a preset configuration for common webhook providers. This will auto-fill
+                      all signature verification fields.
+                    </FormDescription>
+                    <div className="grid grid-cols-2 gap-2">
+                      <Button
+                        type="button"
+                        variant={appliedPreset === 'github' ? 'secondary' : 'outline'}
+                        size="sm"
+                        onClick={() => applyPreset('github')}
+                        className="justify-start gap-2"
+                      >
+                        <ProviderIcon provider="github" size={16} />
+                        GitHub
+                        {appliedPreset === 'github' && <Check className="h-3 w-3 ml-auto" />}
+                      </Button>
+                      <Button
+                        type="button"
+                        variant={appliedPreset === 'slack' ? 'secondary' : 'outline'}
+                        size="sm"
+                        onClick={() => applyPreset('slack')}
+                        className="justify-start gap-2"
+                      >
+                        <ProviderIcon provider="slack" size={16} />
+                        Slack
+                        {appliedPreset === 'slack' && <Check className="h-3 w-3 ml-auto" />}
+                      </Button>
+                      <Button
+                        type="button"
+                        variant={appliedPreset === 'zendesk' ? 'secondary' : 'outline'}
+                        size="sm"
+                        onClick={() => applyPreset('zendesk')}
+                        className="justify-start gap-2"
+                      >
+                        <ProviderIcon provider="zendesk" size={16} />
+                        Zendesk
+                        {appliedPreset === 'zendesk' && <Check className="h-3 w-3 ml-auto" />}
+                      </Button>
+                      <Button
+                        type="button"
+                        variant={appliedPreset === 'stripe' ? 'secondary' : 'outline'}
+                        size="sm"
+                        onClick={() => applyPreset('stripe')}
+                        className="justify-start gap-2"
+                      >
+                        <ProviderIcon provider="stripe" size={16} />
+                        Stripe
+                        {appliedPreset === 'stripe' && <Check className="h-3 w-3 ml-auto" />}
+                      </Button>
+                    </div>
+                  </CollapsibleContent>
+                </Collapsible>
 
+                {/* Signing Secret Credential */}
+                <GenericSelect
+                  control={form.control}
+                  name="signingSecretCredentialReferenceId"
+                  label="Signing Secret Credential"
+                  options={credentials}
+                  placeholder={
+                    loadingCredentials
+                      ? 'Loading credentials...'
+                      : credentials.length === 0
+                        ? 'No project-scoped credentials available'
+                        : 'Select a credential'
+                  }
+                  disabled={loadingCredentials}
+                  isRequired
+                  description="Select a project-scoped credential that contains the HMAC signing secret for webhook signature verification."
+                />
+
+                {/* Algorithm and Encoding selectors */}
+                <div className="grid grid-cols-2 gap-4">
+                  <FormField
+                    control={form.control}
+                    name="signatureAlgorithm"
+                    render={({ field: _field }) => (
+                      <FormItem>
+                        <FormLabel>HMAC Algorithm</FormLabel>
+                        <GenericSelect
+                          control={form.control}
+                          name="signatureAlgorithm"
+                          label=""
+                          options={algorithmOptions}
+                          placeholder="Select algorithm"
+                        />
+                        <FormDescription>
+                          Choose the HMAC algorithm. SHA-256 is recommended for most use cases.
+                        </FormDescription>
+                        <FormMessage />
+                      </FormItem>
+                    )}
+                  />
+                  <FormField
+                    control={form.control}
+                    name="signatureEncoding"
+                    render={({ field: _field }) => (
+                      <FormItem>
+                        <FormLabel>Signature Encoding</FormLabel>
+                        <GenericSelect
+                          control={form.control}
+                          name="signatureEncoding"
+                          label=""
+                          options={encodingOptions}
+                          placeholder="Select encoding"
+                        />
+                        <FormDescription>
+                          Choose how the signature is encoded. Hexadecimal is the most common.
+                        </FormDescription>
+                        <FormMessage />
+                      </FormItem>
+                    )}
+                  />
+                </div>
+
+                {/* Show deprecation warning for SHA-1 or MD5 */}
+                {(form.watch('signatureAlgorithm') === 'sha1' ||
+                  form.watch('signatureAlgorithm') === 'md5') && (
+                  <Alert variant="warning">
+                    <AlertDescription>
+                      <strong>Warning:</strong> {form.watch('signatureAlgorithm')?.toUpperCase()} is
+                      deprecated and should only be used for legacy systems. Consider upgrading to
+                      SHA-256 or SHA-512 for better security.
+                    </AlertDescription>
+                  </Alert>
+                )}
+
+                {/* Signature Source Configuration */}
+                <div className="pt-4 border-t space-y-3">
+                  <h4 className="text-sm font-medium">Signature Location</h4>
+                  <FormField
+                    control={form.control}
+                    name="signatureSource"
+                    render={({ field: _field }) => (
+                      <FormItem>
+                        <FormLabel>Signature Source</FormLabel>
+                        <GenericSelect
+                          control={form.control}
+                          name="signatureSource"
+                          label=""
+                          options={signatureSourceOptions}
+                          placeholder="Select signature source"
+                        />
+                        <FormDescription>
+                          Choose where the signature is located in the webhook request. Most
+                          providers send signatures in HTTP headers.
+                        </FormDescription>
+                        <FormMessage />
+                      </FormItem>
+                    )}
+                  />
+
+                  <FormField
+                    control={form.control}
+                    name="signatureKey"
+                    render={({ field }) => (
+                      <FormItem>
+                        <FormLabel>
+                          {signatureSource === 'header'
+                            ? 'Header Name'
+                            : signatureSource === 'query'
+                              ? 'Query Parameter Name'
+                              : 'JMESPath Expression'}
+                        </FormLabel>
+                        <FormControl>
+                          <Input
+                            {...field}
+                            placeholder={
+                              signatureSource === 'header'
+                                ? 'e.g., X-Hub-Signature-256'
+                                : signatureSource === 'query'
+                                  ? 'e.g., signature'
+                                  : 'e.g., signature or headers."X-Signature"'
+                            }
+                            onBlur={(e) => {
+                              field.onBlur();
+                              if (signatureSource === 'body') {
+                                const error = validateJMESPath(e.target.value);
+                                setSignatureKeyError(error);
+                              }
+                            }}
+                          />
+                        </FormControl>
+                        <FormDescription>
+                          {signatureSource === 'header'
+                            ? 'The name of the HTTP header containing the signature (case-insensitive by default).'
+                            : signatureSource === 'query'
+                              ? 'The name of the query parameter containing the signature.'
+                              : 'A JMESPath expression to extract the signature from the request body.'}
+                        </FormDescription>
+                        {signatureKeyError && (
+                          <p className="text-sm font-medium text-destructive">
+                            {signatureKeyError}
+                          </p>
+                        )}
+                        <FormMessage />
+                      </FormItem>
+                    )}
+                  />
+
+                  <FormField
+                    control={form.control}
+                    name="signaturePrefix"
+                    render={({ field }) => (
+                      <FormItem>
+                        <FormLabel>Signature Prefix (Optional)</FormLabel>
+                        <FormControl>
+                          <Input {...field} placeholder='e.g., "sha256=" or "v0="' />
+                        </FormControl>
+                        <FormDescription>
+                          If the signature includes a prefix (like "sha256=" in GitHub webhooks),
+                          specify it here. The prefix will be stripped before verification.
+                        </FormDescription>
+                        <FormMessage />
+                      </FormItem>
+                    )}
+                  />
+
+                  <FormField
+                    control={form.control}
+                    name="signatureRegex"
+                    render={({ field }) => (
+                      <FormItem>
+                        <FormLabel>Signature Regex (Optional)</FormLabel>
+                        <FormControl>
+                          <Input
+                            {...field}
+                            placeholder='e.g., "t=\\d+,v1=([a-f0-9]+)"'
+                            onBlur={(e) => {
+                              field.onBlur();
+                              const error = validateRegex(e.target.value);
+                              setSignatureRegexError(error);
+                            }}
+                          />
+                        </FormControl>
+                        <FormDescription>
+                          A regular expression to extract the signature from the value. The first
+                          capture group will be used as the signature. Useful for complex signature
+                          formats like Stripe.
+                        </FormDescription>
+                        {signatureRegexError && (
+                          <p className="text-sm font-medium text-destructive">
+                            {signatureRegexError}
+                          </p>
+                        )}
+                        <FormMessage />
+                      </FormItem>
+                    )}
+                  />
+                </div>
+
+                {/* Signed Components Builder */}
+                <div className="pt-4 border-t space-y-3">
+                  <h4 className="text-sm font-medium">Signed Components</h4>
+                  <FormDescription>
+                    Define the components that are included in the signature. Components are joined
+                    in order to create the signed payload.
+                  </FormDescription>
+
+                  {/* Signed Components List */}
+                  <div className="space-y-3">
+                    {componentFields.map((field, index) => {
+                      const componentSource = form.watch(`signedComponents.${index}.source`);
+
+                      return (
+                        <div key={field.id} className="space-y-2 p-4 border rounded-lg">
+                          <div className="flex items-center justify-between mb-2">
+                            <span className="text-sm font-medium">Component {index + 1}</span>
+                            <div className="flex gap-1">
+                              <Button
+                                type="button"
+                                variant="ghost"
+                                size="icon"
+                                onClick={() => moveComponent(index, index - 1)}
+                                disabled={index === 0}
+                                className="h-7 w-7"
+                              >
+                                <ArrowUp className="h-3 w-3" />
+                              </Button>
+                              <Button
+                                type="button"
+                                variant="ghost"
+                                size="icon"
+                                onClick={() => moveComponent(index, index + 1)}
+                                disabled={index === componentFields.length - 1}
+                                className="h-7 w-7"
+                              >
+                                <ArrowDown className="h-3 w-3" />
+                              </Button>
+                              <Button
+                                type="button"
+                                variant="ghost"
+                                size="icon"
+                                onClick={() => removeComponent(index)}
+                                className="h-7 w-7"
+                              >
+                                <Trash2 className="h-3 w-3" />
+                              </Button>
+                            </div>
+                          </div>
+
+                          <div className="grid grid-cols-2 gap-3">
+                            <FormField
+                              control={form.control}
+                              name={`signedComponents.${index}.source`}
+                              render={({ field: _selectField }) => (
+                                <FormItem>
+                                  <FormLabel>Component Source</FormLabel>
+                                  <GenericSelect
+                                    control={form.control}
+                                    name={`signedComponents.${index}.source`}
+                                    label=""
+                                    options={componentSourceOptions}
+                                    placeholder="Select source"
+                                  />
+                                  <FormMessage />
+                                </FormItem>
+                              )}
+                            />
+
+                            {componentSource !== 'literal' && (
+                              <FormField
+                                control={form.control}
+                                name={`signedComponents.${index}.key`}
+                                render={({ field: inputField }) => (
+                                  <FormItem>
+                                    <FormLabel>
+                                      {componentSource === 'header'
+                                        ? 'Header Name'
+                                        : 'JMESPath Expression'}
+                                    </FormLabel>
+                                    <FormControl>
+                                      <Input
+                                        {...inputField}
+                                        placeholder={
+                                          componentSource === 'header'
+                                            ? 'e.g., X-Request-Timestamp'
+                                            : 'e.g., timestamp or body.timestamp'
+                                        }
+                                      />
+                                    </FormControl>
+                                    <FormMessage />
+                                  </FormItem>
+                                )}
+                              />
+                            )}
+
+                            {componentSource === 'literal' && (
+                              <FormField
+                                control={form.control}
+                                name={`signedComponents.${index}.value`}
+                                render={({ field: inputField }) => (
+                                  <FormItem>
+                                    <FormLabel>Literal Value</FormLabel>
+                                    <FormControl>
+                                      <Input {...inputField} placeholder='e.g., "v0"' />
+                                    </FormControl>
+                                    <FormMessage />
+                                  </FormItem>
+                                )}
+                              />
+                            )}
+                          </div>
+
+                          <div className="grid grid-cols-2 gap-3">
+                            <FormField
+                              control={form.control}
+                              name={`signedComponents.${index}.regex`}
+                              render={({ field: inputField }) => (
+                                <FormItem>
+                                  <FormLabel>Regex Extraction (Optional)</FormLabel>
+                                  <FormControl>
+                                    <Input {...inputField} placeholder='e.g., "([a-f0-9]+)"' />
+                                  </FormControl>
+                                  <FormDescription className="text-xs">
+                                    Extract a portion of the component using a regex capture group.
+                                  </FormDescription>
+                                  <FormMessage />
+                                </FormItem>
+                              )}
+                            />
+
+                            <FormField
+                              control={form.control}
+                              name={`signedComponents.${index}.required`}
+                              render={({ field }) => (
+                                <FormItem className="flex flex-row items-center justify-between rounded-lg border p-3 mt-2">
+                                  <div className="space-y-0.5">
+                                    <FormLabel className="text-sm">Required</FormLabel>
+                                    <FormDescription className="text-xs">
+                                      If unchecked, missing component = empty string
+                                    </FormDescription>
+                                  </div>
+                                  <FormControl>
+                                    <Switch
+                                      checked={field.value}
+                                      onCheckedChange={field.onChange}
+                                    />
+                                  </FormControl>
+                                </FormItem>
+                              )}
+                            />
+                          </div>
+                        </div>
+                      );
+                    })}
+                  </div>
+
+                  <Button
+                    type="button"
+                    variant="outline"
+                    size="sm"
+                    onClick={() =>
+                      appendComponent({
+                        source: 'header',
+                        key: '',
+                        value: '',
+                        regex: '',
+                        required: true,
+                      })
+                    }
+                  >
+                    <Plus className="h-4 w-4 mr-2" />
+                    Add Signed Component
+                  </Button>
+
+                  {/* Component Join Configuration */}
+                  <div className="pt-3 border-t space-y-3">
+                    <h4 className="text-sm font-medium">Component Joining</h4>
+                    <div className="grid grid-cols-2 gap-4">
                       <FormField
                         control={form.control}
-                        name="headerCaseSensitive"
-                        render={({ field }) => (
-                          <FormItem className="flex flex-row items-center justify-between rounded-lg border p-3">
-                            <div className="space-y-0.5">
-                              <FormLabel className="text-sm">Case-Sensitive Headers</FormLabel>
-                              <FormDescription className="text-xs">
-                                If enabled, header names are matched case-sensitively. Most
-                                providers are case-insensitive (default).
-                              </FormDescription>
-                            </div>
-                            <FormControl>
-                              <Switch checked={field.value} onCheckedChange={field.onChange} />
-                            </FormControl>
+                        name="joinStrategy"
+                        render={({ field: _field }) => (
+                          <FormItem>
+                            <FormLabel>Join Strategy</FormLabel>
+                            <GenericSelect
+                              control={form.control}
+                              name="joinStrategy"
+                              label=""
+                              options={joinStrategyOptions}
+                              placeholder="Select strategy"
+                            />
+                            <FormDescription className="text-xs">
+                              Strategy for combining components.
+                            </FormDescription>
+                            <FormMessage />
                           </FormItem>
                         )}
                       />
 
                       <FormField
                         control={form.control}
-                        name="allowEmptyBody"
+                        name="joinSeparator"
                         render={({ field }) => (
-                          <FormItem className="flex flex-row items-center justify-between rounded-lg border p-3">
-                            <div className="space-y-0.5">
-                              <FormLabel className="text-sm">Allow Empty Body</FormLabel>
-                              <FormDescription className="text-xs">
-                                If enabled, allows verification with an empty request body. Disable
-                                if your webhook always requires a body (default: enabled).
-                              </FormDescription>
-                            </div>
+                          <FormItem>
+                            <FormLabel>Separator</FormLabel>
                             <FormControl>
-                              <Switch checked={field.value} onCheckedChange={field.onChange} />
+                              <Input {...field} placeholder='e.g., ":" or "."' />
                             </FormControl>
+                            <FormDescription className="text-xs">
+                              String to insert between components.
+                            </FormDescription>
+                            <FormMessage />
                           </FormItem>
                         )}
                       />
+                    </div>
+                  </div>
 
-                      <FormField
-                        control={form.control}
-                        name="normalizeUnicode"
-                        render={({ field }) => (
-                          <FormItem className="flex flex-row items-center justify-between rounded-lg border p-3">
-                            <div className="space-y-0.5">
-                              <FormLabel className="text-sm">Normalize Unicode</FormLabel>
-                              <FormDescription className="text-xs">
-                                If enabled, normalizes Unicode strings to NFC form before signing.
-                                Enable if you encounter signature mismatches with Unicode characters
-                                (default: disabled).
-                              </FormDescription>
-                            </div>
-                            <FormControl>
-                              <Switch checked={field.value} onCheckedChange={field.onChange} />
-                            </FormControl>
-                          </FormItem>
-                        )}
-                      />
-                    </CollapsibleContent>
-                  </Collapsible>
+                  {/* Advanced Validation Options */}
+                  <div className="pt-4 border-t">
+                    <Collapsible>
+                      <CollapsibleTrigger asChild>
+                        <Button variant="ghost" size="sm" className="w-full justify-between">
+                          <span className="text-sm font-medium">Advanced Validation Options</span>
+                          <ChevronDown className="h-4 w-4 transition-transform" />
+                        </Button>
+                      </CollapsibleTrigger>
+                      <CollapsibleContent className="pt-3 space-y-3">
+                        <FormDescription>
+                          Configure advanced options for signature validation behavior.
+                        </FormDescription>
+
+                        <FormField
+                          control={form.control}
+                          name="headerCaseSensitive"
+                          render={({ field }) => (
+                            <FormItem className="flex flex-row items-center justify-between rounded-lg border p-3">
+                              <div className="space-y-0.5">
+                                <FormLabel className="text-sm">Case-Sensitive Headers</FormLabel>
+                                <FormDescription className="text-xs">
+                                  If enabled, header names are matched case-sensitively. Most
+                                  providers are case-insensitive (default).
+                                </FormDescription>
+                              </div>
+                              <FormControl>
+                                <Switch checked={field.value} onCheckedChange={field.onChange} />
+                              </FormControl>
+                            </FormItem>
+                          )}
+                        />
+
+                        <FormField
+                          control={form.control}
+                          name="allowEmptyBody"
+                          render={({ field }) => (
+                            <FormItem className="flex flex-row items-center justify-between rounded-lg border p-3">
+                              <div className="space-y-0.5">
+                                <FormLabel className="text-sm">Allow Empty Body</FormLabel>
+                                <FormDescription className="text-xs">
+                                  If enabled, allows verification with an empty request body.
+                                  Disable if your webhook always requires a body (default: enabled).
+                                </FormDescription>
+                              </div>
+                              <FormControl>
+                                <Switch checked={field.value} onCheckedChange={field.onChange} />
+                              </FormControl>
+                            </FormItem>
+                          )}
+                        />
+
+                        <FormField
+                          control={form.control}
+                          name="normalizeUnicode"
+                          render={({ field }) => (
+                            <FormItem className="flex flex-row items-center justify-between rounded-lg border p-3">
+                              <div className="space-y-0.5">
+                                <FormLabel className="text-sm">Normalize Unicode</FormLabel>
+                                <FormDescription className="text-xs">
+                                  If enabled, normalizes Unicode strings to NFC form before signing.
+                                  Enable if you encounter signature mismatches with Unicode
+                                  characters (default: disabled).
+                                </FormDescription>
+                              </div>
+                              <FormControl>
+                                <Switch checked={field.value} onCheckedChange={field.onChange} />
+                              </FormControl>
+                            </FormItem>
+                          )}
+                        />
+                      </CollapsibleContent>
+                    </Collapsible>
+                  </div>
                 </div>
               </div>
-            </div>
+            )}
           </CardContent>
         </Card>
 
         {/* Request Preview */}
-        {((watchedAuthHeaders && watchedAuthHeaders.length > 0) || watchedSigningCredential) && (
+        {((watchedAuthHeaders && watchedAuthHeaders.length > 0) ||
+          (watchedSignatureVerificationEnabled && watchedSigningCredential)) && (
           <Card>
             <CardHeader>
               <CardTitle>Request Preview</CardTitle>


### PR DESCRIPTION
## Summary

- Remove `showAuth` query parameter gate - authentication/signature verification sections are now always visible
- **Restructure Authentication UI into two separate sections:**
  - **Authentication Headers (Optional)** - For required header validation
  - **Signature Verification** - For HMAC signature verification with dedicated toggle
- Add `signatureVerificationEnabled` toggle to show/hide complex signature configuration
- Add provider presets (GitHub, Slack, Zendesk, Stripe) with brand icons using existing ProviderIcon component
- Presets apply all signature verification settings (header name, prefix, algorithm, signed components)
- Add request preview section showing example webhook request format based on current configuration
- Secrets are masked in preview display

## Changes

### UI Restructuring
- Split the original "Authentication" card into two distinct sections
- Signature Verification has its own toggle that controls visibility of configuration options
- When toggle is OFF, signature verification fields are not sent to backend
- When toggle is ON, full configuration UI is shown including presets, credential selection, and advanced options

### Presets Enhancement
- Quick Setup Presets section with collapsible UI
- Provider icons for GitHub, Slack, Zendesk, Stripe
- Applied preset shown as badge after selection
- Presets auto-fill: header name, signature prefix, algorithm, encoding, signed components

### Request Preview
- Shows example HTTP request format based on current configuration
- Only visible when auth headers exist OR signature verification is enabled with a credential
- Displays expected headers, signature format, and computation details

## Test Plan

### Manual Testing (Completed via Browser Automation)
- [x] Navigate to trigger create/edit page
- [x] Verify authentication headers and signature verification are in separate sections
- [x] Test signature verification toggle shows/hides configuration UI
- [x] Test applying different presets (GitHub, Slack, Zendesk, Stripe)
- [x] Verify preset auto-fills header name, prefix, and signed component
- [x] Test selecting signing secret credential
- [x] Verify request preview updates based on configuration
- [x] Create trigger without signature verification - verify it saves correctly
- [x] Create trigger with signature verification - verify it saves correctly
- [x] Edit saved triggers - verify all values persist correctly

### Existing Test Coverage
- API CRUD tests for triggers including signatureVerification field
- Unit tests for signature verification logic (GitHub, Slack, Zendesk, Stripe patterns)