### PR TITLE
fix: add --archive=tgz to prevent CLI hanging during deploy

### DIFF
--- a/.github/workflows/vercel-production.yml
+++ b/.github/workflows/vercel-production.yml
@@ -50,7 +50,7 @@ jobs:
       - name: Deploy Staged Production
         id: deploy
         run: |
-          DEPLOYMENT_URL=$(vercel deploy --prod --skip-domain --token=${{ secrets.VERCEL_TOKEN }})
+          DEPLOYMENT_URL=$(vercel deploy --prod --skip-domain --archive=tgz --token=${{ secrets.VERCEL_TOKEN }})
           if [ -z "$DEPLOYMENT_URL" ]; then
             echo "Error: Failed to capture deployment URL"
             exit 1


### PR DESCRIPTION
## Summary
- Adds `--archive=tgz` flag to `vercel deploy` command
- This compresses files before upload which prevents hanging issues with large codebases

## Context
The previous workflow run (21695595729) hung for 20+ minutes on the "Deploy Staged Production" step for agents-api. The CLI was stuck uploading files.

The `--archive=tgz` flag is a [known fix](https://errorism.dev/issues/vercel-vercel-vercel-deploy-fails-reason-socket-hang-up) for this issue.

## Test plan
- [ ] Re-run workflow after merge