### PR TITLE
feat(pr-review): add deduplication context and inline comment support

### DIFF
--- a/.claude/agents/pr-review-architecture.md
+++ b/.claude/agents/pr-review-architecture.md
@@ -5,36 +5,6 @@ description: |
   Spawned by pr-review orchestrator for code changes that introduce new patterns or modify system boundaries.
   Focus: macro-level system design and precedent-setting.
 
-  <example>
-  Context: Orchestrator dispatches architecture review for new service or abstraction
-  user: "Review these files for architecture concerns: src/services/newService.ts, src/lib/newPattern.ts"
-  assistant: "New patterns and abstractions detected. I'll review for system design consistency."
-  <commentary>
-  New code introducing patterns/abstractions matches this reviewer's scope.
-  </commentary>
-  assistant: "Evaluating against existing system design and returning architecture findings."
-  </example>
-
-  <example>
-  Context: User asks about a bug (not system design)
-  user: "Is there a null pointer issue in this code?"
-  assistant: "That's a code correctness question, not system design."
-  <commentary>
-  Bug detection is out of scope for architecture review.
-  </commentary>
-  assistant: "Code correctness is out of scope. I focus on system design and patterns."
-  </example>
-
-  <example>
-  Context: Simple bug fix with no architectural implications
-  user: "Review this one-line null check fix: src/utils/helpers.ts"
-  assistant: "This is a localized bug fix with no architectural impact."
-  <commentary>
-  Trivial fixes without pattern/abstraction changes are outside architecture review scope.
-  </commentary>
-  assistant: "No architecture concerns for this change. Returning empty findings."
-  </example>
-
 tools: Read, Grep, Glob, Bash
 disallowedTools: Write, Edit, Task
 skills:
@@ -147,8 +117,9 @@ Things AI agents and junior engineers often miss at the system level:
 
 # Workflow
 
-1. **Understand intent** — What is this PR trying to accomplish at a system level?
-2. **Research prior art** — Use Grep/Glob to find similar patterns in the codebase
+1. **Fetch the PR diff** — Run `gh pr diff [PR_NUMBER]` to see all changes
+2. **Understand intent** — What is this PR trying to accomplish at a system level?
+3. **Research prior art** — Use Grep/Glob to find similar patterns in the codebase
 3. **Evaluate consistency** — Does this fit with what exists?
 4. **Assess evolvability** — Will this age well? Will we regret this?
 5. **Check boundaries** — Are transaction/consistency boundaries clear?

--- a/.claude/agents/pr-review-breaking-changes.md
+++ b/.claude/agents/pr-review-breaking-changes.md
@@ -4,41 +4,6 @@ description: |
   Reviews for breaking changes in schema, migration, env, and contract files.
   Spawned by pr-review orchestrator when these file types are detected.
 
-  Use when: reviewing schema changes, migrations, env variable additions, API contract modifications.
-  Avoid using for: implementation tasks, non-schema files, general code review.
-
-  <example>
-  Context: Orchestrator dispatches breaking-changes review for schema and migration files
-  user: "Review these files for breaking changes: src/db/manage/manage-schema.ts, drizzle/manage/0003_migration.sql"
-  assistant: "These are schema and migration files that need breaking change analysis."
-  <commentary>
-  Schema + migration files + explicit review request matches this subagent's scope.
-  The preloaded data-model-changes skill provides the evaluation checklist.
-  </commentary>
-  assistant: "I'll evaluate these against data-model-changes standards and return JSON findings."
-  </example>
-
-  <example>
-  Context: Orchestrator dispatches for env.ts changes
-  user: "Review these files for breaking changes: agents-api/src/env.ts, .env.example"
-  assistant: "Env configuration files need adding-env-variables checklist review."
-  <commentary>
-  Env files match this subagent's scope. The preloaded adding-env-variables skill provides the checklist.
-  </commentary>
-  assistant: "I'll check for missing .describe() calls and .env.example sync."
-  </example>
-
-  <example>
-  Context: User asks for implementation help (near-miss)
-  user: "Can you add a new column to this schema and generate the migration?"
-  assistant: "This is an edit request. I'm a read-only reviewer and cannot modify files."
-  <commentary>
-  Edit/implementation requests do not match read-only reviewer scope.
-  Refuse and explain the constraint; do not attempt to edit.
-  </commentary>
-  assistant: "I can only review files for breaking changes. Please use a different agent for edits."
-  </example>
-
 tools: Read, Grep, Glob, Bash
 disallowedTools: Write, Edit, Task
 skills:
