### PR TITLE
fix: use repository variables instead of secrets for non-sensitive values

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,7 +88,7 @@ jobs:
           TURBO_TELEMETRY_DISABLED: 1
           TURBO_CACHE_DIR: .turbo
           TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
-          TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
+          TURBO_TEAM: ${{ vars.TURBO_TEAM }}
           ENVIRONMENT: test
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY || 'sk-test-key-for-ci-testing' }}
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY || 'sk-ant-test-key-for-ci-testing' }}
@@ -224,7 +224,7 @@ jobs:
           TURBO_TELEMETRY_DISABLED: 1
           TURBO_CACHE_DIR: .turbo
           TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
-          TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
+          TURBO_TEAM: ${{ vars.TURBO_TEAM }}
 
       - name: Run database migrations
         run: pnpm db:migrate

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -34,18 +34,18 @@ jobs:
           --health-retries 5
           --health-start-period 20s
       postgres:
-          image: postgres:18
-          env:
-            POSTGRES_DB: inkeep_agents
-            POSTGRES_USER: appuser
-            POSTGRES_PASSWORD: password
-          options: >-
-            --health-cmd "pg_isready -U appuser"
-            --health-interval 10s
-            --health-timeout 5s
-            --health-retries 5
-          ports:
-            - 5433:5432
+        image: postgres:18
+        env:
+          POSTGRES_DB: inkeep_agents
+          POSTGRES_USER: appuser
+          POSTGRES_PASSWORD: password
+        options: >-
+          --health-cmd "pg_isready -U appuser"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 5433:5432
 
     steps:
       - name: Checkout code
@@ -107,7 +107,7 @@ jobs:
           TURBO_TELEMETRY_DISABLED: 1
           TURBO_CACHE_DIR: .turbo
           TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
-          TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
+          TURBO_TEAM: ${{ vars.TURBO_TEAM }}
           INKEEP_AGENTS_MANAGE_DATABASE_URL: postgresql://appuser:password@localhost:5432/inkeep_agents
           INKEEP_AGENTS_RUN_DATABASE_URL: postgresql://appuser:password@localhost:5433/inkeep_agents
           INKEEP_AGENTS_MANAGE_API_BYPASS_SECRET: test-bypass-secret-for-ci

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,8 +34,8 @@ jobs:
       - name: Setup npm for OIDC publishing
         uses: actions/setup-node@v4
         with:
-          node-version: '22'
-          registry-url: 'https://registry.npmjs.org'
+          node-version: "22"
+          registry-url: "https://registry.npmjs.org"
 
       - name: Ensure npm 11.5.1+ for OIDC support
         run: npm install -g npm@latest
@@ -53,7 +53,7 @@ jobs:
         env:
           TURBO_TELEMETRY_DISABLED: 1
           TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
-          TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
+          TURBO_TEAM: ${{ vars.TURBO_TEAM }}
 
       - name: Publish packages
         id: changesets
@@ -90,10 +90,10 @@ jobs:
 
           # Get the most recently merged PR's body
           PR_BODY=$(gh pr list --state merged --base main --json body,mergedAt --jq 'sort_by(.mergedAt) | last | .body')
-          
+
           # Extract everything from "# Releases" onward and replace with "# Changelog"
           CHANGELOG=$(echo "$PR_BODY" | sed -n '/^# Releases/,$p' | sed '1s/^# Releases/# Changelog/')
-          
+
           # Create release notes with Highlights section above Changelog
           RELEASE_NOTES="# Highlights
 
@@ -120,10 +120,10 @@ jobs:
 
           # Get the most recently merged PR's body
           PR_BODY=$(gh pr list --state merged --base main --json body,mergedAt --jq 'sort_by(.mergedAt) | last | .body')
-          
+
           # Extract everything from "# Releases" onward and replace with "# Changelog"
           CHANGELOG=$(echo "$PR_BODY" | sed -n '/^# Releases/,$p' | sed '1s/^# Releases/# Changelog/')
-          
+
           # Generate highlights using Claude
           HIGHLIGHTS=$(curl -s -K <(echo "header = \"x-api-key: $ANTHROPIC_API_KEY\"") \
             https://api.anthropic.com/v1/messages \
@@ -139,7 +139,7 @@ jobs:
                   content: "Based on this changelog, write a Highlights section for a GitHub release. Focus on the most impactful user-facing changes. Use markdown with ## headers for major features and bullet points for details. Do not include a top-level heading - start directly with the content.\n\nChangelog:\n\($changelog)"
                 }]
               }')" | jq -r '.content[0].text')
-          
+
             # Create release notes with AI-generated Highlights
 
             RELEASE_NOTES="# Highlights
@@ -152,7 +152,7 @@ jobs:
             gh release create "v${VERSION}-AI" \
               --title "${RELEASE_DATE}-AI" \
               --notes "$RELEASE_NOTES" \
-              --draft  
+              --draft
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}

--- a/.github/workflows/vercel-production.yml
+++ b/.github/workflows/vercel-production.yml
@@ -19,7 +19,7 @@ on:
   workflow_dispatch:
 
 env:
-  VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+  VERCEL_ORG_ID: ${{ vars.VERCEL_ORG_ID }}
 
 jobs:
   deploy:
@@ -61,7 +61,7 @@ jobs:
       - name: Wait for Deployment Checks
         run: |
           echo "Waiting for Vercel deployment checks to complete..."
-          vercel inspect ${{ steps.deploy.outputs.url }} --token=${{ secrets.VERCEL_TOKEN }} --scope=${{ secrets.VERCEL_ORG_ID }} --wait
+          vercel inspect ${{ steps.deploy.outputs.url }} --token=${{ secrets.VERCEL_TOKEN }} --scope=${{ vars.VERCEL_ORG_ID }} --wait
 
       - name: Promote to Production
-        run: vercel promote ${{ steps.deploy.outputs.url }} --yes --token=${{ secrets.VERCEL_TOKEN }} --scope=${{ secrets.VERCEL_ORG_ID }}
+        run: vercel promote ${{ steps.deploy.outputs.url }} --yes --token=${{ secrets.VERCEL_TOKEN }} --scope=${{ vars.VERCEL_ORG_ID }}


### PR DESCRIPTION
## Summary
- Move `TURBO_TEAM` and `VERCEL_ORG_ID` from `secrets.` to `vars.` to prevent GitHub Actions from masking these values in logs
- Secret values are automatically masked by GitHub, which was causing "inkeep" to appear as `***` throughout CI logs

## Files Changed
- `.github/workflows/ci.yml` - TURBO_TEAM
- `.github/workflows/cypress.yml` - TURBO_TEAM
- `.github/workflows/release.yml` - TURBO_TEAM
- `.github/workflows/vercel-production.yml` - VERCEL_ORG_ID

## Required Setup
After merging, ensure these are configured as **organization or repository variables** (not secrets) in GitHub Settings > Secrets and variables > Actions > Variables:
- `TURBO_TEAM`
- `VERCEL_ORG_ID`