### PR TITLE
fix: enforce consistent PR review title for re-review delta detection

### DIFF
--- a/.claude/agents/pr-review.md
+++ b/.claude/agents/pr-review.md
@@ -406,6 +406,8 @@ The review body is the summary markdown. It will be submitted together with all 
 
 > ⚠️ **NO DUPLICATION**: Items in Pending Recommendations MUST NOT appear here. Items posted as Inline Comments must appear only as 1-line inline logs (not full writeups). See No Duplication Principle.
 
+**HARD CONSTRAINT:** The review body MUST start with exactly `## PR Review Summary` — this exact heading, every time, regardless of whether this is a first review or a re-review. The CI workflow uses a regex (`^## PR Review Summary`) to identify prior automated reviews and compute the delta for re-reviews. If you change this heading, subsequent re-reviews will fail to find this review as a baseline.
+
 ````markdown
 ## PR Review Summary
 

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -364,6 +364,8 @@ jobs:
           # Uses commit { oid } from the GraphQL reviews query to find the exact SHA
           # the last automated review was made against, then computes the delta.
           PR_HEAD="${{ steps.pr.outputs.head_sha }}"
+          # COUPLED: The regex below must match the heading in .claude/agents/pr-review.md Phase 6.2.
+          # The pr-review agent is constrained to always start its review body with "## PR Review Summary".
           LAST_REVIEW_SHA=$(echo "$REVIEWS" | jq -r '
             [.[] | select(
               (.author.login == "claude" or .author.login == "claude[bot]") and


### PR DESCRIPTION
## Summary

- The pr-review agent was producing "Re-Review Summary (Delta Focus)" as the heading on re-reviews, which broke the CI workflow's regex (`^## PR Review Summary`) used to find the last automated review commit SHA for computing the re-review delta.
- Added a hard constraint in the agent instructions (`pr-review.md`) to always use `## PR Review Summary` and a coupling comment in the workflow file pointing back to the agent.

## Test plan

- [ ] Trigger a re-review on a PR and verify the review body starts with `## PR Review Summary`
- [ ] Verify the next re-review after that correctly detects the prior review and computes the delta


Made with [Cursor](https://cursor.com)