### PR TITLE
fix(pr-review): correct MCP tool names for batched review

### DIFF
--- a/.claude/agents/pr-review.md
+++ b/.claude/agents/pr-review.md
@@ -158,14 +158,11 @@ Feel free to make your own determination about the confidence and severity level
 Create a pending (draft) review. Nothing is visible to anyone until you submit in Phase 6.
 
 ```
-mcp__github__pull_request_review_write
-  method: "create"
+mcp__github__create_pending_pull_request_review
   owner: {from pr-context: Repo field, before the '/'}
   repo: {from pr-context: Repo field, after the '/'}
   pullNumber: {from pr-context: PR number}
 ```
-
-No `event` parameter = PENDING state.
 
 ### 5.1 Identify Inline-Eligible Findings
 
@@ -410,8 +407,7 @@ Previous issues posted by humans or yourself from **previous runs** that are sti
 Submit the pending review with the summary as the review body. This atomically publishes both the review body AND all inline comments added in Phase 5 as a single PR review.
 
 ```
-mcp__github__pull_request_review_write
-  method: "submit_pending"
+mcp__github__submit_pending_pull_request_review
   owner: {from pr-context: Repo field, before the '/'}
   repo: {from pr-context: Repo field, after the '/'}
   pullNumber: {from pr-context: PR number}
@@ -540,8 +536,9 @@ Throughout Phases 4–6, track the **origin reviewer** for every finding (includ
 | **Read** | Examine files for context before dispatch |
 | **Grep/Glob** | Discover files by pattern |
 | **Bash** | Git operations (`git diff`, `git merge-base`), `gh api` for queries |
-| **mcp__github__pull_request_review_write** | Create pending review (Phase 5.0), submit review with body + event (Phase 6) |
+| **mcp__github__create_pending_pull_request_review** | Create pending review (Phase 5.0) |
 | **mcp__github__add_comment_to_pending_review** | Add inline comments with suggestion blocks to the pending review (Phase 5.3) |
+| **mcp__github__submit_pending_pull_request_review** | Submit review with body + event (Phase 6) |
 
 **Do not:** Write files, edit code, or use Bash for non-git commands.
 

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -271,7 +271,7 @@ jobs:
           claude_args: |
             --agent pr-review
             --mcp-config '{"mcpServers":{"exa":{"command":"npx","args":["-y","exa-mcp-server"],"env":{"EXA_API_KEY":"${{ secrets.EXA_API_KEY }}"}}}}'
-            --allowedTools "Task,Read,Grep,Glob,mcp__exa__web_search_exa,mcp__github__pull_request_review_write,mcp__github__add_comment_to_pending_review,Bash(git diff:*),Bash(git log:*),Bash(git show:*),Bash(git merge-base:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh api:*)"
+            --allowedTools "Task,Read,Grep,Glob,mcp__exa__web_search_exa,mcp__github__create_pending_pull_request_review,mcp__github__add_comment_to_pending_review,mcp__github__submit_pending_pull_request_review,Bash(git diff:*),Bash(git log:*),Bash(git show:*),Bash(git merge-base:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh api:*)"
           prompt: |
             Review PR #${{ github.event.pull_request.number }}.
 


### PR DESCRIPTION
## Summary

Fixes the MCP tool names used in the batched PR review workflow (shipped in #1792). The pinned `claude-code-action` version bundles an older `github-mcp-server` that uses **separate tools**, not the consolidated `pull_request_review_write` from the latest `github-mcp-server` main branch.

## Root Cause

From the execution logs of the failed review on PR #1789:

```
[msg 126] mcp__github__create_pending_pull_request_review
  -> Result [ERROR]: Claude requested permissions to use mcp__github__create_pending_pull_request_review,
     but you haven't granted it yet.
```

Claude found the correct tools in the MCP server, but they weren't in `--allowedTools` because we listed `mcp__github__pull_request_review_write` (which doesn't exist in this version). Claude then fell back to posting the review as an issue comment, which the cleanup step deleted -- resulting in no visible output.

## Fix

| What we had (wrong) | Actual tool name (pinned version) |
|---------------------|----------------------------------|
| `mcp__github__pull_request_review_write` | `mcp__github__create_pending_pull_request_review` |
| (same tool, method: submit_pending) | `mcp__github__submit_pending_pull_request_review` |
| `mcp__github__add_comment_to_pending_review` | `mcp__github__add_comment_to_pending_review` (was correct) |

Updated in both `claude-code-review.yml` (`--allowedTools`) and `pr-review.md` (Phase 5.0, Phase 6 submit, Tool Policy table).

## Test plan

- [ ] Merge this PR
- [ ] Rebase `retry-triggers` branch onto main to trigger a new review on PR #1789
- [ ] Verify the batched review appears as a single PR Review with inline comments grouped under "View changes"

Made with [Cursor](https://cursor.com)