### PR TITLE
feat: Closed PR Review Auto-Improver (automated feedback loop)

### DIFF
--- a/.github/workflows/closed-pr-review-auto-improver.yml
+++ b/.github/workflows/closed-pr-review-auto-improver.yml
@@ -262,3 +262,12 @@ jobs:
             5. If no generalizable patterns: Output your analysis JSON and exit
 
             Be conservative: only HIGH generalizability patterns should become PRs.
+
+      - name: Upload Debug Artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: auto-improver-debug-pr-${{ steps.pr-meta.outputs.pr_number }}-${{ github.run_id }}
+          path: ${{ steps.analyze.outputs.execution_file }}
+          retention-days: 7
+          if-no-files-found: ignore


### PR DESCRIPTION
## Summary

Introduces an automated system that **learns from human reviewers** to continuously improve our AI code review agents.

### The Problem

When human reviewers catch issues that our `pr-review-*` agents miss, that knowledge currently dies with the PR. We manually noticed patterns like "Type Definition Discipline" (PR #1737) but there's no systematic way to:
1. Detect when humans catch something bots missed
2. Determine if it's a generalizable pattern (vs repo-specific)
3. Propose improvements to the reviewer agents

### The Solution

A GitHub Actions workflow that triggers **after every PR merge** (or manually for testing):

```
PR Merged → Extract Human Comments → Analyze Gaps → Apply Generalizability Test → Create Draft PR (if HIGH)
```

**Key innovation: Git time-travel** — The agent reconstructs what the human reviewer saw at comment time (not the final merged state), since issues are often fixed before merge.

### Architecture

**Plugin isolation**: The agent and skills live in a private repo (`inkeep/internal-cc-plugins`) and are loaded via `--plugin-dir` at CI runtime. This keeps CI/CD-only capabilities out of the main workspace.

**Cross-repo auth**: Uses a GitHub App (`inkeep-internal-ci`) with 8-hour tokens instead of PATs for better security and zero manual rotation.

```
inkeep/agents                          inkeep/internal-cc-plugins (private)
├── .github/workflows/                 ├── closed-pr-review-auto-improver/
│   └── closed-pr-review-auto-         │   ├── agents/
│       improver.yml ─────────────────────►│   │   └── closed-pr-review-auto-improver.md
│       (clones plugin repo,           │   └── skills/
│        uses --plugin-dir)            │       ├── find-similar-patterns/
                                       │       ├── pr-review-subagents-available/
                                       │       └── pr-review-subagents-guidelines/
```

### How It Works

1. **Trigger**: `pull_request_target: [closed]` + `merged == true`, or `workflow_dispatch` for manual testing
2. **Auth**: GitHub App generates 8-hour token to clone `internal-cc-plugins`
3. **Extract**: GraphQL query fetches all comment types (discussion, inline, reviews)
4. **Filter**: Removes bot comments and trivial human comments ("LGTM", "thanks")
5. **Analyze**: Agent investigates each promising comment:
   - Uses `git rev-list --before` + `git show` to see code at comment time
   - Progressive context gathering (diffHunk → full file → PR diff → other files)
   - Explicit stop conditions: EXIT A (not generalizable) or EXIT B (pattern found)
6. **Test**: 4-criteria generalizability test (cross-codebase, universal principle, expressible, industry-recognized)
7. **Output**: If HIGH generalizability → creates draft PR with improvements to `pr-review-*.md`

### Generalizability Test (all must pass)

| Criterion | Question |
|-----------|----------|
| Cross-codebase | Would this pattern appear in other TS/React/Node codebases? |
| Universal principle | Is it DRY, SOLID, separation of concerns, etc.? |
| Expressible | Can it be a checklist item, detection pattern, or failure mode? |
| Industry recognition | Would senior engineers elsewhere recognize this? |

**Conservative by default**: Better to miss a good pattern than pollute reviewers with repo-specific noise.

### Manual Testing

After merge, you can test against historical PRs:

1. Go to **Actions** → **Closed PR Review Auto-Improver**
2. Click **Run workflow**
3. Enter a PR number (e.g., `1737` for the type/schema feedback)
4. Watch it analyze the historical human comments

### Files Changed

| File | Purpose |
|------|---------|
| `.github/workflows/closed-pr-review-auto-improver.yml` | Workflow: trigger, GitHub App auth, comment extraction, plugin loading |

### Prerequisites (already set up)

- [x] GitHub App `inkeep-internal-ci` created with Contents:read permission
- [x] App installed on `internal-cc-plugins` repo
- [x] Secrets added: `INTERNAL_CI_APP_ID`, `INTERNAL_CI_APP_PRIVATE_KEY`
- [x] Plugin repo `inkeep/internal-cc-plugins` with agent + skills

### Design Decisions

| Decision | Choice | Rationale |
|----------|--------|-----------|
| Auth method | GitHub App | 8-hour tokens, no rotation, survives user departure |
| Plugin location | Private repo | Keeps CI-only agents out of main workspace |
| Output action | Draft PRs | Human review of proposed improvements |
| Generalizability threshold | HIGH only | Conservative; MEDIUM noted but no PR |
| Model | Opus | Pattern recognition requires strong reasoning |

---

## Test Plan

- [ ] Verify workflow triggers on merged PRs (not closed-without-merge)
- [ ] Test `workflow_dispatch` with historical PR number (e.g., 1737)
- [ ] Verify GitHub App token generation and plugin repo clone
- [ ] Test comment extraction against a known PR with human comments
- [ ] Verify bot filtering excludes claude-code, dependabot, etc.
- [ ] Test git time-travel reconstructs correct code state
- [ ] Verify agent correctly classifies repo-specific vs generalizable patterns
- [ ] Confirm draft PR creation with proper formatting

---

🤖 Generated with [Claude Code](https://claude.ai/code)