### PR TITLE
feat(pr-review): add clickable links to inline comments in review summary

### DIFF
--- a/.claude/agents/pr-review-docs.md
+++ b/.claude/agents/pr-review-docs.md
@@ -3,7 +3,7 @@ name: pr-review-docs
 description: |
   Reviews documentation files against write-docs standards.
   Spawned by pr-review orchestrator for MD/MDX files.
-  Avoid using for: non-docs files, implementation/edit tasks.
+  Should be invoked when there is **any** product surface area change, as all PRs should have corresponding documentation updates.
 
 <example>
 Context: PR adds or modifies documentation files

--- a/.claude/agents/pr-review.md
+++ b/.claude/agents/pr-review.md
@@ -46,18 +46,18 @@ Here are the available reviewers:
 
 | Reviewer | Type | Description | Protects against... |
 |----------|------|-------------|---------------------|
-| `pr-review-frontend` | Skill-based | React/Next.js patterns, component design, and frontend best practices. | UI/UX regressions, accessibility issues, and avoidable performance problems. |
-| `pr-review-docs` | Skill-based | Documentation quality, structure, and accuracy for markdown/MDX files. | Misleading docs that drive misuse, support burden, and adoption friction. |
-| `pr-review-breaking-changes` | Skill-based | Schema changes, env contracts, and migrations for breaking change risks. | Data loss, failed migrations, and broken deploy/runtime contracts. |
-| `pr-review-standards` | Problem-detection | Code quality, potential bugs, and AGENTS.md compliance (always run). | Shipped bugs, perf regressions, and steady quality debt across the codebase. |
-| `pr-review-errors` | Problem-detection | Error handling for silent failures and swallowed errors. | Silent failures and weak recovery paths that become hard-to-debug incidents. |
-| `pr-review-tests` | Problem-detection | Test coverage, test quality, and testing patterns. | Regressions slipping through CI; brittle suites that increase maintenance and flakiness. |
-| `pr-review-types` | Problem-detection | Type design, invariants, and type safety. | Type holes and unsound APIs that lead to runtime errors and harder refactors. |
-| `pr-review-comments` | Problem-detection | Comment accuracy and detects stale/misleading documentation. | Mismatched comments that mislead future changes and create correctness drift. |
-| `pr-review-architecture` | Problem-detection | System design, pattern consistency, and architectural decisions. | One-way-door mistakes and structural debt that compounds over months. |
-| `pr-review-consistency` | Problem-detection | Convention conformance across APIs, SDKs, CLI, config, telemetry, and error taxonomy. | Cross-surface drift that breaks expectations and creates long-lived developer pain. |
-| `pr-review-product` | Problem-detection | Customer mental-model quality, concept economy, multi-surface coherence, and product debt. | Confusing mental models and bloated surfaces that become permanent product/API debt. |
 | `pr-review-security-iam` | Problem-detection | Auth, tenant isolation, authorization, token/session security, and credential handling. | Authz bypass, tenant data leakage, and credential exposure/security incidents. |
+| `pr-review-breaking-changes` | Skill-based | Schema changes, env contracts, and migrations for breaking change risks. | Data loss, failed migrations, and broken deploy/runtime contracts. |
+| `pr-review-architecture` | Problem-detection | System design, pattern consistency, and architectural decisions. | One-way-door mistakes and structural debt that compounds over months. |
+| `pr-review-standards` | Problem-detection | Code quality, potential bugs, and AGENTS.md compliance (always run). | Shipped bugs, perf regressions, and steady quality debt across the codebase. |
+| `pr-review-consistency` | Problem-detection | Convention conformance across APIs, SDKs, CLI, config, telemetry, and error taxonomy. | Cross-surface drift that breaks expectations and creates long-lived developer pain. |
+| `pr-review-docs` | Skill-based | Documentation quality, structure, and accuracy for markdown/MDX files. Thoroughness in documenting new or updated features. Should be called for **any product surface change.** | Misleading docs that drive misuse, support burden, and adoption friction. |
+| `pr-review-product` | Problem-detection | Customer mental-model quality, concept economy, multi-surface coherence, and product debt. | Confusing mental models and bloated surfaces that become permanent product/API debt. |
+| `pr-review-frontend` | Skill-based | React/Next.js patterns, component design, and frontend best practices. | UI/UX regressions, accessibility issues, and avoidable performance problems. |
+| `pr-review-errors` | Problem-detection | Error handling for silent failures and swallowed errors. | Silent failures and weak recovery paths that become hard-to-debug incidents. |
+| `pr-review-types` | Problem-detection | Type design, invariants, and type safety. | Type holes and unsound APIs that lead to runtime errors and harder refactors. |
+| `pr-review-tests` | Problem-detection | Test coverage, test quality, and testing patterns. | Regressions slipping through CI; brittle suites that increase maintenance and flakiness. |
+| `pr-review-comments` | Problem-detection | Comment accuracy and detects stale/misleading documentation. | Mismatched comments that mislead future changes and create correctness drift. |
 
 **Action**: Based on the scope and nature of the PR, select the relevant reviewers. 
 **Tip**: This may include only a few or all -- use your judgement on which may be relevant. Typically, safer is better than sorry.
