### PR TITLE
Fix optional chaining for data.details in error case

### DIFF
--- a/.changeset/sharp-pillows-dance.md
+++ b/.changeset/sharp-pillows-dance.md
@@ -1,0 +1,6 @@
+---
+"@inkeep/agents-manage-ui": patch
+---
+
+Fix optional chaining for data.details in error case to prevent runtime errors
+

--- a/agents-manage-ui/src/features/agent/state/use-agent-store.ts
+++ b/agents-manage-ui/src/features/agent/state/use-agent-store.ts
@@ -472,7 +472,7 @@ const agentState: StateCreator<AgentState> = (set, get) => ({
             };
           }
           case 'error': {
-            const { relationshipId, agent } = data.details.data ?? {};
+            const { relationshipId, agent } = data.details?.data ?? {};
             if (!relationshipId && !data.agent && !agent) {
               const error = new Error(`[type: error] relationshipId is missing`);
               sentry.captureException(error, { extra: data });


### PR DESCRIPTION
fix sentry error `Cannot read properties of undefined (reading 'data')`

https://inkeep.sentry.io/issues/7230327676/events/9254027c3e5f49e8970655be3e33fc23?project=4510560027213824&referrer=alert-rule-issue-list