### PR TITLE
docs: add authentication and access control documentation

### DIFF
--- a/agents-docs/content/community/contributing/overview.mdx
+++ b/agents-docs/content/community/contributing/overview.mdx
@@ -40,8 +40,7 @@ This will:
 - Create `~/.inkeep/config` for user-global settings if missing
 - Add `.env` to `.gitignore` if needed
 - Install dependencies
-- Start Doltgres (manage) + Postgres (runtime) via `docker-compose.dbs.yml` and run migrations
-- Optionally set up SpiceDB if `ENABLE_AUTHZ=true`
+- Start Doltgres (manage) + Postgres (runtime) + SpiceDB (authorization) via `docker-compose.dbs.yml` and run migrations
 
 Add API keys for the AI providers you want to use in the root `.env` or `~/.inkeep/config`. `ANTHROPIC_API_KEY` is required.
 

--- a/agents-docs/content/deployment/(docker)/authentication.mdx
+++ b/agents-docs/content/deployment/(docker)/authentication.mdx
@@ -1,0 +1,142 @@
+---
+title: Configure Authentication
+sidebarTitle: Authentication
+description: Set up Better Auth for user sign-in and team management
+icon: LuLock
+---
+
+Configure user authentication, admin credentials, and optional OAuth providers.
+
+<Note>
+  For a feature overview of authentication and authorization, see [Access Control](/visual-builder/access-control).
+</Note>
+
+## Prerequisites
+
+- Docker Compose environment running (see [Local Development](/deployment/docker-local))
+- At least one AI provider API key configured
+
+## Environment Variables Reference
+
+### Authentication (Better Auth)
+
+| Variable | Required | Description |
+|----------|----------|-------------|
+| `BETTER_AUTH_SECRET` | Yes | Secret for session encryption (32+ chars) |
+| `INKEEP_AGENTS_MANAGE_UI_USERNAME` | Yes | Initial admin email address |
+| `INKEEP_AGENTS_MANAGE_UI_PASSWORD` | Yes | Initial admin password (8+ chars) |
+
+### OAuth Providers (Optional)
+
+| Variable | Required | Description |
+|----------|----------|-------------|
+| `PUBLIC_GOOGLE_CLIENT_ID` | No | Google OAuth client ID |
+| `GOOGLE_CLIENT_SECRET` | No | Google OAuth client secret |
+
+## Configuring Authentication
+
+Authentication is enabled by default. Configure the required environment variables to set up your admin credentials and session security.
+
+<Steps>
+  <Step>
+    ### Generate a secret
+
+    Create a secure secret for Better Auth:
+
+    ```bash
+    openssl rand -base64 32
+    ```
+  </Step>
+  <Step>
+    ### Configure environment variables
+
+    Add these to your `.env` file:
+
+    ```dotenv title=".env"
+    # Better Auth secret (paste your generated secret)
+    BETTER_AUTH_SECRET=<your-generated-secret>
+
+    # Initial admin credentials
+    INKEEP_AGENTS_MANAGE_UI_USERNAME=admin@example.com
+    INKEEP_AGENTS_MANAGE_UI_PASSWORD=<secure-password-8-chars-min>
+
+    # SpiceDB connection, localhost
+    SPICEDB_ENDPOINT=localhost:50051
+    SPICEDB_PRESHARED_KEY=dev-secret-key
+    ```
+  </Step>
+  <Step>
+    ### Restart services
+
+    ```bash
+    docker compose up -d
+    ```
+  </Step>
+  <Step>
+    ### Sign in
+
+    Open http://localhost:3000 and sign in with the credentials you configured.
+  </Step>
+</Steps>
+
+## Adding OAuth Providers
+
+### Google OAuth
+
+<Steps>
+  <Step>
+    ### Create OAuth application
+
+    1. Go to the [Google Cloud Console](https://console.cloud.google.com/)
+    2. Navigate to **APIs & Services** → **Credentials**
+    3. Click **Create Credentials** → **OAuth client ID**
+    4. Select **Web application**
+  </Step>
+  <Step>
+    ### Configure redirect URI
+
+    Add this authorized redirect URI:
+
+    ```
+    {your-app-url}/api/auth/callback/google
+    ```
+
+    For local development: `http://localhost:3000/api/auth/callback/google`
+  </Step>
+  <Step>
+    ### Add credentials to environment
+
+    ```dotenv title=".env"
+    PUBLIC_GOOGLE_CLIENT_ID=<your-client-id>
+    GOOGLE_CLIENT_SECRET=<your-client-secret>
+    ```
+  </Step>
+  <Step>
+    ### Restart services
+
+    ```bash
+    docker compose up -d
+    ```
+
+    The Google sign-in option will now appear on the login page.
+  </Step>
+</Steps>
+
+## Troubleshooting
+
+### "Invalid credentials" on first login
+
+Verify these environment variables are set correctly:
+- `INKEEP_AGENTS_MANAGE_UI_USERNAME` — must be a valid email format
+- `INKEEP_AGENTS_MANAGE_UI_PASSWORD` — must be at least 8 characters
+
+### Google sign-in not appearing or not working
+
+- Ensure both `PUBLIC_GOOGLE_CLIENT_ID` and `GOOGLE_CLIENT_SECRET` are set
+- Verify the redirect URI in Google Cloud Console matches your app URL exactly
+
+### Users can't see projects
+
+Organization Members need explicit project-level roles to access projects. Either:
+- Assign them a project role via **Project Settings** → **Members**
+- Promote them to organization Admin (gives access to all projects)

--- a/agents-docs/content/deployment/(docker)/aws-ec2.mdx
+++ b/agents-docs/content/deployment/(docker)/aws-ec2.mdx
@@ -127,9 +127,16 @@ PUBLIC_NANGO_SERVER_URL=http://<vm_external_ip>:3050
 PUBLIC_NANGO_CONNECT_BASE_URL=http://<vm_external_ip>:3051
 PUBLIC_SIGNOZ_URL=http://<vm_external_ip>:3080
 
-# Uncomment and set these to access Manage UI at http://<vm_external_ip>:3000
+# Better Auth secret (paste your generated secret)
+BETTER_AUTH_SECRET=<your-generated-secret>
+
+# Initial admin credentials
 INKEEP_AGENTS_MANAGE_UI_USERNAME=admin@example.com
-INKEEP_AGENTS_MANAGE_UI_PASSWORD=adminADMIN!@12
+INKEEP_AGENTS_MANAGE_UI_PASSWORD=<secure-password-8-chars-min>
+
+# SpiceDB connection, localhost. Can replace with cloud endpoint and preshared key
+SPICEDB_ENDPOINT=localhost:50051
+SPICEDB_PRESHARED_KEY=dev-secret-key
 ```
 
 <Snippet file="self-hosting/runtime-limits-note.mdx" />

--- a/agents-docs/content/deployment/(docker)/docker-local.mdx
+++ b/agents-docs/content/deployment/(docker)/docker-local.mdx
@@ -77,9 +77,16 @@ NANGO_SECRET_KEY=
 # SigNoz
 SIGNOZ_API_KEY=
 
-# Default username and password for Manage UI (http://localhost:3000)
-# INKEEP_AGENTS_MANAGE_UI_USERNAME=admin@example.com
-# INKEEP_AGENTS_MANAGE_UI_PASSWORD=adminADMIN!@12
+# Better Auth secret (paste your generated secret)
+BETTER_AUTH_SECRET=<your-generated-secret>
+
+# Initial admin credentials
+INKEEP_AGENTS_MANAGE_UI_USERNAME=admin@example.com
+INKEEP_AGENTS_MANAGE_UI_PASSWORD=<secure-password-8-chars-min>
+
+# SpiceDB connection, localhost. Can replace with cloud endpoint and preshared key
+SPICEDB_ENDPOINT=localhost:50051
+SPICEDB_PRESHARED_KEY=dev-secret-key
 ```
 
 <Snippet file="self-hosting/runtime-limits-note.mdx" />

--- a/agents-docs/content/deployment/(docker)/gcp-compute-engine.mdx
+++ b/agents-docs/content/deployment/(docker)/gcp-compute-engine.mdx
@@ -143,9 +143,16 @@ PUBLIC_NANGO_SERVER_URL=http://<vm_external_ip>:3050
 PUBLIC_NANGO_CONNECT_BASE_URL=http://<vm_external_ip>:3051
 PUBLIC_SIGNOZ_URL=http://<vm_external_ip>:3080
 
-# Uncomment and set these to access Manage UI at http://<vm_external_ip>:3000
+# Better Auth secret (paste your generated secret)
+BETTER_AUTH_SECRET=<your-generated-secret>
+
+# Initial admin credentials
 INKEEP_AGENTS_MANAGE_UI_USERNAME=admin@example.com
-INKEEP_AGENTS_MANAGE_UI_PASSWORD=adminADMIN!@12
+INKEEP_AGENTS_MANAGE_UI_PASSWORD=<secure-password-8-chars-min>
+
+# SpiceDB connection, localhost. Can replace with cloud endpoint and preshared key
+SPICEDB_ENDPOINT=localhost:50051
+SPICEDB_PRESHARED_KEY=dev-secret-key
 ```
 
 <Snippet file="self-hosting/runtime-limits-note.mdx" />

--- a/agents-docs/content/deployment/(docker)/hetzner.mdx
+++ b/agents-docs/content/deployment/(docker)/hetzner.mdx
@@ -133,8 +133,8 @@ PUBLIC_NANGO_CONNECT_BASE_URL=http://<vm_external_ip>:3051
 PUBLIC_SIGNOZ_URL=http://<vm_external_ip>:3080
 
 # Uncomment and set these to access Manage UI at http://<vm_external_ip>:3000
-INKEEP_AGENTS_MANAGE_UI_USERNAME=admin@example.com
-INKEEP_AGENTS_MANAGE_UI_PASSWORD=adminADMIN!@12
+INKEEP_AGENTS_MANAGE_UI_USERNAME=<email-address>
+INKEEP_AGENTS_MANAGE_UI_PASSWORD=<secure-password-8-chars-min>
 ```
 
 <Snippet file="self-hosting/runtime-limits-note.mdx" />

--- a/agents-docs/content/deployment/(docker)/meta.json
+++ b/agents-docs/content/deployment/(docker)/meta.json
@@ -2,6 +2,7 @@
   "icon": "brand/DockerIcon",
   "pages": [
     "docker-local",
+    "authentication",
     "gcp-compute-engine",
     "gcp-cloud-run",
     "aws-ec2",

--- a/agents-docs/content/visual-builder/access-control.mdx
+++ b/agents-docs/content/visual-builder/access-control.mdx
@@ -1,0 +1,112 @@
+---
+title: Access Control
+description: Multi-tenant authentication with organizations, team management, and fine-grained project permissions
+icon: LuShieldCheck
+---
+
+The Inkeep Agent Framework provides two layers of access control:
+
+| Layer | What it does | Powered by |
+|-------|--------------|------------|
+| **Authentication** | Users sign in, belong to organizations, manage teams | [Better Auth](https://www.better-auth.com/) |
+| **Authorization** | Fine-grained project-level roles and permissions | [SpiceDB](https://authzed.com/spicedb) |
+
+Authentication handles user sign-in and organization membership. Authorization adds granular control over who can do what within each project.
+
+<Note>
+  For deployment configuration including OAuth providers and SpiceDB, see [Authentication Setup](/deployment/authentication).
+</Note>
+
+## Sign-In Methods
+
+| Method | Description |
+|--------|-------------|
+| **Email & Password** | Default sign-in with email and password credentials |
+| **Google** | OAuth sign-in (requires configuration) |
+
+To add Google sign-in, see [Adding OAuth Providers](/deployment/authentication#google-oauth).
+
+<Tip>
+  The framework uses [Better Auth](https://www.better-auth.com/), which supports many authentication plugins including GitHub, Microsoft, SAML, passkeys, and more. See the [Better Auth authentication documentation](https://www.better-auth.com/docs/authentication/email-password) to add additional sign-in methods.
+</Tip>
+
+## Organizations & Team Management
+
+Each organization operates as an isolated tenant:
+
+- **Separate workspaces**: Each organization has its own projects, agents, MCP servers, and credentials
+- **Team collaboration**: Multiple users can belong to the same organization
+- **Role-based access**: Team members have different permission levels
+
+### Organization Roles
+
+| Role | Permissions |
+|------|-------------|
+| **Admin** | Full access to all projects and settings, can add members |
+| **Member** | Access determined by project-level roles |
+
+### Managing Team Members
+
+1. Go to **Settings** in the left sidebar
+2. View current members and their roles
+3. Click **Add** to add new team members
+4. Select a role (Admin or Member) for the new team member
+
+## Project Roles & Permissions
+
+Assign granular roles at the project level to give organization Members specific access to individual projects.
+
+### Role Hierarchy
+
+| Role | View | Use | Edit |
+|------|:----:|:---:|:----:|
+| **Project Admin** | ✓ | ✓ | ✓ |
+| **Project Member** | ✓ | ✓ | ✗ |
+| **Project Viewer** | ✓ | ✗ | ✗ |
+
+### Permission Breakdown
+
+| Permission | What it allows |
+|------------|----------------|
+| **View** | See project configuration, agents, and settings (read-only) |
+| **Use** | Invoke agents, create API keys, view traces |
+| **Edit** | Modify agents, tools, credentials, and project settings |
+
+### Managing Project Members
+
+1. Navigate to your project
+2. Go to **Members**
+3. Search for members by email and select one or more to add
+4. Choose a role for the selected members and click **Add**
+
+<Tip>
+  Organization Admins always have full access to all projects, regardless of project-level roles.
+</Tip>
+
+## User-Scoped vs Project-Scoped Resources
+
+Certain resources can be configured with different scopes:
+
+| Scope | Description |
+|-------|-------------|
+| **Project-scoped** | Shared across all users in the project |
+| **User-scoped** | Configured separately for each user |
+
+### Example: MCP Servers
+
+MCP servers can be configured as either project-scoped or user-scoped:
+
+| Use Case | Recommended Scope |
+|----------|-------------------|
+| Shared company tools (internal APIs, databases) | Project-scoped |
+| Personal integrations (user's Slack, GitHub, email) | User-scoped |
+| Services requiring per-user authorization | User-scoped |
+| Tools where data should be separated by user | User-scoped |
+
+<Tip>
+  You only configure a user-scoped MCP server once. Each user sees the same server but connects with their own credentials. The framework automatically manages the per-user authentication.
+</Tip>
+
+To select the scope, go to **MCP Servers** → create a server → select the scope.
+
+See [MCP Servers](/visual-builder/tools/mcp-servers) for more details.

--- a/agents-docs/content/visual-builder/meta.json
+++ b/agents-docs/content/visual-builder/meta.json
@@ -1,3 +1,11 @@
 {
-  "pages": ["sub-agents", "tools", "headers", "structured-outputs", "context-fetchers", "..."]
+  "pages": [
+    "sub-agents",
+    "tools",
+    "headers",
+    "structured-outputs",
+    "context-fetchers",
+    "access-control",
+    "..."
+  ]
 }

--- a/agents-docs/redirects.json
+++ b/agents-docs/redirects.json
@@ -137,5 +137,10 @@
     "source": "/get-started/inkeep-mcp",
     "destination": "/get-started/ai-coding-setup-for-ide",
     "permanent": true
+  },
+  {
+    "source": "/visual-builder/user-authentication",
+    "destination": "/visual-builder/access-control",
+    "permanent": true
   }
 ]


### PR DESCRIPTION
## Summary

This PR adds new documentation for authentication and access control:

### New Documentation
- **Authentication Guide** (`agents-docs/content/deployment/(docker)/authentication.mdx`) - Documentation for setting up authentication in Docker deployments
- **Access Control Guide** (`agents-docs/content/visual-builder/access-control.mdx`) - Documentation for access control in the visual builder

### Updates
- Improved deployment guides (AWS EC2, GCP Compute Engine, Hetzner, Docker Local)
- Updated meta.json files for proper navigation
- Added redirects for new pages

### Testing
- Documentation builds successfully
- Links and navigation work correctly