### PR TITLE
fix(manage-ui): MCP Tool Calls scrollbox not filling parent container

### DIFF
--- a/.changeset/fix-mcp-scrollbox-sizing.md
+++ b/.changeset/fix-mcp-scrollbox-sizing.md
@@ -1,0 +1,5 @@
+---
+'@inkeep/agents-manage-ui': patch
+---
+
+Fix MCP Tool Calls card scrollbox to fill parent container instead of being capped at 120px

--- a/agents-manage-ui/src/components/traces/mcp-breakdown-card.tsx
+++ b/agents-manage-ui/src/components/traces/mcp-breakdown-card.tsx
@@ -105,7 +105,7 @@ export function MCPBreakdownCard({ conversation }: MCPBreakdownCardProps) {
           {mcpStats.totalCalls === 0 ? (
             <div className="text-sm text-muted-foreground px-3 py-2">0 MCP tool calls</div>
           ) : (
-            <div className="space-y-3 max-h-[120px] overflow-y-auto pr-1">
+            <div className="space-y-3 h-full overflow-y-auto pr-1">
               {mcpStats.servers.map((server) => (
                 <div key={server.serverName} className="space-y-1">
                   {/* Server Name Header */}


### PR DESCRIPTION
## Summary

- Fixes the MCP Tool Calls card scrollbox on the conversation details page being mis-sized — it was capped at `120px` (`max-h-[120px]`) instead of filling the available space in the parent grid row.
- Changed to `h-full` so the scrollable list stretches to match sibling cards (Duration, AI Calls, Alerts).

## Test plan

- [ ] Navigate to a conversation detail page with MCP tool calls (e.g. `/traces/conversations/<id>`)
- [ ] Verify the MCP Tool Calls card content area fills the full card height, matching the other summary cards in the row
- [ ] Verify scrolling still works when there are many tool calls


Made with [Cursor](https://cursor.com)