### PR TITLE
improve(pr-review): Reviewer tiers, pending recommendations, and context fetching

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -80,7 +80,7 @@ jobs:
                       path
                       line
                       diffSide
-                      comments(first: 5) {
+                      comments(first: 10) {
                         nodes {
                           author { login }
                           body
@@ -92,7 +92,7 @@ jobs:
                       }
                     }
                   }
-                  reviews(last: 10) {
+                  reviews(last: 20) {
                     nodes {
                       author { login }
                       body
@@ -127,7 +127,7 @@ jobs:
             query($owner: String!, $repo: String!, $pr: Int!) {
               repository(owner: $owner, name: $repo) {
                 pullRequest(number: $pr) {
-                  comments(first: 50) {
+                  comments(last: 50) {
                     nodes {
                       author {
                         __typename


### PR DESCRIPTION
## Summary

- **Reviewer tier restructure**: Split the flat "Conditional" tier into **Critical Domain** (architecture, security-iam, sre) and **Domain-Specific** (frontend, errors, llm, devops, comments) to properly signal irreversible/catastrophic risk vs. domain expertise
- **Pending Recommendations from previous reviews**: The orchestrator now surfaces unresolved findings from both `Existing Review Threads` (inline comments) AND `Previous Reviews` (review body findings) — previously, review-body-only findings (like PR #1789) were invisible on re-runs
- **Terminology alignment**: Added a mapping table (pr-context sections → GitHub API concepts) and aligned all references throughout the prompt to use consistent terms
- **Core skip refinement**: Docs-only PRs now correctly run `pr-review-docs`, `pr-review-product`, and `pr-review-consistency` instead of skipping all Core reviewers
- **GraphQL fetch limits**: Thread replies `first: 5` → `first: 10`, reviews `last: 10` → `last: 20`, PR discussion `first: 50` → `last: 50` (prioritize recent comments)
- **Housekeeping**: Removed duplicate Reviewer Stats section, fixed typos

## Test plan

- [ ] Trigger a PR review on a PR with prior review-body-only findings (no inline comments) and verify Pending Recommendations surfaces them
- [ ] Trigger a PR review on a docs-only PR and verify only docs/product/consistency Core reviewers are selected
- [ ] Verify reviewer selection logs show the new tier names (Critical Domain, Domain-Specific)


Made with [Cursor](https://cursor.com)