### PR TITLE
fix: add --scope flag to Vercel CLI commands in production workflow

### DIFF
--- a/.github/workflows/vercel-production.yml
+++ b/.github/workflows/vercel-production.yml
@@ -61,7 +61,7 @@ jobs:
       - name: Wait for Deployment Checks
         run: |
           echo "Waiting for Vercel deployment checks to complete..."
-          vercel inspect ${{ steps.deploy.outputs.url }} --token=${{ secrets.VERCEL_TOKEN }} --wait
+          vercel inspect ${{ steps.deploy.outputs.url }} --token=${{ secrets.VERCEL_TOKEN }} --scope=${{ secrets.VERCEL_ORG_ID }} --wait
 
       - name: Promote to Production
-        run: vercel promote ${{ steps.deploy.outputs.url }} --token=${{ secrets.VERCEL_TOKEN }}
+        run: vercel promote ${{ steps.deploy.outputs.url }} --token=${{ secrets.VERCEL_TOKEN }} --scope=${{ secrets.VERCEL_ORG_ID }}


### PR DESCRIPTION
## Summary
- Fixes authorization error in Vercel production deployment workflow
- The `vercel inspect` and `vercel promote` commands were failing because `VERCEL_ORG_ID` as an env var isn't used by the CLI for scope resolution
- Added `--scope=${{ secrets.VERCEL_ORG_ID }}` to both commands

## Context
Failed run: https://github.com/inkeep/agents/actions/runs/21695031954/job/62563333139

Error was:
```
Error: Not authorized: Trying to access resource under scope "andrew-mikofalvys-projects". 
You must re-authenticate to this scope or use a token with access to this scope.
```

## Test plan
- [ ] Re-run the Vercel production deployment workflow after merge