@@ -70,7 +35,7 @@ Review files for compliance with preloaded skill standards.
 
 # Workflow
 
-1. Receive file list from orchestrator
+1. **Fetch the PR diff** — Run `gh pr diff [PR_NUMBER]` to see all changes
 2. Read each file using the Read tool
 3. Evaluate against skill checklists:
    - Schema/migration files: `data-model-changes` checklist

--- a/.claude/agents/pr-review-comments.md
+++ b/.claude/agents/pr-review-comments.md
@@ -1,13 +1,8 @@
 ---
 name: pr-review-comments
 description: |
-  Use this agent when you need to analyze code comments for accuracy, completeness, and long-term maintainability. This includes: (1) After generating large documentation comments or docstrings, (2) Before finalizing a pull request that adds or modifies comments, (3) When reviewing existing comments for potential technical debt or comment rot, (4) When you need to verify that comments accurately reflect the code they describe.
-
-  <example>
-  Context: Orchestrator dispatches comment review for files with significant comments
-  user: "Review comments for accuracy: src/api/client.ts, src/services/auth.ts"
-  assistant: "I'll use the pr-review-comments agent to verify that the comments are accurate against the actual code."
-  </example>
+  Reviews code comments for accuracy, staleness, and misleading information.
+  Spawned by pr-review orchestrator for files with significant JSDoc or inline comments.
 
 tools: Read, Grep, Glob, Bash
 disallowedTools: Write, Edit, Task
@@ -22,6 +17,8 @@ You are a meticulous code comment analyzer with deep expertise in technical docu
 Your primary mission is to protect codebases from comment rot by ensuring every comment adds genuine value and remains accurate as code evolves. You analyze comments through the lens of a developer encountering the code months or years later, potentially without context about the original implementation.
 
 When analyzing comments, you will:
+
+0. **Fetch the PR diff** — Run `gh pr diff [PR_NUMBER]` to see all changes
 
 1. **Verify Factual Accuracy**: Cross-reference every claim in the comment against the actual code implementation. Check:
    - Function signatures match documented parameters and return types

--- a/.claude/agents/pr-review-customer-impact.md
+++ b/.claude/agents/pr-review-customer-impact.md
@@ -4,36 +4,6 @@ description: |
   Customer impact reviewer. Evaluates PRs for breaking changes, API contract stability, UX implications, and configuration complexity.
   Spawned by pr-review orchestrator for changes to APIs, SDKs, UI components, or customer-facing interfaces.
 
-  <example>
-  Context: Orchestrator dispatches customer impact review for API changes
-  user: "Review these files for customer impact: src/api/endpoints.ts, src/types/responses.ts"
-  assistant: "API and response type changes detected. I'll review for breaking changes and customer impact."
-  <commentary>
-  API/type changes affecting customers match this reviewer's scope.
-  </commentary>
-  assistant: "Evaluating customer-facing contracts and returning impact findings."
-  </example>
-
-  <example>
-  Context: User asks for implementation help (not review)
-  user: "Can you add a new field to this API response?"
-  assistant: "This is an implementation request. I'm a read-only reviewer and cannot modify files."
-  <commentary>
-  Implementation requests do not match read-only reviewer role.
-  </commentary>
-  assistant: "I can identify customer impact concerns but cannot make edits. Use a different agent."
-  </example>
-
-  <example>
-  Context: Internal-only code with no customer exposure
-  user: "Review this internal utility: src/internal/helpers.ts"
-  assistant: "This is internal code with no customer-facing surface."
-  <commentary>
-  Internal utilities without customer exposure are outside this reviewer's scope.
-  </commentary>
-  assistant: "No customer impact concerns for internal code. Returning empty findings."
-  </example>
-
 tools: Read, Grep, Glob, Bash
 disallowedTools: Write, Edit, Task
 skills:
@@ -120,8 +90,9 @@ Things that frequently cause customer pain:
 
 # Workflow
 
-1. **Identify customer-facing surfaces** — What in this PR do customers interact with?
-2. **Check for breaking changes** — Compare before/after contracts
+1. **Fetch the PR diff** — Run `gh pr diff [PR_NUMBER]` to see all changes
+2. **Identify customer-facing surfaces** — What in this PR do customers interact with?
+3. **Check for breaking changes** — Compare before/after contracts
 3. **Evaluate edge cases** — How might this fail for customers?
 4. **Assess configuration** — Is this adding complexity?
 5. **Check modality parity** — Is this consistent across interfaces?

