### PR TITLE
fix: route internal A2A and self-calls in-process to prevent multi-instance stream failures

### DIFF
--- a/agents-api/src/createApp.ts
+++ b/agents-api/src/createApp.ts
@@ -39,6 +39,7 @@ import { executionBaggageMiddleware } from './middleware/tracing';
 import { setupOpenAPIRoutes } from './openapi';
 import { healthChecksHandler } from './routes/healthChecks';
 import type { AppConfig, AppVariables } from './types';
+import { getInProcessFetch, registerAppFetch } from './utils/in-process-fetch';
 
 const logger = getLogger('agents-api');
 
@@ -345,7 +346,7 @@ function createAgentsHono(config: AppConfig) {
       body: bodyBuffer,
     });
 
-    return fetch(forwardedRequest);
+    return getInProcessFetch()(forwardedRequest);
   });
 
   app.route('/evals', evalRoutes);
@@ -368,6 +369,8 @@ function createAgentsHono(config: AppConfig) {
   // Wrap in base Hono for framework detection
   const base = new Hono();
   base.route('/', app);
+
+  registerAppFetch(base.request.bind(base) as typeof fetch);
 
   return base;
 }

--- a/agents-api/src/domains/evals/services/EvaluationService.ts
+++ b/agents-api/src/domains/evals/services/EvaluationService.ts
@@ -30,6 +30,7 @@ import manageDbPool from '../../../data/db/manageDbPool';
 import runDbClient from '../../../data/db/runDbClient';
 import { env } from '../../../env';
 import { getLogger } from '../../../logger';
+import { getInProcessFetch } from '../../../utils/in-process-fetch';
 
 const logger = getLogger('EvaluationService');
 
@@ -187,7 +188,7 @@ export class EvaluationService {
       'Running dataset item through chat API'
     );
 
