### PR TITLE
feat: add Vercel production deployment workflow

### DIFF
--- a/.github/workflows/vercel-production.yml
+++ b/.github/workflows/vercel-production.yml
@@ -9,7 +9,8 @@ name: Deploy to Vercel Production
 # Required secrets (configure in GitHub Repository Settings > Secrets):
 # - VERCEL_TOKEN: API token from Vercel Dashboard > Settings > Tokens
 # - VERCEL_ORG_ID: Organization/team ID from .vercel/project.json after running `vercel link`
-# - VERCEL_PROJECT_ID: Project ID from .vercel/project.json after running `vercel link`
+# - VERCEL_API_PROJECT_ID: Project ID for agents-api
+# - VERCEL_MANAGE_UI_PROJECT_ID: Project ID for agents-manage-ui
 
 on:
   release:
@@ -17,17 +18,26 @@ on:
 
 env:
   VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
-  VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
 
 jobs:
   deploy:
-    name: Deploy to Production
+    name: Deploy ${{ matrix.project.name }}
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        project:
+          - name: agents-api
+            project_id_secret: VERCEL_API_PROJECT_ID
+          - name: agents-manage-ui
+            project_id_secret: VERCEL_MANAGE_UI_PROJECT_ID
     steps:
       - name: Checkout
         uses: actions/checkout@v4
         with:
           ref: ${{ github.event.release.tag_name }}
+
+      - name: Set Project ID
+        run: echo "VERCEL_PROJECT_ID=${{ secrets[matrix.project.project_id_secret] }}" >> $GITHUB_ENV
 
       - name: Install Vercel CLI
         run: npm install -g vercel
@@ -40,7 +50,7 @@ jobs:
 
       - name: Deploy Preview for Checks
         id: deploy
-      run: |
+        run: |
           DEPLOYMENT_URL=$(vercel deploy --prebuilt --token=${{ secrets.VERCEL_TOKEN }})
           if [ -z "$DEPLOYMENT_URL" ]; then
             echo "Error: Failed to capture deployment URL"
@@ -52,8 +62,6 @@ jobs:
       - name: Wait for Deployment Checks
         run: |
           echo "Waiting for Vercel deployment checks to complete..."
-          # Vercel deployment checks are configured in the Vercel dashboard
-          # This step waits for checks to pass before promoting
           vercel inspect ${{ steps.deploy.outputs.url }} --token=${{ secrets.VERCEL_TOKEN }} --wait
 
       - name: Promote to Production


### PR DESCRIPTION
## Summary

- Add GitHub Actions workflow to deploy to Vercel production only when a GitHub release is published
- Enables separation of staging (main branch) and production (release-based) deployments

## Deployment Strategy

| Trigger | Environment | URL |
|---------|-------------|-----|
| Push to PR/branch | Preview | `<branch>-<project>.vercel.app` |
| Push to `main` | Staging (persistent) | `main-<project>.vercel.app` |
| Release published | Production | Production domain |

## Setup Required

### 1. Add GitHub Secrets

| Secret | How to Obtain |
|--------|---------------|
| `VERCEL_TOKEN` | Vercel Dashboard → Settings → Tokens → Create |
| `VERCEL_ORG_ID` | Run `vercel link` locally, check `.vercel/project.json` |
| `VERCEL_PROJECT_ID` | Same as above |

### 2. Vercel Dashboard Configuration

**Project Settings → Git → Production Branch**: Change from `main` to `_disabled_`

This prevents `main` from auto-deploying to production while keeping preview deployments working.

## How It Works

1. PRs and branches get automatic preview deployments (unchanged)
2. Main branch gets persistent staging deployment (now a "preview" not "production")
3. When you publish a GitHub release (from the existing changesets workflow), it triggers production deployment

## Test plan

- [ ] Add required secrets to GitHub
- [ ] Configure Vercel Production Branch setting
- [ ] Merge a PR to main → verify staging deploys but not production
- [ ] Publish a GitHub release → verify production deploys