### PR TITLE
fix: update profile config test URLs to match new cloud endpoints

### DIFF
--- a/agents-cli/src/__tests__/utils/profile-config.test.ts
+++ b/agents-cli/src/__tests__/utils/profile-config.test.ts
@@ -80,7 +80,7 @@ describe('Profile Configuration', () => {
 
       const profile = profileManager.getProfile('production');
       expect(profile?.name).toBe('production');
-      expect(profile?.remote.api).toBe('https://agents-api.inkeep.com');
+      expect(profile?.remote.api).toBe('https://api.agents.inkeep.com');
       expect(profile?.environment).toBe('production');
     });
 
@@ -123,8 +123,8 @@ describe('Profile Configuration', () => {
       writeFileSync(join(testDir, 'profiles.yaml'), yaml.stringify(config));
 
       const profile = profileManager.getActiveProfile();
-      expect(profile.remote.api).toBe('https://agents-api.inkeep.com');
-      expect(profile.remote.manageUi).toBe('https://manage.inkeep.com');
+      expect(profile.remote.api).toBe('https://api.agents.inkeep.com');
+      expect(profile.remote.manageUi).toBe('https://app.inkeep.com');
     });
 
     it('should use explicit URLs when provided', () => {


### PR DESCRIPTION
## Summary
- Updates `profile-config.test.ts` expectations to match the new cloud URLs introduced in #1752
  - `https://agents-api.inkeep.com` -> `https://api.agents.inkeep.com`
  - `https://manage.inkeep.com` -> `https://app.inkeep.com`

## Test plan
- [x] `agents-cli` tests pass (39 files, 616 tests)
- [x] Verified the expected URLs match the constants in `agents-cli/src/utils/profiles/types.ts`

Made with [Cursor](https://cursor.com)