### PR TITLE
refactor(pr-review): Write PR context to temp file for all agents

### DIFF
--- a/.claude/agents/pr-review-architecture.md
+++ b/.claude/agents/pr-review-architecture.md
@@ -117,7 +117,7 @@ Things AI agents and junior engineers often miss at the system level:
 
 # Workflow
 
-1. **Fetch the PR diff** — Run `gh pr diff [PR_NUMBER]` to see all changes
+1. **Read the PR context** — Read `/tmp/pr-context.md` using the **Read** tool (!important) to see the diff, changed files, and PR metadata
 2. **Understand intent** — What is this PR trying to accomplish at a system level?
 3. **Research prior art** — Use Grep/Glob to find similar patterns in the codebase
 3. **Evaluate consistency** — Does this fit with what exists?

--- a/.claude/agents/pr-review-breaking-changes.md
+++ b/.claude/agents/pr-review-breaking-changes.md
@@ -35,8 +35,8 @@ Review files for compliance with preloaded skill standards.
 
 # Workflow
 
-1. **Fetch the PR diff** — Run `gh pr diff [PR_NUMBER]` to see all changes
-2. Read each file using the Read tool
+1. **Read the PR context** — Read `/tmp/pr-context.md` using the **Read** tool (!important) to see the diff, changed files, and PR metadata
+2. Read each file using the **Read** tool (!important)
 3. Evaluate against skill checklists:
    - Schema/migration files: `data-model-changes` checklist
    - Env files: `adding-env-variables` checklist

--- a/.claude/agents/pr-review-comments.md
+++ b/.claude/agents/pr-review-comments.md
@@ -18,7 +18,7 @@ Your primary mission is to protect codebases from comment rot by ensuring every 
 
 When analyzing comments, you will:
 
-0. **Fetch the PR diff** — Run `gh pr diff [PR_NUMBER]` to see all changes
+0. **Read the PR context** — Read `/tmp/pr-context.md` using the **Read** tool (!important) to see the diff, changed files, and PR metadata
 
 1. **Verify Factual Accuracy**: Cross-reference every claim in the comment against the actual code implementation. Check:
    - Function signatures match documented parameters and return types

--- a/.claude/agents/pr-review-customer-impact.md
+++ b/.claude/agents/pr-review-customer-impact.md
@@ -90,7 +90,7 @@ Things that frequently cause customer pain:
 
 # Workflow
 
-1. **Fetch the PR diff** — Run `gh pr diff [PR_NUMBER]` to see all changes
+1. **Read the PR context** — Read `/tmp/pr-context.md` using the **Read** tool (!important) to see the diff, changed files, and PR metadata
 2. **Identify customer-facing surfaces** — What in this PR do customers interact with?
 3. **Check for breaking changes** — Compare before/after contracts
 3. **Evaluate edge cases** — How might this fail for customers?

--- a/.claude/agents/pr-review-docs.md
+++ b/.claude/agents/pr-review-docs.md
@@ -32,7 +32,7 @@ Review documentation files for compliance with **write-docs skill standards**.
 
 # Workflow
 
-1. **Fetch the PR diff** — Run `gh pr diff [PR_NUMBER]` to see doc changes
+1. **Read the PR context** — Read `/tmp/pr-context.md` using the **Read** tool (!important) to see the diff, changed files, and PR metadata
 2. **Read each file** using Read tool
 3. **Evaluate against write-docs skill** - use the skill's verification checklist as your rubric:
    - Frontmatter (title, sidebarTitle, description)

--- a/.claude/agents/pr-review-errors.md
+++ b/.claude/agents/pr-review-errors.md
@@ -28,9 +28,9 @@ You operate under these non-negotiable rules:
 
 When examining a PR, you will:
 
-### 0. Fetch the PR Diff
+### 0. Read the PR Context
 
-Run `gh pr diff [PR_NUMBER]` to get the full diff, then proceed with analysis.
+Read the PR context from `/tmp/pr-context.md` using the **Read** tool (!important) to see the diff, changed files, and PR metadata. Then proceed with analysis.
 
 ### 1. Identify All Error Handling Code
 

