### PR TITLE
chore(pr-review): Exclude lock files and auto-generated noise from diff

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -22,12 +22,23 @@ jobs:
       - name: Get PR Diff
         id: diff
         run: |
-          # Get the diff for the PR
-          DIFF=$(git diff origin/${{ github.event.pull_request.base.ref }}...HEAD)
+          # Exclude noisy auto-generated files from diff
+          EXCLUDE_PATTERNS=(
+            ':!pnpm-lock.yaml'
+            ':!package-lock.json'
+            ':!yarn.lock'
+            ':!agents-api/__snapshots__/openapi.json'
+            ':!**/drizzle/*/meta/*_snapshot.json'
+            ':!**/drizzle/*/meta/_journal.json'
+            ':!**/CHANGELOG.md'
+          )
+
+          # Get the diff for the PR (excluding noisy files)
+          DIFF=$(git diff origin/${{ github.event.pull_request.base.ref }}...HEAD -- . "${EXCLUDE_PATTERNS[@]}")
           DIFF_SIZE=${#DIFF}
 
-          # Get changed files list
-          FILES=$(git diff --name-only origin/${{ github.event.pull_request.base.ref }}...HEAD)
+          # Get changed files list (excluding noisy files)
+          FILES=$(git diff --name-only origin/${{ github.event.pull_request.base.ref }}...HEAD -- . "${EXCLUDE_PATTERNS[@]}")
           echo "changed_files<<EOF" >> $GITHUB_OUTPUT
           echo "$FILES" >> $GITHUB_OUTPUT
           echo "EOF" >> $GITHUB_OUTPUT


### PR DESCRIPTION
## Summary

Exclude noisy auto-generated files from the PR review diff to reduce context size and improve review quality.

**Excluded patterns:**
- `pnpm-lock.yaml`, `package-lock.json`, `yarn.lock` - Lock files
- `agents-api/__snapshots__/openapi.json` - OpenAPI snapshot (36k lines)
- `**/drizzle/*/meta/*_snapshot.json` - Drizzle migration snapshots
- `**/drizzle/*/meta/_journal.json` - Drizzle journal
- `**/CHANGELOG.md` - Generated changelogs

This should significantly reduce diff noise for large PRs like the Slack integration.