### PR TITLE
chore(ci): auto-cancel duplicate PR review workflow runs

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -4,6 +4,10 @@ on:
   pull_request:
     types: [opened, synchronize]
 
+concurrency:
+  group: pr-review-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 jobs:
   pr-review:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
Add `concurrency` group to Claude PR review workflow to automatically cancel in-progress runs when a new commit is pushed to the same PR.

**Key behavior:**
- Groups by PR number: `pr-review-${{ github.event.pull_request.number }}`
- `cancel-in-progress: true` - cancels mid-flight runs when new commits pushed
- Different PRs remain independent

This prevents redundant reviews and reduces noise from duplicate workflow runs.

## Context
Re-applying after previous revert. This is a standalone 4-line change to the workflow file only.

## Test Plan
- [x] Verified syntax against [GitHub Actions concurrency docs](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/control-the-concurrency-of-workflows-and-jobs)
- [x] `github.event.pull_request.number` is valid for `pull_request` events