### PR TITLE
fix(auth,cors): support cross-subdomain auth for domains without shared 3-part parent

### DIFF
--- a/.changeset/rigid-blush-pinniped.md
+++ b/.changeset/rigid-blush-pinniped.md
@@ -1,0 +1,6 @@
+---
+"@inkeep/agents-core": patch
+"@inkeep/agents-api": patch
+---
+
+Fix cross-subdomain auth for domains that don't share a 3-part parent (e.g., app.inkeep.com + api.agents.inkeep.com)

--- a/agents-api/src/__tests__/manage/utils/cors.test.ts
+++ b/agents-api/src/__tests__/manage/utils/cors.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { getBaseDomain } from '../../../middleware/cors';
+import { getBaseDomain, getRootDomain } from '../../../middleware/cors';
 
 vi.mock('../../../env', () => ({
   env: {
@@ -31,6 +31,22 @@ describe('getBaseDomain', () => {
 
   it('should handle empty string', () => {
     expect(getBaseDomain('')).toBe('');
+  });
+});
+
+describe('getRootDomain', () => {
+  it('should return the last 2 parts for multi-part hostnames', () => {
+    expect(getRootDomain('api.agents.inkeep.com')).toBe('inkeep.com');
+    expect(getRootDomain('app.inkeep.com')).toBe('inkeep.com');
+    expect(getRootDomain('agents-manage-ui.preview.inkeep.com')).toBe('inkeep.com');
+  });
+
+  it('should return hostname as-is for 2-part domains', () => {
+    expect(getRootDomain('inkeep.com')).toBe('inkeep.com');
+  });
+
+  it('should return hostname as-is for single-part hostnames', () => {
+    expect(getRootDomain('localhost')).toBe('localhost');
   });
 });
 
@@ -107,7 +123,7 @@ describe('isOriginAllowed', () => {
     });
   });
 
-  describe('production mode with explicit UI URL', () => {
+  describe('production mode with explicit UI URL (same base domain)', () => {
     beforeEach(() => {
       vi.doMock('../../../env', () => ({
         env: {
@@ -122,17 +138,40 @@ describe('isOriginAllowed', () => {
       expect(isOriginAllowed('https://agents-manage-ui.inkeep.com')).toBe(true);
     });
 
-    it('should reject different 3-part subdomains (base domain includes subdomain)', async () => {
-      const { isOriginAllowed } = await import('../../../middleware/cors');
-      expect(isOriginAllowed('https://other-app.inkeep.com')).toBe(false);
-    });
-
     it('should allow 4-part hostnames with matching base domain', async () => {
       const { isOriginAllowed } = await import('../../../middleware/cors');
       expect(isOriginAllowed('https://app.agents-api.inkeep.com')).toBe(true);
     });
 
-    it('should reject origins from different domains', async () => {
+    it('should reject origins from different root domains', async () => {
+      const { isOriginAllowed } = await import('../../../middleware/cors');
+      expect(isOriginAllowed('https://malicious-site.com')).toBe(false);
+      expect(isOriginAllowed('https://inkeep.com.evil.com')).toBe(false);
+    });
+  });
+
+  describe('production mode with different 3-part bases (app.inkeep.com + api.agents.inkeep.com)', () => {
+    beforeEach(() => {
+      vi.doMock('../../../env', () => ({
+        env: {
+          INKEEP_AGENTS_API_URL: 'https://api.agents.inkeep.com',
+          INKEEP_AGENTS_MANAGE_UI_URL: 'https://app.inkeep.com',
+        },
+      }));
+    });
+
+    it('should allow the exact UI URL hostname', async () => {
+      const { isOriginAllowed } = await import('../../../middleware/cors');
+      expect(isOriginAllowed('https://app.inkeep.com')).toBe(true);
+    });
+
+    it('should allow origins sharing the same root domain as both API and UI', async () => {
+      const { isOriginAllowed } = await import('../../../middleware/cors');
+      expect(isOriginAllowed('https://other.inkeep.com')).toBe(true);
+      expect(isOriginAllowed('https://api.agents.inkeep.com')).toBe(true);
+    });
+
+    it('should reject origins from different root domains', async () => {
       const { isOriginAllowed } = await import('../../../middleware/cors');
       expect(isOriginAllowed('https://malicious-site.com')).toBe(false);
       expect(isOriginAllowed('https://inkeep.com.evil.com')).toBe(false);
@@ -163,6 +202,22 @@ describe('isOriginAllowed', () => {
     it('should reject origins from different preview environments', async () => {
       const { isOriginAllowed } = await import('../../../middleware/cors');
       expect(isOriginAllowed('https://app.staging.inkeep.com')).toBe(false);
+    });
+  });
+
+  describe('root domain fallback requires UI URL to be set', () => {
+    beforeEach(() => {
+      vi.doMock('../../../env', () => ({
+        env: {
+          INKEEP_AGENTS_API_URL: 'https://api.agents.inkeep.com',
+          INKEEP_AGENTS_MANAGE_UI_URL: undefined,
+        },
+      }));
+    });
+
+    it('should NOT allow root domain match when UI URL is not configured', async () => {
+      const { isOriginAllowed } = await import('../../../middleware/cors');
+      expect(isOriginAllowed('https://app.inkeep.com')).toBe(false);
     });
   });
 

--- a/agents-api/src/__tests__/utils/cors.test.ts
+++ b/agents-api/src/__tests__/utils/cors.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { getBaseDomain } from '../../middleware/cors';
+import { getBaseDomain, getRootDomain } from '../../middleware/cors';
 
 vi.mock('../../env', () => ({
   env: {
@@ -31,6 +31,22 @@ describe('getBaseDomain', () => {
 
   it('should handle empty string', () => {
     expect(getBaseDomain('')).toBe('');
+  });
+});
+
+describe('getRootDomain', () => {
+  it('should return the last 2 parts for multi-part hostnames', () => {
+    expect(getRootDomain('api.agents.inkeep.com')).toBe('inkeep.com');
+    expect(getRootDomain('app.inkeep.com')).toBe('inkeep.com');
+    expect(getRootDomain('agents-manage-ui.preview.inkeep.com')).toBe('inkeep.com');
+  });
+
+  it('should return hostname as-is for 2-part domains', () => {
+    expect(getRootDomain('inkeep.com')).toBe('inkeep.com');
+  });
+
+  it('should return hostname as-is for single-part hostnames', () => {
+    expect(getRootDomain('localhost')).toBe('localhost');
   });
 });
 
@@ -107,7 +123,7 @@ describe('isOriginAllowed', () => {
     });
   });
 
-  describe('production mode with explicit UI URL', () => {
+  describe('production mode with explicit UI URL (same base domain)', () => {
     beforeEach(() => {
       vi.doMock('../../env', () => ({
         env: {
@@ -122,17 +138,40 @@ describe('isOriginAllowed', () => {
       expect(isOriginAllowed('https://agents-manage-ui.inkeep.com')).toBe(true);
     });
 
-    it('should reject different 3-part subdomains (base domain includes subdomain)', async () => {
-      const { isOriginAllowed } = await import('../../middleware/cors');
-      expect(isOriginAllowed('https://other-app.inkeep.com')).toBe(false);
-    });
-
     it('should allow 4-part hostnames with matching base domain', async () => {
       const { isOriginAllowed } = await import('../../middleware/cors');
       expect(isOriginAllowed('https://app.agents-api.inkeep.com')).toBe(true);
     });
 
-    it('should reject origins from different domains', async () => {
+    it('should reject origins from different root domains', async () => {
+      const { isOriginAllowed } = await import('../../middleware/cors');
+      expect(isOriginAllowed('https://malicious-site.com')).toBe(false);
+      expect(isOriginAllowed('https://inkeep.com.evil.com')).toBe(false);
+    });
+  });
+
+  describe('production mode with different 3-part bases (app.inkeep.com + api.agents.inkeep.com)', () => {
+    beforeEach(() => {
+      vi.doMock('../../env', () => ({
+        env: {
+          INKEEP_AGENTS_API_URL: 'https://api.agents.inkeep.com',
+          INKEEP_AGENTS_MANAGE_UI_URL: 'https://app.inkeep.com',
+        },
+      }));
+    });
+
+    it('should allow the exact UI URL hostname', async () => {
+      const { isOriginAllowed } = await import('../../middleware/cors');
+      expect(isOriginAllowed('https://app.inkeep.com')).toBe(true);
+    });
+
+    it('should allow origins sharing the same root domain as both API and UI', async () => {
+      const { isOriginAllowed } = await import('../../middleware/cors');
+      expect(isOriginAllowed('https://other.inkeep.com')).toBe(true);
+      expect(isOriginAllowed('https://api.agents.inkeep.com')).toBe(true);
+    });
+
+    it('should reject origins from different root domains', async () => {
       const { isOriginAllowed } = await import('../../middleware/cors');
       expect(isOriginAllowed('https://malicious-site.com')).toBe(false);
       expect(isOriginAllowed('https://inkeep.com.evil.com')).toBe(false);
@@ -163,6 +202,22 @@ describe('isOriginAllowed', () => {
     it('should reject origins from different preview environments', async () => {
       const { isOriginAllowed } = await import('../../middleware/cors');
       expect(isOriginAllowed('https://app.staging.inkeep.com')).toBe(false);
+    });
+  });
+
+  describe('root domain fallback requires UI URL to be set', () => {
+    beforeEach(() => {
+      vi.doMock('../../env', () => ({
+        env: {
+          INKEEP_AGENTS_API_URL: 'https://api.agents.inkeep.com',
+          INKEEP_AGENTS_MANAGE_UI_URL: undefined,
+        },
+      }));
+    });
+
+    it('should NOT allow root domain match when UI URL is not configured', async () => {
+      const { isOriginAllowed } = await import('../../middleware/cors');
+      expect(isOriginAllowed('https://app.inkeep.com')).toBe(false);
     });
   });
 

--- a/agents-api/src/env.ts
+++ b/agents-api/src/env.ts
@@ -39,6 +39,12 @@ const envSchema = z.object({
     .optional()
     .default('http://localhost:3002')
     .describe('URL where the agents management API is running'),
+  AUTH_COOKIE_DOMAIN: z
+    .string()
+    .optional()
+    .describe(
+      'Explicit cookie domain for cross-subdomain auth (e.g., .inkeep.com). Required when the API and UI do not share a common 3-part parent domain.'
+    ),
 
   // Authentication
   BETTER_AUTH_SECRET: z

--- a/agents-api/src/factory.ts
+++ b/agents-api/src/factory.ts
@@ -25,6 +25,7 @@ export function createAgentsAuth(userAuthConfig?: UserAuthConfig) {
     baseURL: env.INKEEP_AGENTS_API_URL || `http://localhost:3002`,
     secret: env.BETTER_AUTH_SECRET || 'development-secret-change-in-production',
     dbClient: runDbClient,
+    ...(env.AUTH_COOKIE_DOMAIN && { cookieDomain: env.AUTH_COOKIE_DOMAIN }),
     ...(userAuthConfig?.ssoProviders && { ssoProviders: userAuthConfig.ssoProviders }),
     ...(userAuthConfig?.socialProviders && { socialProviders: userAuthConfig.socialProviders }),
   });

--- a/packages/agents-core/src/auth/__tests__/extractCookieDomain.test.ts
+++ b/packages/agents-core/src/auth/__tests__/extractCookieDomain.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from 'vitest';
+import { extractCookieDomain } from '../auth';
+
+describe('extractCookieDomain', () => {
+  describe('with explicit domain override', () => {
+    it('should return the explicit domain as-is when it starts with a dot', () => {
+      expect(extractCookieDomain('https://api.agents.inkeep.com', '.inkeep.com')).toBe(
+        '.inkeep.com'
+      );
+    });
+
+    it('should prepend a dot when the explicit domain does not start with one', () => {
+      expect(extractCookieDomain('https://api.agents.inkeep.com', 'inkeep.com')).toBe(
+        '.inkeep.com'
+      );
+    });
+
+    it('should use explicit domain regardless of baseURL', () => {
+      expect(extractCookieDomain('http://localhost:3002', '.inkeep.com')).toBe('.inkeep.com');
+    });
+  });
+
+  describe('auto-computed from baseURL (no override)', () => {
+    it('should return undefined for localhost', () => {
+      expect(extractCookieDomain('http://localhost:3002')).toBeUndefined();
+    });
+
+    it('should return undefined for IP addresses', () => {
+      expect(extractCookieDomain('http://127.0.0.1:3002')).toBeUndefined();
+      expect(extractCookieDomain('http://192.168.1.1:3002')).toBeUndefined();
+    });
+
+    it('should handle 2-part domains (e.g., inkeep.com)', () => {
+      expect(extractCookieDomain('https://inkeep.com')).toBe('.inkeep.com');
+    });
+
+    it('should handle 3-part domains (e.g., pilot.inkeep.com)', () => {
+      expect(extractCookieDomain('https://pilot.inkeep.com')).toBe('.pilot.inkeep.com');
+    });
+
+    it('should handle 4-part domains by dropping the first part (e.g., api.pilot.inkeep.com)', () => {
+      expect(extractCookieDomain('https://api.pilot.inkeep.com')).toBe('.pilot.inkeep.com');
+    });
+
+    it('should handle 4-part domains with different structure (e.g., api.agents.inkeep.com)', () => {
+      expect(extractCookieDomain('https://api.agents.inkeep.com')).toBe('.agents.inkeep.com');
+    });
+
+    it('should return undefined for single-part hostnames', () => {
+      expect(extractCookieDomain('http://myhost')).toBeUndefined();
+    });
+
+    it('should return undefined for invalid URLs', () => {
+      expect(extractCookieDomain('not-a-url')).toBeUndefined();
+    });
+  });
+
+  describe('production domain scenarios', () => {
+    it('old structure: api.pilot.inkeep.com and pilot.inkeep.com share .pilot.inkeep.com', () => {
+      const apiDomain = extractCookieDomain('https://api.pilot.inkeep.com');
+      expect(apiDomain).toBe('.pilot.inkeep.com');
+    });
+
+    it('new structure: api.agents.inkeep.com needs AUTH_COOKIE_DOMAIN=.inkeep.com to share with app.inkeep.com', () => {
+      const withoutOverride = extractCookieDomain('https://api.agents.inkeep.com');
+      expect(withoutOverride).toBe('.agents.inkeep.com');
+
+      const withOverride = extractCookieDomain('https://api.agents.inkeep.com', '.inkeep.com');
+      expect(withOverride).toBe('.inkeep.com');
+    });
+  });
+});

--- a/packages/agents-core/src/auth/auth.ts
+++ b/packages/agents-core/src/auth/auth.ts
@@ -83,6 +83,7 @@ export interface BetterAuthConfig {
   baseURL: string;
   secret: string;
   dbClient: AgentsRunDatabaseClient;
+  cookieDomain?: string;
   ssoProviders?: SSOProviderConfig[];
   socialProviders?: {
     google?: GoogleOptions;
@@ -100,48 +101,45 @@ export interface UserAuthConfig {
 
 /**
  * Extracts the root domain from a URL for cross-subdomain cookie sharing.
- * For example:
+ *
+ * When the API and UI share a common 3-part parent (e.g., api.pilot.inkeep.com
+ * and pilot.inkeep.com both share .pilot.inkeep.com), the function auto-computes
+ * the shared parent. When domains don't share a 3-part parent (e.g.,
+ * api.agents.inkeep.com and app.inkeep.com), set AUTH_COOKIE_DOMAIN explicitly.
+ *
+ * Examples (auto-computed from baseURL):
  * - https://api.pilot.inkeep.com -> .pilot.inkeep.com
  * - https://pilot.inkeep.com -> .pilot.inkeep.com
  * - http://localhost:3002 -> undefined (no domain for localhost)
  *
- * The logic extracts the parent domain that can be shared across subdomains.
- * For domains with 3+ parts, it takes everything except the first part.
- * For domains with exactly 2 parts, it takes both parts.
+ * With AUTH_COOKIE_DOMAIN=.inkeep.com:
+ * - Any *.inkeep.com URL -> .inkeep.com
  */
-function extractCookieDomain(baseURL: string): string | undefined {
+export function extractCookieDomain(baseURL: string, explicitDomain?: string): string | undefined {
+  if (explicitDomain) {
+    return explicitDomain.startsWith('.') ? explicitDomain : `.${explicitDomain}`;
+  }
+
   try {
     const url = new URL(baseURL);
     const hostname = url.hostname;
 
-    // Don't set domain for localhost or IP addresses
     if (hostname === 'localhost' || hostname.match(/^\d+\.\d+\.\d+\.\d+$/)) {
       return undefined;
     }
 
-    // Split hostname into parts
     const parts = hostname.split('.');
 
-    // We need at least 2 parts to form a domain (e.g., inkeep.com)
     if (parts.length < 2) {
       return undefined;
     }
 
-    // Extract the parent domain that can be shared across subdomains
-    // Examples:
-    // - pilot.inkeep.com (3 parts) -> take all 3 parts -> .pilot.inkeep.com
-    // - api.pilot.inkeep.com (4 parts) -> take last 3 parts -> .pilot.inkeep.com
-    // - inkeep.com (2 parts) -> take both parts -> .inkeep.com
-
     let domainParts: string[];
     if (parts.length === 3) {
-      // For 3-part domains like pilot.inkeep.com, take all parts
       domainParts = parts;
     } else if (parts.length > 3) {
-      // For 4+ part domains like api.pilot.inkeep.com, take everything except first
       domainParts = parts.slice(1);
     } else {
-      // For 2-part domains like inkeep.com, take both parts
       domainParts = parts;
     }
 
@@ -186,8 +184,7 @@ async function registerSSOProvider(
 }
 
 export function createAuth(config: BetterAuthConfig) {
-  // Extract cookie domain from baseURL for cross-subdomain cookie sharing
-  const cookieDomain = extractCookieDomain(config.baseURL);
+  const cookieDomain = extractCookieDomain(config.baseURL, config.cookieDomain);
 
   const auth = betterAuth({
     baseURL: config.baseURL,
@@ -255,7 +252,6 @@ export function createAuth(config: BetterAuthConfig) {
         sameSite: 'none',
         secure: true,
         httpOnly: true,
-        partitioned: true,
         ...(cookieDomain && { domain: cookieDomain }),
       },
       ...config.advanced,

--- a/packages/agents-core/src/env.ts
+++ b/packages/agents-core/src/env.ts
@@ -94,6 +94,12 @@ const envSchema = z.object({
     .string()
     .optional()
     .describe('URL where the agents management API is running'),
+  AUTH_COOKIE_DOMAIN: z
+    .string()
+    .optional()
+    .describe(
+      'Explicit cookie domain for cross-subdomain auth (e.g., .inkeep.com). Required when the API and UI do not share a common 3-part parent domain.'
+    ),
   GITHUB_MCP_API_KEY: z.string().optional().describe('API key for the GitHub MCP'),
 });
 


### PR DESCRIPTION
## Summary

Fixes login loop when the manage UI and API use domains that don't share a common 3-part parent domain (e.g., `app.inkeep.com` + `api.agents.inkeep.com`), as opposed to the old structure where they did (e.g., `pilot.inkeep.com` + `api.pilot.inkeep.com`).

Three interconnected issues were causing a 401 → redirect → login loop:

- **Cookie domain mismatch**: `extractCookieDomain` computed `.agents.inkeep.com` from the API URL, but `app.inkeep.com` is not under that domain — so session cookies couldn't be shared. Added `AUTH_COOKIE_DOMAIN` env var to explicitly set the shared cookie domain (e.g., `.inkeep.com`).
- **Partitioned cookies**: Removed `partitioned: true` from cookie attributes. Cookies set in first-party context during OAuth redirects (browser on `api.agents.inkeep.com`) get different partition keys when later accessed cross-site from `app.inkeep.com`, preventing session cookies from being sent.
- **CORS rejection**: `getBaseDomain` only compared last-3-part domains (`agents.inkeep.com` vs `app.inkeep.com` — mismatch). Added `getRootDomain` (eTLD+1) fallback that activates when `INKEEP_AGENTS_MANAGE_UI_URL` is configured and all origins share the same root domain.

## Required env vars (agents-api on Vercel)

| Variable | Value |
|---|---|
| `AUTH_COOKIE_DOMAIN` | `.inkeep.com` |
| `INKEEP_AGENTS_MANAGE_UI_URL` | `https://app.inkeep.com` |
| `INKEEP_AGENTS_API_URL` | `https://api.agents.inkeep.com` |
| `TRUSTED_ORIGIN` | `https://app.inkeep.com` |

## Test plan

- [x] New `extractCookieDomain` tests pass (13 tests covering explicit override, auto-computation, production scenarios)
- [x] Updated CORS tests pass in both test locations (26 tests each, including new domain structure scenarios)
- [ ] Deploy to Vercel with required env vars and verify Google OAuth login no longer loops
- [ ] Verify existing `pilot.inkeep.com` / `api.pilot.inkeep.com` deployments (if any) still work with auto-computed cookie domain