### PR TITLE
chore: trigger release for all packages

### DIFF
--- a/.changeset/fair-coral-magpie.md
+++ b/.changeset/fair-coral-magpie.md
@@ -1,0 +1,5 @@
+---
+"@inkeep/ai-sdk-provider": patch
+---
+
+Trigger release

--- a/.changeset/federal-tan-swan.md
+++ b/.changeset/federal-tan-swan.md
@@ -1,0 +1,5 @@
+---
+"@inkeep/agents-sdk": patch
+---
+
+Trigger release

--- a/.changeset/probable-orange-buzzard.md
+++ b/.changeset/probable-orange-buzzard.md
@@ -1,0 +1,5 @@
+---
+"@inkeep/agents-api": patch
+---
+
+Trigger release

--- a/.changeset/prominent-amethyst-duck.md
+++ b/.changeset/prominent-amethyst-duck.md
@@ -1,0 +1,5 @@
+---
+"@inkeep/agents-manage-ui": patch
+---
+
+Trigger release

--- a/.changeset/prominent-harlequin-chipmunk.md
+++ b/.changeset/prominent-harlequin-chipmunk.md
@@ -1,0 +1,5 @@
+---
+"@inkeep/create-agents": patch
+---
+
+Trigger release

--- a/.changeset/victorious-tan-minnow.md
+++ b/.changeset/victorious-tan-minnow.md
@@ -1,0 +1,5 @@
+---
+"@inkeep/agents-cli": patch
+---
+
+Trigger release

--- a/.changeset/youngest-gray-snail.md
+++ b/.changeset/youngest-gray-snail.md
@@ -1,0 +1,5 @@
+---
+"@inkeep/agents-core": patch
+---
+
+Trigger release


### PR DESCRIPTION
## Summary
- No-op patch bumps for all published packages to trigger a new release

## Packages bumped
- `@inkeep/agents-cli`
- `@inkeep/agents-core`
- `@inkeep/agents-api`
- `@inkeep/agents-manage-ui`
- `@inkeep/agents-sdk`
- `@inkeep/create-agents`
- `@inkeep/ai-sdk-provider`

## Test plan
- [x] No code changes, only changeset files added