### PR TITLE
feat: add client-side search to project switcher dropdown

### DIFF
--- a/agents-manage-ui/src/components/sidebar-nav/project-switcher.tsx
+++ b/agents-manage-ui/src/components/sidebar-nav/project-switcher.tsx
@@ -95,6 +95,13 @@ export const ProjectSwitcher: FC = () => {
         <div className="flex items-center gap-2 px-2 py-1.5">
           <Search className="size-4 shrink-0 text-muted-foreground" />
           <Input
+            aria-label="Search projects"
+            placeholder="Search projects..."
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            onKeyDown={(e) => e.stopPropagation()}
+            className="h-7 border-none shadow-none focus-visible:ring-0 px-0"
+          />
             placeholder="Search projects..."
             value={search}
             onChange={(e) => setSearch(e.target.value)}


### PR DESCRIPTION
## Summary
- Adds a search input at the top of the project switcher dropdown menu that filters projects by name or description (client-side)
- Shows a "No projects found" empty state when the search query has no matches
- Search text resets when the dropdown is closed
- Project list is scrollable independently of the search input and "Create project" button

## Test plan
- [ ] Open the project switcher dropdown and verify the search input appears at the top
- [ ] Type a project name and verify the list filters correctly
- [ ] Type a partial match against a project description and verify it also matches
- [ ] Type a query with no matches and verify the "No projects found" message appears
- [ ] Close and reopen the dropdown and verify the search is cleared
- [ ] Verify keyboard input works in the search box without triggering dropdown navigation
- [ ] Verify the "Create project" button remains visible and functional below the project list


Made with [Cursor](https://cursor.com)