-    const response = await fetch(chatUrl, {
+    const response = await getInProcessFetch()(chatUrl, {
       method: 'POST',
       headers,
       body: JSON.stringify(chatPayload),

--- a/agents-api/src/domains/run/agents/relationTools.ts
+++ b/agents-api/src/domains/run/agents/relationTools.ts
@@ -19,6 +19,7 @@ import { tool } from 'ai';
 import manageDbPool from 'src/data/db/manageDbPool';
 import runDbClient from '../../../data/db/runDbClient';
 import { getLogger } from '../../../logger';
+import { getInProcessFetch } from '../../../utils/in-process-fetch';
 import { A2AClient } from '../a2a/client';
 import {
   DELEGATION_TOOL_BACKOFF_EXPONENT,
@@ -383,6 +384,7 @@ export function createDelegateToAgentTool({
             maxElapsedTime: DELEGATION_TOOL_BACKOFF_MAX_ELAPSED_TIME_MS,
           },
         },
+        ...(isInternal || isTeam ? { fetchFn: getInProcessFetch() } : {}),
       });
 
       const messageToSend = {

--- a/agents-api/src/domains/run/handlers/executionHandler.ts
+++ b/agents-api/src/domains/run/handlers/executionHandler.ts
@@ -14,6 +14,7 @@ import {
 import runDbClient from '../../../data/db/runDbClient.js';
 import { flushBatchProcessor } from '../../../instrumentation.js';
 import { getLogger } from '../../../logger.js';
+import { getInProcessFetch } from '../../../utils/in-process-fetch.js';
 import { triggerConversationEvaluation } from '../../evals/services/conversationEvaluation.js';
 import { A2AClient } from '../a2a/client.js';
 import { executeTransfer } from '../a2a/transfer.js';
@@ -265,9 +266,9 @@ export class ExecutionHandler {
             'x-inkeep-project-id': projectId,
             'x-inkeep-agent-id': agentId,
             'x-inkeep-sub-agent-id': currentAgentId,
-            // Forward user session headers for MCP tool authentication
             ...(forwardedHeaders || {}),
           },
+          fetchFn: getInProcessFetch(),
         });
 
         let messageResponse: SendMessageResponse | null = null;

--- a/agents-api/src/utils/__tests__/in-process-fetch.test.ts
+++ b/agents-api/src/utils/__tests__/in-process-fetch.test.ts
@@ -1,0 +1,49 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+describe('in-process-fetch', () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  it('should return registered fetch when app is registered', async () => {
+    const { registerAppFetch, getInProcessFetch } = await import('../in-process-fetch');
+    const mockFetch = vi.fn() as unknown as typeof fetch;
+
+    registerAppFetch(mockFetch);
+
+    expect(getInProcessFetch()).toBe(mockFetch);
+  });
+
+  it('should throw in production when not registered', async () => {
+    vi.stubEnv('ENVIRONMENT', 'production');
+
+    const { getInProcessFetch } = await import('../in-process-fetch');
+
+    expect(() => getInProcessFetch()).toThrow('[in-process-fetch] App fetch not registered');
+
+    vi.unstubAllEnvs();
+  });
+
+  it('should fall back to global fetch in test environment when not registered', async () => {
+    vi.stubEnv('ENVIRONMENT', 'test');
+
+    const { getInProcessFetch } = await import('../in-process-fetch');
+
+    expect(getInProcessFetch()).toBe(fetch);
+
+    vi.unstubAllEnvs();
+  });
+
+  it('should return registered fetch even in test environment', async () => {
+    vi.stubEnv('ENVIRONMENT', 'test');
+
+    const { registerAppFetch, getInProcessFetch } = await import('../in-process-fetch');
+    const mockFetch = vi.fn() as unknown as typeof fetch;
+
+    registerAppFetch(mockFetch);
+
+    expect(getInProcessFetch()).toBe(mockFetch);
+
+    vi.unstubAllEnvs();
+  });
+});

--- a/agents-api/src/utils/in-process-fetch.ts
+++ b/agents-api/src/utils/in-process-fetch.ts
@@ -1,0 +1,35 @@
+/**
+ * In-process fetch transport for internal self-calls.
+ *
+ * Routes requests through the Hono app's full middleware stack in-process
+ * rather than over the network. This guarantees same-instance execution,
+ * which is critical for features that rely on process-local state
+ * (e.g. the stream helper registry for real-time SSE streaming).
+ *
+ * Drop-in replacement for `fetch()` — same signature, same return type.
+ * Throws in production if the app hasn't been registered.
+ * Falls back to global `fetch` in test environments where the full app
+ * may not be initialized.
+ *
+ * @example
+ * import { getInProcessFetch } from './utils/in-process-fetch';
+ * const response = await getInProcessFetch()(url, init);
+ */
+
+let _appFetch: typeof fetch | undefined;
+
+export function registerAppFetch(fn: typeof fetch): void {
+  _appFetch = fn;
+}
+
+export function getInProcessFetch(): typeof fetch {
+  if (!_appFetch) {
+    if (process.env.ENVIRONMENT === 'test') {
+      return fetch;
+    }
+    throw new Error(
+      '[in-process-fetch] App fetch not registered. Call registerAppFetch() during app initialization before handling requests.'
+    );
+  }
+  return _appFetch;
+}


### PR DESCRIPTION
## Background: How Streaming Works Today

When a user sends a chat message, the system opens a Server-Sent Events (SSE) stream back to the client. The response is generated by an AI agent, which writes text deltas to this stream in real-time via a **`StreamHelper`** — registered in an in-memory `Map` (the **stream helper registry**), keyed by a unique `requestId`.

## Background: How Internal Agent Calls Work

The **ExecutionHandler** dispatches work to agents via the **A2A protocol** — an HTTP call using `A2AClient` to the service's own `/run/agents/a2a` endpoint. The agent looks up the `StreamHelper` by `requestId` and writes text deltas directly. The critical detail: this call goes **over HTTP**, meaning a load balancer can route it to a **different instance**.

## The Problem

When the A2A HTTP call lands on a different instance than the one that registered the `StreamHelper`:

1. Instance A creates a `StreamHelper` and stores it in Instance A's in-memory registry.
2. `ExecutionHandler` on Instance A sends HTTP to `/run/agents/a2a`.
3. Load balancer routes to **Instance B**.
4. Instance B's agent generates a response, looks up the `StreamHelper` in **Instance B's** registry — not found.
5. **Result**: Agent completes (visible in OTEL traces), but no text reaches the user's SSE stream. The user sees an empty or prematurely-closed response.

This is **intermittent** — depends on load balancer routing.

### Full Audit: All Internal Self-Calls

| # | Location | Mechanism | What breaks |
|---|---|---|---|
| 1 | `executionHandler.ts` — Transfer loop | `A2AClient.sendMessage()` | Streaming fails (primary bug) |
| 2 | `relationTools.ts` — Internal delegation | `A2AClient.sendMessage()` | Operation events lost |
| 3 | `relationTools.ts` — Team agent delegation | `A2AClient.sendMessage()` | Operation events lost |
| 4 | `EvaluationService.ts` — Evals calling chat API | `fetch()` | Unnecessary latency, double invocation cost on serverless |
| 5 | `createApp.ts` — Workflow queue forwarding | `fetch()` | Fragile self-reachability, future middleware drift |

## Solution: Unified In-Process Fetch Transport

### Design principle

> **When calling your own service, use `getInProcessFetch()` instead of `fetch()`.**

A drop-in `fetch` replacement (literally `typeof fetch`) that routes requests through the Hono app's full middleware stack **in-process**. Same auth, same project config, same ref resolution, same baggage — identical to a real HTTP request, but guaranteed same-instance.

### Implementation

**New module** — `agents-api/src/utils/in-process-fetch.ts` (~37 lines):
- `registerAppFetch(fn)` — called once at app startup with `app.request.bind(app)`
- `getInProcessFetch()` — returns the in-process fetch; **throws in production** if not registered (catches misconfiguration immediately); falls back to global `fetch` in test environments (`process.env.ENVIRONMENT === 'test'`)

**`A2AClient` change** — optional `fetchFn` field on `A2AClientOptions`. Internal callers pass `getInProcessFetch()`. External callers omit it (defaults to real `fetch`). All 5 internal `fetch()` calls in the class use `this.fetchFn`.

**Call site changes** (all 5 sites, same pattern):
- Sites 1-3: `fetchFn: getInProcessFetch()` passed to `A2AClient` constructor
- Site 4: `getInProcessFetch()(chatUrl, ...)` replacing `fetch(chatUrl, ...)`
- Site 5: `getInProcessFetch()(forwardedRequest)` replacing `fetch(forwardedRequest)`

### What doesn't change

- `ExecutionHandlerParams` — no new fields
- Route handlers (`chat.ts`, `chatDataStream.ts`, `TriggerService.ts`) — untouched
- `@inkeep/agents-core` types — untouched
- `StreamHelper` / `stream-registry.ts` — works as-is
- External A2A calls (to external agents) — still use real HTTP `fetch`

## Options Considered and Discarded

| Option | Why discarded |
|---|---|
| **Sticky sessions** | Unsupported on Vercel serverless. Brittle under scaling/restarts. |
| **Distributed streaming bus** (Redis pub/sub) | Infrastructure overhead, ordering/backpressure complexity. Overkill for a routing problem. |
| **Direct function call** (bypass HTTP stack) | Skips middleware — creates silent drift when new middleware is added. |

## Future Considerations: Distributed Execution Mode

`getInProcessFetch()` is designed as the **deployment-mode configuration point**:

- **Single-instance (current)**: `registerAppFetch(app.request.bind(app))` — in-process routing
- **Distributed (future)**: `registerAppFetch(fetch)` or `registerAppFetch(workerDispatchFetch)` — routes to workers via network/queue

In distributed mode, stream bridging would be handled by the coordinator consuming the worker's streaming response and piping it to the local `StreamHelper` (the A2A protocol already supports this via `sendMessageStream()`). The transition is additive — new env var, new registration logic — **none of the 5 call sites change**.

## Files Changed

| File | Change |
|---|---|
| `agents-api/src/utils/in-process-fetch.ts` | **New** — `registerAppFetch` / `getInProcessFetch` module |
| `agents-api/src/domains/run/a2a/client.ts` | Add `fetchFn` to `A2AClientOptions`, use in all fetch calls |
| `agents-api/src/createApp.ts` | Register app fetch at startup; use for workflow forward |
| `agents-api/src/domains/run/handlers/executionHandler.ts` | Pass `fetchFn: getInProcessFetch()` to `A2AClient` |
| `agents-api/src/domains/run/agents/relationTools.ts` | Pass `fetchFn: getInProcessFetch()` for internal/team delegation |
| `agents-api/src/domains/evals/services/EvaluationService.ts` | Use `getInProcessFetch()` for chat API self-call |

## Test Plan

- [x] Typecheck passes (`pnpm typecheck`)
- [x] Lint passes (`pnpm lint` — 285 files, 0 warnings)
- [x] Formatter clean (`pnpm format`)
- [x] Unit tests pass (agents-api)
- [ ] Verify streaming works end-to-end in deployed preview
- [ ] Verify agent transfers produce streamed text in the UI
- [ ] Verify eval dataset runs complete successfully

Made with [Cursor](https://cursor.com)