### PR TITLE
chore: Add .vercel directory to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -109,3 +109,4 @@ progress.txt
 *-actual-chromium.png
 
 .pnpm-store/
+.vercel


### PR DESCRIPTION
Add .vercel directory to .gitignore to exclude Vercel deployment metadata from version control.

Made with [Cursor](https://cursor.com)