### PR TITLE
fix: simplify Vercel workflow to use direct production deploy

### DIFF
--- a/.github/workflows/vercel-production.yml
+++ b/.github/workflows/vercel-production.yml
@@ -2,10 +2,8 @@ name: Deploy to Vercel Production
 
 # This workflow deploys to Vercel production when a GitHub release is published,
 # or manually via workflow_dispatch (deploys latest main).
-# It uses staged production deployments to verify health before promoting:
-# 1. Deploy as production but skip domain assignment (staged)
+# 1. Deploy to production (builds with production env vars, assigns production domains)
 # 2. Wait for Vercel deployment checks to pass (configured in Vercel dashboard)
-# 3. Promote the verified deployment to production (instant, no rebuild)
 #
 # Required secrets (configure in GitHub Repository Settings > Secrets):
 # - VERCEL_TOKEN: API token from Vercel Dashboard > Settings > Tokens
@@ -47,10 +45,10 @@ jobs:
       - name: Pull Vercel Environment
         run: vercel pull --yes --environment=production --token=${{ secrets.VERCEL_TOKEN }}
 
-      - name: Deploy Staged Production
+      - name: Deploy to Production
         id: deploy
         run: |
-          DEPLOYMENT_URL=$(vercel deploy --prod --skip-domain --archive=tgz --token=${{ secrets.VERCEL_TOKEN }})
+          DEPLOYMENT_URL=$(vercel deploy --prod --token=${{ secrets.VERCEL_TOKEN }})
           if [ -z "$DEPLOYMENT_URL" ]; then
             echo "Error: Failed to capture deployment URL"
             exit 1
@@ -62,6 +60,3 @@ jobs:
         run: |
           echo "Waiting for Vercel deployment checks to complete..."
           vercel inspect ${{ steps.deploy.outputs.url }} --token=${{ secrets.VERCEL_TOKEN }} --scope=${{ vars.VERCEL_ORG_ID }} --wait
-
-      - name: Promote to Production
-        run: vercel promote ${{ steps.deploy.outputs.url }} --yes --token=${{ secrets.VERCEL_TOKEN }} --scope=${{ vars.VERCEL_ORG_ID }}


### PR DESCRIPTION
## Summary
- Remove `--skip-domain` flag which was causing CLI to hang
- Remove separate promote step (`--prod` auto-assigns domains)
- Simpler, more reliable workflow

## Changes
- `vercel deploy --prod` now directly deploys and assigns production domains
- Deployment checks still run via `vercel inspect --wait`
- No more staged/promote flow that was causing issues