### PR TITLE
fix: pin claude-code-action to SDK 0.2.25 to avoid AJV crash

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -195,7 +195,10 @@ jobs:
 
       - name: Run PR Review
         id: claude
-        uses: anthropics/claude-code-action@v1
+        # Pinned to SDK 0.2.25 (last working version) due to AJV validation crash in 0.2.27+
+        # Tracking: https://github.com/anthropics/claude-code-action/issues/892
+        # Remove pin when issue is resolved and @v1 is stable again
+        uses: anthropics/claude-code-action@01e756b34ef7a1447e9508f674143b07d20c2631
         env:
           CLAUDE_CODE_DEBUG_LOGS_DIR: ${{ runner.temp }}/claude-debug
         with:


### PR DESCRIPTION
## Summary

Pins `anthropics/claude-code-action` to commit `01e756b` (SDK 0.2.25) to work around an AJV validation crash in SDK 0.2.27+.

## Problem

SDK versions 0.2.27+ have a bug where AJV JSON schema validation crashes during initialization, **before any API calls are made**. This causes all PR reviews to fail with:

```
{
  "type": "result",
  "subtype": "success",
  "is_error": true,
  "duration_ms": 372,
  "num_turns": 1,
  "total_cost_usd": 0,
  "permission_denials": []
}
SDK execution error: 14 |     depsCount: ${Q},
15 |     deps: ${$}}`};var Pj={keyword:"dependencies"...
```

## Tracking

- **Root issue:** https://github.com/anthropics/claude-code-action/issues/892
- **Related:** #852 (AJV validation), #880 (error hiding), #804 (crash reports)

## Resolution

Will revert to `@v1` when the upstream issue is resolved.

## Test Plan

- [ ] Verify PR review works on a test PR after merge