--- a/.claude/agents/pr-review-frontend.md
+++ b/.claude/agents/pr-review-frontend.md
@@ -41,7 +41,7 @@ Do not re-explain rules that are documented in skills. Focus findings on specifi
 
 # Workflow
 
-1. **Fetch the PR diff** — Run `gh pr diff [PR_NUMBER]` to see all changes
+1. **Read the PR context** — Read `/tmp/pr-context.md` using the **Read** tool (!important) to see the diff, changed files, and PR metadata
 2. Read each file using Read tool
 3. Evaluate against skill standards
 4. Create Finding objects per `pr-review-output-contract` schema

--- a/.claude/agents/pr-review-standards.md
+++ b/.claude/agents/pr-review-standards.md
@@ -113,7 +113,7 @@ You may be reviewing work from an AI agent or junior engineer. Watch for these i
 
 # Review Process
 
-1. **Fetch the PR diff** — Run `gh pr diff [PR_NUMBER]` to get the changes
+1. **Read the PR context** — Read `/tmp/pr-context.md` using the **Read** tool (!important) to see the diff, changed files, and PR metadata
 2. **Read AGENTS.md first** — understand project-specific rules
 3. **Check scope** — are all changes necessary for the stated goal?
 4. **Analyze each file** against the code quality checklist

--- a/.claude/agents/pr-review-tests.md
+++ b/.claude/agents/pr-review-tests.md
@@ -39,7 +39,7 @@ You are an expert test coverage analyst specializing in pull request review. You
 
 **Analysis Process:**
 
-1. **Fetch the PR diff:** Run `gh pr diff [PR_NUMBER]` to get the full diff
+1. **Read the PR context** — Read `/tmp/pr-context.md` using the **Read** tool (!important) to see the diff, changed files, and PR metadata
 2. Examine the PR's changes to understand new functionality and modifications
 3. Review the accompanying tests to map coverage to functionality
 4. Identify critical paths that could cause production issues if broken

--- a/.claude/agents/pr-review-types.md
+++ b/.claude/agents/pr-review-types.md
@@ -19,7 +19,7 @@ You evaluate type designs with a critical eye toward invariant strength, encapsu
 
 **Analysis Framework:**
 
-**First:** Fetch the PR diff by running `gh pr diff [PR_NUMBER]` to see all type changes.
+**First:** Read the PR context from `/tmp/pr-context.md` using the **Read** tool (!important) to see the diff, changed files, and PR metadata.
 
 When analyzing a type, you will:
 

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -114,6 +114,59 @@ jobs:
           echo "$COMMENTS" >> $GITHUB_OUTPUT
           echo "EOF" >> $GITHUB_OUTPUT
 
+      - name: Write PR Context to Temp File
+        run: |
+          cat > /tmp/pr-context.md << 'PRCONTEXT_EOF'
+          # PR Review Context
+
+          Use this context to:
+          1. Get an initial sense of the purpose and scope of the changes
+          2. Note what's already been flagged or discussed
+          3. Identify if previous feedback was addressed or ignored
+
+          ---
+
+          ## PR Metadata
+
+          **PR #${{ github.event.pull_request.number }}:** ${{ github.event.pull_request.title }}
+          **Base:** ${{ github.event.pull_request.base.ref }}
+          **Author:** ${{ github.event.pull_request.user.login }}
+
+          ## Description
+          Author-provided description (may not fully reflect actual scope):
+
+          ${{ github.event.pull_request.body }}
+
+          ## Changed Files
+          Use for routing to appropriate reviewers:
+          ```
+          ${{ steps.diff.outputs.changed_files }}
+          ```
+
+          ## Diff
+          ${{ steps.diff.outputs.truncated == 'true' && '> **Note:** Diff was truncated due to size. Use `gh pr diff` to fetch the full diff.' || '' }}
+          ```diff
+          ${{ steps.diff.outputs.diff_content }}
+          ```
+
+          ## Existing Inline Comments
+          Prior review threads on specific lines. Each object has: `isResolved`, `isOutdated`, `path`, `line`, `diffSide`, and first comment with `body`, `author`, and `diffHunk` context. Use to avoid posting duplicate inline comments.
+          ```json
+          ${{ steps.threads.outputs.review_threads }}
+          ```
+
+          ## PR Discussion
+          General comments from humans and previous review summaries. Use to avoid re-raising addressed issues.
+          ```json
+          ${{ steps.pr_comments.outputs.pr_comments }}
+          ```
+
+          > **IMPORTANT:** Do NOT re-raise issues that have already been flagged, dismissed, or addressed in prior comments. You may allude to unresolved important items briefly, but do not restate details already covered.
+
+          PRCONTEXT_EOF
+          
+          echo "PR context written to /tmp/pr-context.md ($(wc -c < /tmp/pr-context.md) bytes)"
+
       - name: Run PR Review
         uses: anthropics/claude-code-action@v1
         with:
