### PR TITLE
fix: mock execution-limits constants in model-context-utils tests

### DIFF
--- a/agents-api/src/domains/run/utils/__tests__/model-context-utils.test.ts
+++ b/agents-api/src/domains/run/utils/__tests__/model-context-utils.test.ts
@@ -64,6 +64,11 @@ vi.mock('../../constants/execution-limits', () => ({
   COMPRESSION_ENABLED: true,
   COMPRESSION_HARD_LIMIT: 120000,
   COMPRESSION_SAFETY_BUFFER: 20000,
+  executionLimitsDefaults: {
+    COMPRESSION_ENABLED: true,
+    COMPRESSION_HARD_LIMIT: 120000,
+    COMPRESSION_SAFETY_BUFFER: 20000,
+  },
 }));
 
 describe('Model Context Utils', () => {

--- a/agents-docs/content/talk-to-your-agents/(chat-components)/meta.json
+++ b/agents-docs/content/talk-to-your-agents/(chat-components)/meta.json
@@ -1,1 +1,5 @@
-{"title":"Chat Components","icon":"LuBlocks","pages":["index","react","nextjs","javascript","customization","..."]}
+{
+  "title": "Chat Components",
+  "icon": "LuBlocks",
+  "pages": ["index", "react", "nextjs", "javascript", "customization", "..."]
+}

--- a/agents-docs/content/talk-to-your-agents/(chat-components)/nextjs/meta.json
+++ b/agents-docs/content/talk-to-your-agents/(chat-components)/nextjs/meta.json
@@ -1,1 +1,5 @@
-{"title":"Next.js","icon":"LuLayout","pages":["index","chat-button","custom-trigger","side-bar-chat","embedded-chat"]}
+{
+  "title": "Next.js",
+  "icon": "LuLayout",
+  "pages": ["index", "chat-button", "custom-trigger", "side-bar-chat", "embedded-chat"]
+}


### PR DESCRIPTION
## Problem

After #1819 fixed `z.stringbool()` parsing, the 3 model-context-utils tests started failing in CI:

- `should apply aggressive thresholds for large models (>500K)`
- `should use environment variables when set`
- `should use default values when environment variables not set`

All 3 failures showed `enabled: false` instead of `enabled: true`.

## Root Cause

`vitest.config.ts` sets `AGENTS_COMPRESSION_ENABLED: 'false'` globally. Before #1819, `z.coerce.boolean()` coerced the string `'false'` to `true` (since `Boolean('false') === true` in JS). After the fix to `z.stringbool()`, `'false'` now correctly parses to `false`.

The module-level constant `COMPRESSION_ENABLED` is evaluated at import time via `parseConstants()`, so the test's `beforeEach` `delete process.env.AGENTS_COMPRESSION_ENABLED` has no effect on the already-computed constant.

## Fix

Mock the `execution-limits` module directly in the test file (same pattern as the existing `llm-info` and `logger` mocks), so the tests control the constant values and aren't affected by global vitest env config.