### PR TITLE
fix: hydration error from date formatting timezone mismatch

### DIFF
--- a/.changeset/fix-date-hydration.md
+++ b/.changeset/fix-date-hydration.md
@@ -1,0 +1,5 @@
+---
+"@inkeep/agents-manage-ui": patch
+---
+
+Fix hydration error by adding UTC timezone to all date formatting functions. Ensures server and client render identical date strings regardless of server/client timezone differences.

--- a/agents-manage-ui/src/lib/utils/format-date.ts
+++ b/agents-manage-ui/src/lib/utils/format-date.ts
@@ -38,6 +38,7 @@ export function formatDate(dateString: string) {
       month: 'short',
       day: 'numeric',
       year: 'numeric',
+      timeZone: 'UTC',
     });
     return formatter.format(date);
   } catch (error) {
@@ -58,6 +59,7 @@ export function formatDateTime(dateString: string): string {
     minute: '2-digit',
     second: '2-digit',
     hour12: true,
+    timeZone: 'UTC',
   }).format(date); // e.g. "Aug 28, 2024, 5:42:30 PM"
 }
 
@@ -72,6 +74,7 @@ export function formatDateTimeTable(dateString: string): string {
     hour: 'numeric',
     minute: '2-digit',
     hour12: true,
+    timeZone: 'UTC',
   }).format(date); // e.g. "Aug 28, 2024, 5:42 PM"
 }
 
@@ -116,6 +119,7 @@ export function formatDateAgo(dateString: string) {
       month: 'short',
       day: 'numeric',
       year: date.getFullYear() !== now.getFullYear() ? 'numeric' : undefined,
+      timeZone: 'UTC',
     });
   } catch (error) {
     console.warn('Error formatting date:', dateString, error);


### PR DESCRIPTION
## Summary

Fixes [PILOT-INKEEP-COM-J](https://inkeep.sentry.io/issues/PILOT-INKEEP-COM-J) - Hydration error affecting 59 occurrences across 60+ URLs, impacting 15 users since Jan 15.

## Problem

All date formatting functions in `format-date.ts` used `Intl.DateTimeFormat` without specifying `timeZone`, causing server/client mismatches:
- **Server** (Vercel): defaults to UTC
- **Client** (browser): defaults to user's local timezone

For dates near midnight UTC, this produces different formatted strings (e.g., "Jan 20, 2025" vs "Jan 19, 2025"), triggering React hydration errors.

## Changes

Added `timeZone: 'UTC'` to all date formatting functions:
- `formatDate`
- `formatDateTime`
- `formatDateTimeTable`
- `formatDateAgo`

## Test plan

- [x] All 22 existing format-date tests pass
- [x] No linter errors introduced
- [ ] Monitor Sentry after deployment for resolution


Made with [Cursor](https://cursor.com)