@@ -124,35 +177,4 @@ jobs:
             --agent pr-review
             --allowedTools "Task,Read,Grep,Glob,mcp__github_inline_comment__create_inline_comment,Bash(git diff:*),Bash(git log:*),Bash(git show:*),Bash(git merge-base:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)"
           prompt: |
-            Review this pull request.
-
-            **PR #${{ github.event.pull_request.number }}:** ${{ github.event.pull_request.title }}
-            **Base:** ${{ github.event.pull_request.base.ref }}
-            **Author:** ${{ github.event.pull_request.user.login }}
-
-            ## Description (User defined, may not be up to date//fully reflect scope)
-            ${{ github.event.pull_request.body }}
-
-            ## Changed Files
-            ```
-            ${{ steps.diff.outputs.changed_files }}
-            ```
-
-            ## Diff
-            ```diff
-            ${{ steps.diff.outputs.diff_content }}
-            ```
-
-            ${{ steps.diff.outputs.truncated == 'true' && '> **Note:** Diff was truncated. Use `gh pr diff` if you need the full diff for judgment.' || '' }}
-
-            ## Existing Inline Comments (for deduplication)
-            Use this to avoid posting duplicate inline comments. Each object has: `isResolved`, `isOutdated`, `path`, `line`, `diffSide`, and first comment with `body`, `author`, and `diffHunk` (code context).
-            ```json
-            ${{ steps.threads.outputs.review_threads }}
-            ```
-
-            ## PR Discussion (general comments)
-            Prior discussion on this PR (humans + your previous comments). Use to avoid re-raising addressed issues.
-            ```json
-            ${{ steps.pr_comments.outputs.pr_comments }}
-            ```
+            Review PR #${{ github.event.pull_request.number }}.


### PR DESCRIPTION
## Summary

Refactors the PR review workflow to write the full PR context to a temp file (`/tmp/pr-context.md`) that all agents read from, instead of having each subagent independently call `gh pr diff`.

**Changes:**
- Add workflow step to write full PR context (metadata, diff, changed files, existing comments, PR discussion) to `/tmp/pr-context.md`
- Simplify the `prompt` field to just point agents to the temp file
- Update `pr-review` orchestrator to read from temp file in Phase 1
- Update all 10 pr-review subagents to read from temp file instead of calling `gh pr diff`
- Add guidance and deduplication instructions directly in the temp file content

**Benefits:**
- **Single source of truth** — All agents read from the same pre-written file
- **No redundant API calls** — Eliminates repeated `gh pr diff` calls across subagents
- **Consistent context** — All agents see exactly the same PR information
- **Embedded guidance** — Instructions about avoiding duplicate feedback are in the file itself

## Files Changed

| File | Change |
|------|--------|
| `.github/workflows/claude-code-review.yml` | Add temp file write step, simplify prompt |
| `.claude/agents/pr-review.md` | Read from temp file in Phase 1, update handoff packet |
| `.claude/agents/pr-review-*.md` (10 files) | Read from temp file instead of `gh pr diff` |

## Test Plan

- [ ] Trigger PR review on a test PR to verify workflow executes correctly
- [ ] Verify temp file is written with expected content
- [ ] Verify all subagents can read from `/tmp/pr-context.md`