### PR TITLE
fix: Add id-token permission for auto-improver OIDC

### DIFF
--- a/.github/workflows/closed-pr-review-auto-improver.yml
+++ b/.github/workflows/closed-pr-review-auto-improver.yml
@@ -23,6 +23,7 @@ jobs:
       contents: write      # For creating branches and commits
       pull-requests: write # For creating draft PRs
       issues: read         # For reading PR comments
+      id-token: write      # For OIDC token (required by claude-code-action)
 
     steps:
       - name: Checkout


### PR DESCRIPTION
Adds missing `id-token: write` permission required by `claude-code-action` for OIDC authentication.

Without this, the workflow fails with: *"Did you remember to add id-token: write to your workflow permissions?"*

---
🤖 Generated with [Claude Code](https://claude.ai/code)