### PR TITLE
fix: unmask static UI chrome in Sentry and PostHog session replays

### DIFF
--- a/agents-manage-ui/src/instrumentation-client.ts
+++ b/agents-manage-ui/src/instrumentation-client.ts
@@ -3,6 +3,7 @@
 // https://docs.sentry.io/platforms/javascript/guides/nextjs/
 
 import type * as SentryNs from '@sentry/nextjs';
+import { REPLAY_UNMASK_SELECTORS, REPLAY_UNBLOCK_SELECTORS } from '@/lib/replay-privacy';
 
 export let onRouterTransitionStart: typeof SentryNs.captureRouterTransitionStart;
 
@@ -14,7 +15,20 @@ if (process.env.NEXT_PUBLIC_SENTRY_DSN) {
     dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
 
     // Add optional integrations for additional features
-    integrations: [Sentry.replayIntegration()],
+    integrations: [
+      Sentry.replayIntegration({
+        // Keep maskAllText: true (default) so all text is masked by default.
+        // Keep maskAllInputs: true (default) so form inputs stay masked.
+        // Keep blockAllMedia: true (default) so media is blocked by default.
+
+        // Unmask static UI chrome that doesn't contain user-generated PII.
+        // Selectors defined in @/lib/replay-privacy.ts (shared with PostHog).
+        unmask: [...REPLAY_UNMASK_SELECTORS],
+
+        // Unblock SVG icons in UI chrome so layout and iconography are visible.
+        unblock: [...REPLAY_UNBLOCK_SELECTORS],
+      }),
+    ],
 
     // Define how likely traces are sampled. Adjust this value in production, or use tracesSampler for greater control.
     tracesSampleRate: 1,

--- a/agents-manage-ui/src/lib/replay-privacy.ts
+++ b/agents-manage-ui/src/lib/replay-privacy.ts
@@ -1,0 +1,52 @@
+/**
+ * Shared selectors for session replay privacy configuration.
+ *
+ * Both Sentry and PostHog session replays mask all text by default.
+ * These selectors identify static UI chrome (navigation, buttons, labels, etc.)
+ * that is safe to unmask because it doesn't contain user-generated PII.
+ *
+ * Sentry uses these as the `unmask` array in `replayIntegration()`.
+ * PostHog uses these joined into a single selector for `element.closest()` in `maskTextFn`.
+ */
+
+/** CSS selectors for static UI elements that are safe to show in session replays. */
+export const REPLAY_UNMASK_SELECTORS = [
+  // Sidebar navigation (menu items, group labels, header, footer)
+  '[data-slot="sidebar"]',
+  // Buttons
+  '[data-slot="button"]',
+  // Tabs
+  '[role="tab"]',
+  '[role="tablist"]',
+  // Breadcrumbs
+  'nav[aria-label="Breadcrumb"]',
+  // Headings (page titles, section headers)
+  'h1',
+  'h2',
+  'h3',
+  'h4',
+  // Table headers
+  'thead',
+  'th',
+  // Form labels (not form values)
+  'label',
+  // Dropdown menus, select options, tooltips
+  '[role="menuitem"]',
+  '[role="menuitemradio"]',
+  '[role="menuitemcheckbox"]',
+  '[role="option"]',
+  '[role="tooltip"]',
+  // Dialog/sheet titles
+  '[role="dialog"]',
+  '[role="alertdialog"]',
+] as const;
+
+/** Pre-joined selector string for use with `element.closest()`. */
+export const REPLAY_UNMASK_SELECTOR_STRING = REPLAY_UNMASK_SELECTORS.join(', ');
+
+/** CSS selectors for media elements (SVG icons) that are safe to unblock in Sentry replays. */
+export const REPLAY_UNBLOCK_SELECTORS = [
+  '[data-slot="sidebar"] svg',
+  '[data-slot="button"] svg',
+  'nav svg',
+] as const;


### PR DESCRIPTION
## Summary

- **Sentry replays** were completely unusable — `replayIntegration()` had no options, so the default `maskAllText: true` + `blockAllMedia: true` masked everything with `****`
- **PostHog replays** had no `session_recording` privacy config at all, meaning all text was recorded in the clear (privacy concern)

This PR configures both systems with a consistent "mask by default, unmask static chrome" approach:

- **Sentry** (`instrumentation-client.ts`): Added `unmask` and `unblock` selector arrays to reveal sidebar nav, buttons, tabs, breadcrumbs, headings, table headers, labels, menus, tooltips, and SVG icons — while keeping `maskAllText`, `maskAllInputs`, and `blockAllMedia` enabled
- **PostHog** (`posthog.tsx`): Added `session_recording` config with `maskTextSelector: '*'` and a `maskTextFn` that uses the same set of safe selectors via `element.closest()` to selectively reveal static UI chrome

### What's unmasked (static UI chrome)
- Sidebar navigation items and group labels
- Buttons, tabs, breadcrumbs
- Headings (`h1`–`h4`), table headers, form labels
- Dropdown menu items, tooltips, dialog titles

### What stays masked (user content)
- All text in the main content area not matched by the selectors
- All form input/textarea values
- All media (except unblocked SVG icons in Sentry)

## Test plan
- [ ] Deploy to a staging/preview environment
- [ ] Trigger a Sentry replay and verify sidebar, buttons, tabs, headings are visible while form inputs and main content text remain masked
- [ ] Trigger a PostHog recording and verify the same masking behavior
- [ ] Confirm no PII (API keys, emails, config values) leaks through the unmasked selectors


Made with [Cursor](https://cursor.com)