### PR TITLE
Fix mixed changeset blocking release pipeline

### DIFF
--- a/.changeset/violet-feet-itch.md
+++ b/.changeset/violet-feet-itch.md
@@ -1,6 +1,5 @@
 ---
 "@inkeep/agents-api": patch
-"@inkeep/agents-docs": patch
 ---
 
 Refactor: Consolidate to single-phase generation


### PR DESCRIPTION
## Summary
- Remove `@inkeep/agents-docs` from the `violet-feet-itch` changeset since it is in the changesets ignore list, which caused a "mixed changeset" error during the Release workflow.

## Test plan
- [ ] Verify the Release GitHub Action passes after merge

Made with [Cursor](https://cursor.com)