### PR TITLE
remove pnpm audit warnings from preact

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,6 +18,7 @@ overrides:
   esbuild: 0.25.9
   '@modelcontextprotocol/sdk>zod': ^3.25.7
   '@anthropic-ai/mcpb>zod': ^3.25.7
+  preact: '-'
 
 patchedDependencies:
   '@changesets/assemble-release-plan@6.0.9':
@@ -11566,9 +11567,6 @@ packages:
   posthog-node@5.20.0:
     resolution: {integrity: sha512-LkR5KfrvEQTnUtNKN97VxFB00KcYG1Iz8iKg8r0e/i7f1eQhg1WSZO+Jp1B4bvtHCmdpIE4HwYbvCCzFoCyjVg==}
     engines: {node: '>=20'}
-
-  preact@10.28.0:
-    resolution: {integrity: sha512-rytDAoiXr3+t6OIP3WGlDd0ouCUG1iCWzkcY3++Nreuoi17y6T5i/zRhe6uYfoVcxq6YU+sBtJouuRDsq8vvqA==}
 
   prebuild-install@7.1.3:
     resolution: {integrity: sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==}
@@ -28457,14 +28455,11 @@ snapshots:
       '@posthog/types': 1.316.1
       core-js: 3.47.0
       fflate: 0.4.8
-      preact: 10.28.0
       web-vitals: 4.2.4
 
   posthog-node@5.20.0:
     dependencies:
       '@posthog/core': 1.9.1
-
-  preact@10.28.0: {}
 
   prebuild-install@7.1.3:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -23,3 +23,4 @@ overrides:
   esbuild: 0.25.9 # we pin it for Cypress
   "@modelcontextprotocol/sdk>zod": ^3.25.7
   "@anthropic-ai/mcpb>zod": ^3.25.7
+  preact: "-" # we don't use preact, this removes pnpm audit warnings from posthog-js>preact


### PR DESCRIPTION
# before

```
20 vulnerabilities found
Severity: 3 low | 5 moderate | 12 high
```

# now

```
19 vulnerabilities found
Severity: 3 low | 5 moderate | 11 high
```