### PR TITLE
fix: guard against undefined subAgent values in agent editor

### DIFF
--- a/agents-manage-ui/src/app/[tenantId]/projects/[projectId]/agents/[agentId]/page.client.tsx
+++ b/agents-manage-ui/src/app/[tenantId]/projects/[projectId]/agents/[agentId]/page.client.tsx
@@ -264,7 +264,7 @@ export const Agent: FC<AgentProps> = ({
     if (!agent.subAgents) return {};
     const lookup: SubAgentTeamAgentConfigLookup = {};
     Object.entries(agent.subAgents).forEach(([subAgentId, agentData]) => {
-      if ('canDelegateTo' in agentData && agentData.canDelegateTo) {
+      if (agentData && 'canDelegateTo' in agentData && agentData.canDelegateTo) {
         const teamAgentConfigs: Record<string, SubAgentTeamAgentConfig> = {};
         agentData.canDelegateTo
           .filter((delegate) => typeof delegate === 'object' && 'agentId' in delegate)
@@ -793,8 +793,9 @@ export const Agent: FC<AgentProps> = ({
                 const subAgentId = mcpNode.data.subAgentId;
                 const toolId = mcpNode.data.toolId;
 
-                if (res.data.subAgents[subAgentId]?.canUse) {
-                  const matchingRelationship = res.data.subAgents[subAgentId].canUse.find(
+                const savedSubAgent = res.data.subAgents[subAgentId];
+                if (savedSubAgent?.canUse) {
+                  const matchingRelationship = savedSubAgent.canUse.find(
                     (tool: any) =>
                       tool.toolId === toolId &&
                       tool.agentToolRelationId &&

--- a/agents-manage-ui/src/features/agent/domain/deserialize.ts
+++ b/agents-manage-ui/src/features/agent/domain/deserialize.ts
@@ -107,6 +107,7 @@ export function deserializeAgentData(data: FullAgentDefinition): TransformResult
   const subAgentIds: string[] = Object.keys(data.subAgents);
   for (const subAgentId of subAgentIds) {
     const subAgent = data.subAgents[subAgentId];
+    if (!subAgent) continue;
     const isDefault = subAgentId === data.defaultSubAgentId;
 
     const nodeType = NodeType.SubAgent;
@@ -187,7 +188,7 @@ export function deserializeAgentData(data: FullAgentDefinition): TransformResult
 
   for (const subAgentId of subAgentIds) {
     const agent = data.subAgents[subAgentId];
-    if ('canUse' in agent && agent.canUse && agent.canUse.length > 0) {
+    if (agent && 'canUse' in agent && agent.canUse && agent.canUse.length > 0) {
       for (const canUseItem of agent.canUse) {
         const toolId = canUseItem.toolId;
         const toolNodeId = generateId();
@@ -261,6 +262,7 @@ export function deserializeAgentData(data: FullAgentDefinition): TransformResult
   const processedPairs = new Set<string>();
   for (const sourceSubAgentId of subAgentIds) {
     const sourceAgent = data.subAgents[sourceSubAgentId];
+    if (!sourceAgent) continue;
 
     if ('canTransferTo' in sourceAgent && sourceAgent.canTransferTo) {
       for (const targetSubAgentId of sourceAgent.canTransferTo) {


### PR DESCRIPTION
## Summary
- Fixes [PILOT-INKEEP-COM-M](https://inkeep.sentry.io/issues/PILOT-INKEEP-COM-M) — `TypeError: Cannot use 'in' operator to search for 'canUse' in undefined`
- Adds null/undefined guards before all `in` operator usages on `subAgent` objects in `deserialize.ts` and `page.client.tsx`
- Extracts `savedSubAgent` local variable in the post-save `setNodes` callback to avoid redundant lookups and ensure consistent null-safety

## Root Cause
The `in` operator in JavaScript throws a `TypeError` when its right-hand operand is not an object. In `deserializeAgentData()`, the code iterates over `Object.keys(data.subAgents)` and uses `'canUse' in agent` without first checking that `agent` is defined. If a subAgent entry has an undefined/null value (e.g. due to stale or incomplete API data), this throws the observed error. The same pattern existed in `page.client.tsx` for `'canDelegateTo' in agentData` and in the post-save relationship ID update callback.

## Changes
- **`deserialize.ts`**: Add `if (!subAgent) continue` guards in all three iteration loops over `subAgentIds`; add `agent &&` guard before `'canUse' in agent`
- **`page.client.tsx`**: Add `agentData &&` guard before `'canDelegateTo' in agentData` in team agent config lookup; extract `savedSubAgent` variable in post-save `setNodes` callback for cleaner null-safe access

## Test plan
- [x] Lint and type-check pass
- [x] Pre-push hooks (build + test) pass
- [ ] Verify the Sentry issue no longer reproduces in production after deploy

Made with [Cursor](https://cursor.com)