--- a/.claude/agents/pr-review-docs.md
+++ b/.claude/agents/pr-review-docs.md
@@ -5,36 +5,6 @@ description: |
   Spawned by pr-review orchestrator for MD/MDX files.
   Avoid using for: non-docs files, implementation/edit tasks.
 
-  <example>
-  Context: Orchestrator dispatches docs review for changed MD/MDX files
-  user: "Review these documentation files: docs/getting-started.md, README.md"
-  assistant: "I'll review these docs files against write-docs standards."
-  <commentary>
-  Docs files + review request -> pr-review-docs is the right subagent.
-  </commentary>
-  assistant: "Evaluating documentation quality and returning findings as JSON."
-  </example>
-
-  <example>
-  Context: User asks for implementation help
-  user: "Can you fix the typo in this README?"
-  assistant: "This is an edit request, not a review. I'm a read-only reviewer."
-  <commentary>
-  Edit/implementation request -> do not use read-only reviewer subagent.
-  </commentary>
-  assistant: "I can only review files, not edit them. Please use a different agent."
-  </example>
-
-  <example>
-  Context: User provides code files instead of docs
-  user: "Review these files: src/utils.ts, lib/helpers.js"
-  assistant: "These are code files, not documentation."
-  <commentary>
-  Non-docs files -> do not use pr-review-docs; orchestrator should route elsewhere.
-  </commentary>
-  assistant: "I review documentation files only. Return [] for non-docs."
-  </example>
-
 tools: Read, Grep, Glob, Bash
 disallowedTools: Write, Edit, Task
 skills:
@@ -62,7 +32,7 @@ Review documentation files for compliance with **write-docs skill standards**.
 
 # Workflow
 
-1. **Receive file list** from orchestrator prompt
+1. **Fetch the PR diff** — Run `gh pr diff [PR_NUMBER]` to see doc changes
 2. **Read each file** using Read tool
 3. **Evaluate against write-docs skill** - use the skill's verification checklist as your rubric:
    - Frontmatter (title, sidebarTitle, description)

--- a/.claude/agents/pr-review-errors.md
+++ b/.claude/agents/pr-review-errors.md
@@ -1,13 +1,8 @@
 ---
 name: pr-review-errors
 description: |
-  Use this agent when reviewing code changes in a pull request to identify silent failures, inadequate error handling, and inappropriate fallback behavior. This agent should be invoked proactively after completing a logical chunk of work that involves error handling, catch blocks, fallback logic, or any code that could potentially suppress errors.
-
-  <example>
-  Context: Orchestrator dispatches error handling review for changed TS files
-  user: "Review these files for error handling: src/api/client.ts, src/services/auth.ts"
-  assistant: "I'll use the pr-review-errors agent to thoroughly examine the error handling in these changes."
-  </example>
+  Reviews code for silent failures, inadequate error handling, and inappropriate fallback behavior.
+  Spawned by pr-review orchestrator for files with try/catch blocks, .catch(), or error handling patterns.
 
 tools: Read, Grep, Glob, Bash
 disallowedTools: Write, Edit, Task
@@ -32,6 +27,10 @@ You operate under these non-negotiable rules:
 ## Your Review Process
 
 When examining a PR, you will:
+
+### 0. Fetch the PR Diff
+
+Run `gh pr diff [PR_NUMBER]` to get the full diff, then proceed with analysis.
 
 ### 1. Identify All Error Handling Code
 

--- a/.claude/agents/pr-review-frontend.md
+++ b/.claude/agents/pr-review-frontend.md
@@ -1,42 +1,8 @@
 ---
 name: pr-review-frontend
 description: |
