### PR TITLE
fix: use correct 'prompt' input for claude-code-action@v1

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -44,7 +44,7 @@ jobs:
           claude_args: |
             --agent pr-review
             --allowedTools "Task,Read,Grep,Glob,Bash(git diff:*),Bash(git log:*),Bash(git show:*),Bash(git merge-base:*),Bash(gh pr comment:*)"
-          direct_prompt: |
+          prompt: |
             Review this pull request.
 
             Base branch: ${{ github.event.pull_request.base.ref }}


### PR DESCRIPTION
## Summary

The `@v1` version of `claude-code-action` renamed `direct_prompt` to `prompt`. This was missed when upgrading from `@beta` in PR #1680.

## Changes

- Rename `direct_prompt` → `prompt` in `.github/workflows/claude-code-review.yml`

## Why

Without this fix, the custom review prompt is ignored and Claude doesn't receive the PR review instructions.