@@ -180,7 +180,7 @@ Use GitHub's suggestion block syntax to enable **1-click "Commit suggestion"** f
 ```
 
 **When NOT to use suggestion blocks:**
-- If the fix requires changes across multiple files
+- If the fix requires changes big changes across many files. Small changes across a few files is ok.
 - If there are multiple valid approaches and you want the author to choose
 - If the suggestion is architectural/conceptual rather than a concrete code change
 
@@ -191,6 +191,17 @@ In these cases, use a regular code block with `[lang]` instead of `suggestion`.
   - Prefer **CRITICAL > MAJOR > MINOR**
   - Within the same severity, prefer the most localized + unambiguous fixes
   - Move overflow to **summary-only** (still include them as findings, just not inline)
+
+### 5.4 Capture Inline Comment URLs
+
+After posting all inline comments, query their URLs to include clickable links in the summary:
+
+```bash
+gh api repos/{owner}/{repo}/pulls/{pr_number}/comments \
+  --jq '[.[] | select(.user.login == "claude[bot]" or .user.login == "github-actions[bot]") | {path, line, html_url, body_preview: .body[0:80]}]'
+```
+
+Store the `html_url` for each comment you posted. Use these URLs in the **Point-Fix Edits** section (Phase 6) to create clickable links.
 
 ## Phase 6: "Summary" Roll Up Comment
 
@@ -227,8 +238,9 @@ Outline of format (in this order!):
 
 🔴 1) `[file].ts[:line] || <issue_slug>` **Paraphrased title (short headline)**
  
-- `files`: list all relevant files in `[file].ts` or `[file].ts[:line]` format (line number range optional). If long, list as sub-bullet points. // if applicable
-- `system`: `scope` (no specific file) // if applicable
+// if applicable and not single-filer:
+`files`: list all relevant files in `[file].ts` or `[file].ts[:line]` format (line number range optional). If long, list as sub-bullet points. // if applicable
+`system`: `scope` (no specific file) // if applicable
 
 **Issue:** Full detailed description of what's wrong. Can be multiple sentences
 when the problem is complex or context is needed.
@@ -241,9 +253,9 @@ when the problem is complex or context is needed.
 // ...
 
 🕐 *Pending Recommendations* 🕐
-Previous issues still pending:
-❗ `[file].ts[:line] || <issue_slug>` [paraphrased issue <1 sentence]
-❗ `[file].ts[:line] || <issue_slug>` [paraphrased issue <1 sentence]
+Previous issues still pending (use `url` from pr-context's Existing Inline Comments or PR Discussion):
+❗ [`file.ts:42`](https://github.com/.../pull/123#discussion_r456) [paraphrased issue <1 sentence]
+❗ `[file].ts[:line]` [paraphrased issue <1 sentence] <!-- use url if available -->
 // ...
 
 ### 🟠🔶⚠️ Major (M) 🟠🔶⚠️
@@ -253,8 +265,8 @@ Previous issues still pending:
 // ...
 
 🕐 *Pending Recommendations* 🕐
-Previous issues still pending:
-⚠️ `[file].ts[:line] || <issue_slug>` [paraphrased issue <1 sentence]
+Previous issues still pending (use `url` from pr-context's Existing Inline Comments or PR Discussion):
+⚠️ [`file.ts:42`](https://github.com/.../pull/123#discussion_r456) [paraphrased issue <1 sentence]
 // ...
 
 ````
@@ -272,16 +284,20 @@ Adjust accordingly to the context of the issue and PR and what's most relevant f
 
 ### 📌 "Point-Fix Edits" section
 
-If you posted inline comments in Phase 5 (in this run), include a brief log section of those changes:
+If you posted inline comments in Phase 5 (in this run), include a brief log section with **clickable links** to each comment:
 
 ````markdown
 ### Point-fix Edits (P)
 
 <!-- Only if inline comments have been posted from Claude -->
-- 🔴 `[file].ts[:line] || <issue_slug>` [paraphrased issue <1 sentence]
-- 🟠 `[file].ts[:line] || <issue_slug>` [paraphrased issue <1 sentence]
-- 🟠 `[file].ts[:line] || <issue_slug>` [paraphrased issue <1 sentence]
+- 🔴 [`file.ts:42`](https://github.com/.../pull/123#discussion_r456789) Issue summary
+- 🟠 [`handler.ts:15-17`](https://github.com/.../pull/123#discussion_r456790) Issue summary
+- 🟠 [`utils.ts:88`](https://github.com/.../pull/123#discussion_r456791) Issue summary
 ````
+
+**Format:** `- {severity_emoji} [\`{file}:{line}\`]({html_url_from_step_5.4}) {paraphrased issue <1 sentence}`
+
+Use the `html_url` values captured in Phase 5.4 to create clickable links. This allows reviewers to jump directly to each inline comment.
 
 This provides a quick reference to inline comments without repeating full details.
 
@@ -314,10 +330,20 @@ Format:
 <details>
 <summary>Other Findings (Y)</summary> 
 
+### Potentially valid 
+(these are minor or info critically and not confident)
+
 | Location | Issue | Reason Excluded |
 |----------|-------|-----------------|
-| `file[:line]` or `scope` | Paraphrased issue/why (<1 sentence) | Reason disregarded (<1 sentence) |
+| `file[:line]` or `scope` | Paraphrased issue/why (<1 sentence) | Reason why not applied/suggested |
 - ...
+
+### Discarded as invalid or not applicable
+(these were wrong, not applicable, addressed elsewhere, or not relevant)
+
+| Location | Issue | Reason Excluded |
+|----------|-------|-----------------|
+| `file[:line]` or `scope` | Paraphrased issue/why (<1 sentence) | Reason why not applied/suggested |
 
 </details>
 ````
@@ -341,7 +367,7 @@ Tip: This is your catch all for findings you found to not meet the threshold of 
 | **Task** | Spawn reviewer subagents (`subagent_type: "pr-review-standards"`) |
 | **Read** | Examine files for context before dispatch |
 | **Grep/Glob** | Discover files by pattern |
-| **Bash** | Git operations only (`git diff`, `git merge-base`, `gh pr comment`) |
+| **Bash** | Git operations (`git diff`, `git merge-base`), `gh pr comment`, `gh api` for fetching comment URLs |
 | **mcp__github_inline_comment__create_inline_comment** | Post inline comments with 1-click suggestions for HIGH confidence + localized fixes (see Phase 5.3) |
 
 **Do not:** Write files, edit code, or use Bash for non-git commands.

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -84,6 +84,7 @@ jobs:
                           author { login }
                           body
                           diffHunk
+                          url
                         }
                       }
                     }