-  Read-only React/Next.js code reviewer. Spawned by pr-review orchestrator when frontend files are detected.
-  Reviews against preloaded skills: vercel-react-best-practices, vercel-composition-patterns, next-best-practices.
-  Returns Finding[] JSON per pr-review-output-contract schema.
-
-  Use for: frontend code review of .tsx/.jsx files, app/ pages/ components/ hooks/ lib/ directories.
-  Avoid for: non-frontend files, implementation/fix requests, backend code.
-
-  <example>
-  Context: Orchestrator dispatches frontend review for changed TSX/JSX files
-  user: "Review these frontend files: app/dashboard/page.tsx, components/Button.tsx"
-  assistant: "Frontend files detected. I'll review against React/Next.js best practices and return structured findings."
-  <commentary>
-  Frontend file review request matches trigger. Return Finding[] JSON for orchestrator aggregation.
-  </commentary>
-  assistant: "Evaluating against loaded skills and returning JSON findings array."
-  </example>
-
-  <example>
-  Context: User asks for implementation help (not review)
-  user: "Fix the re-render issue in Button.tsx"
-  assistant: "This is an implementation request. I'm a read-only reviewer and cannot edit files."
-  <commentary>
-  Edit/fix requests do not match read-only reviewer role. Do not delegate.
-  </commentary>
-  assistant: "I can identify issues but cannot make edits. Use a different agent for fixes."
-  </example>
-
-  <example>
-  Context: Non-frontend file passed to reviewer
-  user: "Review these files: api/routes/users.ts, lib/db.ts"
-  assistant: "These are backend files, not frontend. I'll return an empty findings array."
-  <commentary>
-  Non-frontend files are outside scope. Return empty array, don't force findings.
-  </commentary>
-  assistant: "Returning [] since no frontend files were provided."
-  </example>
+  React/Next.js code reviewer. Reviews against vercel-react-best-practices, vercel-composition-patterns, next-best-practices.
+  Spawned by pr-review orchestrator for .tsx/.jsx files in app/, pages/, components/, hooks/, lib/.
 
 tools: Read, Grep, Glob, Bash
 disallowedTools: Write, Edit, Task
@@ -75,7 +41,7 @@ Do not re-explain rules that are documented in skills. Focus findings on specifi
 
 # Workflow
 
-1. Receive file list from orchestrator handoff
+1. **Fetch the PR diff** — Run `gh pr diff [PR_NUMBER]` to see all changes
 2. Read each file using Read tool
 3. Evaluate against skill standards
 4. Create Finding objects per `pr-review-output-contract` schema

--- a/.claude/agents/pr-review-standards.md
+++ b/.claude/agents/pr-review-standards.md
@@ -5,36 +5,6 @@ description: |
   Spawned by pr-review orchestrator for all code changes (always runs).
   Focus: micro-level code correctness and cleanliness.
 
-  <example>
-  Context: Orchestrator dispatches standards review for changed source files
-  user: "Review these files for code quality: src/api/client.ts, src/services/auth.ts"
-  assistant: "I'll review the code for bugs, security issues, and AGENTS.md compliance."
-  <commentary>
-  Code files + review request matches this reviewer. Check AGENTS.md first, then analyze code quality.
-  </commentary>
-  assistant: "Evaluating code quality and returning findings."
-  </example>
-
-  <example>
-  Context: User asks about system-level patterns (not code quality)
-  user: "Is this the right abstraction for handling payments?"
-  assistant: "That's a system design question, not code quality."
-  <commentary>
-  Abstraction and pattern questions are out of scope for code quality review.
-  </commentary>
-  assistant: "System design is out of scope. I focus on code correctness and cleanliness."
-  </example>
-
-  <example>
-  Context: User asks for implementation help (not review)
-  user: "Can you fix this null pointer bug?"
-  assistant: "This is an implementation request. I'm a read-only reviewer."
-  <commentary>
-  Implementation requests do not match read-only reviewer role.
-  </commentary>
-  assistant: "I can identify the issue but cannot make edits. Use a different agent."
-  </example>
-
 tools: Read, Grep, Glob, Bash
 disallowedTools: Write, Edit, Task
 skills:
@@ -143,11 +113,12 @@ You may be reviewing work from an AI agent or junior engineer. Watch for these i
 
 # Review Process
 
-1. **Read AGENTS.md first** — understand project-specific rules
-2. **Check scope** — are all changes necessary for the stated goal?
-3. **Analyze each file** against the code quality checklist
-4. **Detect bugs** that will cause runtime issues
-5. **Filter aggressively** — only report ≥80% confidence
+1. **Fetch the PR diff** — Run `gh pr diff [PR_NUMBER]` to get the changes
+2. **Read AGENTS.md first** — understand project-specific rules
+3. **Check scope** — are all changes necessary for the stated goal?
+4. **Analyze each file** against the code quality checklist
+5. **Detect bugs** that will cause runtime issues
+6. **Filter aggressively** — only report ≥80% confidence
 
 # Confidence Scoring
 

--- a/.claude/agents/pr-review-tests.md
+++ b/.claude/agents/pr-review-tests.md
@@ -1,13 +1,8 @@
 ---
 name: pr-review-tests
 description: |
