### PR TITLE
Revert "fix(agents-core): remove refine call in resource id schema"

### DIFF
--- a/packages/agents-core/src/__tests__/validation/schemas.test.ts
+++ b/packages/agents-core/src/__tests__/validation/schemas.test.ts
@@ -38,6 +38,7 @@ describe('Validation Schemas', () => {
         'test/id', // slash
         'test\\id', // backslash
         'a'.repeat(256), // too long
+        'new', // reserved
       ];
 
       for (const id of invalidIds) {

--- a/packages/agents-core/src/validation/schemas.ts
+++ b/packages/agents-core/src/validation/schemas.ts
@@ -124,6 +124,7 @@ export const ResourceIdSchema = z
   .regex(URL_SAFE_ID_PATTERN, {
     message: 'ID must contain only letters, numbers, hyphens, underscores, and dots',
   })
+  .refine((value) => value !== 'new', 'Must not use a reserved name "new"')
   .openapi({
     description: 'Resource identifier',
     example: 'resource_789',


### PR DESCRIPTION
this isn't right, refine on field is totally valid, see https://inkeep.slack.com/archives/C08QXR5CWBH/p1770185644827539?thread_ts=1770185353.023009&cid=C08QXR5CWBH