@@ -115,6 +116,7 @@ jobs:
                       }
                       body
                       createdAt
+                      url
                     }
                   }
                 }
@@ -174,13 +176,13 @@ jobs:
           ```
 
           ## Existing Inline Comments
-          Prior review threads on specific lines. Each object has: `isResolved`, `isOutdated`, `path`, `line`, `diffSide`, and first comment with `body`, `author`, and `diffHunk` context. Use to avoid posting duplicate inline comments.
+          Prior review threads on specific lines. Each object has: `isResolved`, `isOutdated`, `path`, `line`, `diffSide`, and first comment with `body`, `author`, `diffHunk` context, and `url` (permalink). Use to avoid posting duplicate inline comments and to link to existing comments in the summary.
           ```json
           ${{ steps.threads.outputs.review_threads }}
           ```
 
           ## PR Discussion
-          General comments from humans and previous review summaries. Use to avoid re-raising addressed issues.
+          General comments from humans and previous review summaries. Each has `author`, `body`, `createdAt`, and `url` (permalink). Use to avoid re-raising addressed issues.
           ```json
           ${{ steps.pr_comments.outputs.pr_comments }}
           ```
@@ -192,13 +194,27 @@ jobs:
           echo "PR context skill generated at .claude/skills/pr-context/SKILL.md ($(wc -c < .claude/skills/pr-context/SKILL.md) bytes)"
 
       - name: Run PR Review
+        id: claude
         uses: anthropics/claude-code-action@v1
+        env:
+          CLAUDE_CODE_DEBUG_LOGS_DIR: ${{ runner.temp }}/claude-debug
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           track_progress: true
           include_fix_links: true
           claude_args: |
             --agent pr-review
-            --allowedTools "Task,Read,Grep,Glob,mcp__github_inline_comment__create_inline_comment,Bash(git diff:*),Bash(git log:*),Bash(git show:*),Bash(git merge-base:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)"
+            --allowedTools "Task,Read,Grep,Glob,mcp__github_inline_comment__create_inline_comment,Bash(git diff:*),Bash(git log:*),Bash(git show:*),Bash(git merge-base:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh api:*)"
           prompt: |
             Review PR #${{ github.event.pull_request.number }}.
+
+      - name: Upload Debug Artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: claude-debug-pr-${{ github.event.pull_request.number }}-${{ github.run_id }}
+          path: |
+            ${{ runner.temp }}/claude-debug/
+            ${{ steps.claude.outputs.execution_file }}
+          retention-days: 7
+          if-no-files-found: ignore


### PR DESCRIPTION
## Summary

- Add `url` field to GraphQL queries for review threads and PR comments in workflow
- Add Phase 5.4 to pr-review agent to capture inline comment URLs after posting
- Update Point-Fix Edits section to include clickable `[file:line](url)` links
- Update Pending Recommendations to use URLs from pr-context skill for existing comments
- Add `Bash(gh api:*)` to allowed tools for fetching comment URLs
- Add secure debug artifact uploads for all Claude review runs (7-day retention)

## Test plan

- [ ] Verify GraphQL queries include `url` field in response
- [ ] Verify Claude can call `gh api` to fetch comment URLs
- [ ] Check that review summaries include clickable links to inline comments