-  Use this agent when you need to review a pull request for test coverage quality and completeness. This agent should be invoked after a PR is created or updated to ensure tests adequately cover new functionality and edge cases.
-
-  <example>
-  Context: Orchestrator dispatches test review for changed test files
-  user: "Review test coverage for: src/api/client.test.ts, src/services/auth.spec.ts"
-  assistant: "I'll use the pr-review-tests agent to review the test coverage and identify any critical gaps."
-  </example>
+  Reviews test coverage quality and completeness. Identifies untested critical paths, edge cases, and error conditions.
+  Spawned by pr-review orchestrator for test files or files with missing test coverage.
 
 tools: Read, Grep, Glob, Bash
 disallowedTools: Write, Edit, Task
@@ -44,12 +39,13 @@ You are an expert test coverage analyst specializing in pull request review. You
 
 **Analysis Process:**
 
-1. First, examine the PR's changes to understand new functionality and modifications
-2. Review the accompanying tests to map coverage to functionality
-3. Identify critical paths that could cause production issues if broken
-4. Check for tests that are too tightly coupled to implementation
-5. Look for missing negative cases and error scenarios
-6. Consider integration points and their test coverage
+1. **Fetch the PR diff:** Run `gh pr diff [PR_NUMBER]` to get the full diff
+2. Examine the PR's changes to understand new functionality and modifications
+3. Review the accompanying tests to map coverage to functionality
+4. Identify critical paths that could cause production issues if broken
+5. Check for tests that are too tightly coupled to implementation
+6. Look for missing negative cases and error scenarios
+7. Consider integration points and their test coverage
 
 **Rating Guidelines:**
 - 9-10: Critical functionality that could cause data loss, security issues, or system failures

--- a/.claude/agents/pr-review-types.md
+++ b/.claude/agents/pr-review-types.md
@@ -1,13 +1,8 @@
 ---
 name: pr-review-types
 description: |
-  Use this agent when you need expert analysis of type design in your codebase. Specifically use it: (1) when introducing a new type to ensure it follows best practices for encapsulation and invariant expression, (2) during pull request creation to review all types being added, (3) when refactoring existing types to improve their design quality. The agent will provide both qualitative feedback and quantitative ratings on encapsulation, invariant expression, usefulness, and enforcement.
-
-  <example>
-  Context: Orchestrator dispatches type review for new interfaces
-  user: "Review type design for: src/types/user.ts, src/models/order.ts"
-  assistant: "I'll use the pr-review-types agent to review the type design and invariant quality."
-  </example>
+  Reviews type design for encapsulation, invariant expression, and type safety.
+  Spawned by pr-review orchestrator for files in types/, models/, or containing new interfaces/types.
 
 tools: Read, Grep, Glob, Bash
 disallowedTools: Write, Edit, Task
@@ -23,6 +18,8 @@ You are a type design expert with extensive experience in large-scale software a
 You evaluate type designs with a critical eye toward invariant strength, encapsulation quality, and practical usefulness. You believe that well-designed types are the foundation of maintainable, bug-resistant software systems.
 
 **Analysis Framework:**
+
+**First:** Fetch the PR diff by running `gh pr diff [PR_NUMBER]` to see all type changes.
 
 When analyzing a type, you will:
 

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -63,10 +63,12 @@ jobs:
                       isOutdated
                       path
                       line
+                      diffSide
                       comments(first: 1) {
                         nodes {
                           author { login }
                           body
+                          diffHunk
                         }
                       }
                     }
@@ -80,13 +82,44 @@ jobs:
           echo "$THREADS" >> $GITHUB_OUTPUT
           echo "EOF" >> $GITHUB_OUTPUT
 
+      - name: Get PR Comments
+        id: pr_comments
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          # Fetch PR comments, include humans + our bot, exclude other bots
+          COMMENTS=$(gh api graphql -f query='
+            query($owner: String!, $repo: String!, $pr: Int!) {
+              repository(owner: $owner, name: $repo) {
+                pullRequest(number: $pr) {
+                  comments(first: 50) {
+                    nodes {
+                      author {
+                        __typename
+                        login
+                      }
+                      body
+                      createdAt
+                    }
+                  }
+                }
+              }
+            }
+          ' -f owner="${{ github.repository_owner }}" \
+            -f repo="${{ github.event.repository.name }}" \
+            -F pr=${{ github.event.pull_request.number }} \
+            --jq '[.data.repository.pullRequest.comments.nodes[] | select(.author.__typename == "User" or (.author.login | test("github-actions|claude"; "i")))]')
+          
+          echo "pr_comments<<EOF" >> $GITHUB_OUTPUT
+          echo "$COMMENTS" >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
+
       - name: Run PR Review
         uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           track_progress: true
           include_fix_links: true
-          use_sticky_comment: true
           claude_args: |
             --agent pr-review
             --allowedTools "Task,Read,Grep,Glob,mcp__github_inline_comment__create_inline_comment,Bash(git diff:*),Bash(git log:*),Bash(git show:*),Bash(git merge-base:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)"
@@ -97,7 +130,7 @@ jobs:
             **Base:** ${{ github.event.pull_request.base.ref }}
             **Author:** ${{ github.event.pull_request.user.login }}
 
-            ## Description
+            ## Description (User defined, may not be up to date//fully reflect scope)
             ${{ github.event.pull_request.body }}
 
             ## Changed Files
@@ -113,10 +146,13 @@ jobs:
             ${{ steps.diff.outputs.truncated == 'true' && '> **Note:** Diff was truncated. Use `gh pr diff` if you need the full diff for judgment.' || '' }}
 
             ## Existing Inline Comments (for deduplication)
-            Use this to avoid posting duplicate inline comments. Each object has: `isResolved`, `isOutdated`, `path`, `line`, and first comment `body`/`author`.
+            Use this to avoid posting duplicate inline comments. Each object has: `isResolved`, `isOutdated`, `path`, `line`, `diffSide`, and first comment with `body`, `author`, and `diffHunk` (code context).
             ```json
             ${{ steps.threads.outputs.review_threads }}
             ```
 
-            Skip Phase 1 (Analyze Diff) - context is provided above.
-            Proceed directly to Phase 2 (Select Reviewers), then dispatch reviewers and aggregate findings.
+            ## PR Discussion (general comments)
+            Prior discussion on this PR (humans + your previous comments). Use to avoid re-raising addressed issues.
+            ```json
+            ${{ steps.pr_comments.outputs.pr_comments }}
+            ```


### PR DESCRIPTION
## Summary

Enhances the Claude PR review system with:
- **Deduplication context** — Pre-fetches existing review threads and PR discussion so the reviewer avoids posting duplicate findings
- **Inline comment support** — HIGH confidence, localized fixes are now posted as inline comments (max 15 per PR)
- **Improved context passing** — Diff passed directly in prompt (capped at 500KB), plus PR metadata

## Changes

### Workflow (`claude-code-review.yml`)

| Change | Purpose |
|--------|---------|
| `Get Existing Review Threads` step | Fetches inline comments via GraphQL (`isResolved`, `isOutdated`, `path`, `line`, `diffHunk`) |
| `Get PR Comments` step | Fetches general PR discussion (humans + our bot, excludes other bots) |
| Diff in prompt (not temp file) | 500KB cap with `[TRUNCATED]` marker if exceeded |
| `direct_prompt` → `prompt` | Fix deprecated parameter |
| Add inline comment MCP tool | `mcp__github_inline_comment__create_inline_comment` |

### Orchestrator (`pr-review.md`)

| Phase | Change |
|-------|--------|
| **Phase 1** | Documents all context sources (metadata, diff, inline comments, PR discussion) |
| **Phase 1.1** (NEW) | Explore subagent step for deeper context gathering |
| **Phase 2** | Reorganized reviewer table (skill-based vs problem detection) |
| **Phase 4** | Improved filtering and conflict resolution guidance |
| **Phase 5** (NEW) | Inline comments: identify eligible findings → deduplicate → post via MCP |
| **Phase 6** | Summary with deduplication against PR discussion |

### Inline Comment Eligibility

A finding is posted inline if **ALL** are true:
- `confidence: HIGH`
- `severity: CRITICAL`, `MAJOR`, or `MINOR`
- `type: "inline"` (line-specific)
- Fix scope: same file, ~1–10 lines
- One clear best-practice fix (not "consider X")

## Test Plan

- [ ] Open a new PR and verify review threads are fetched
- [ ] Verify PR discussion is fetched and passed to orchestrator
- [ ] Verify inline comments are posted for eligible findings
- [ ] Verify duplicate inline comments are skipped when re-running review
- [ ] Verify summary excludes findings already posted as inline comments