### PR TITLE
feat: add @claude /full-review command to force full-scope PR review

### DIFF
--- a/.claude/agents/pr-review.md
+++ b/.claude/agents/pr-review.md
@@ -67,7 +67,7 @@ You may spin up multiple parallel Explore subagents or chain new ones in sequenc
 
 This step is about context gathering // "world model" building only, not about making judgements, assumptions, or determinations. Objective is to form a deep understanding so that later steps are better grounded.
 
-**Note**: In "summary mode" (large PR diffs), the diff isn't fully inline — use Explore subagents to read key changed files directly as relevant. On "re-reviews", focus exploration on the delta and how it interacts with the broader PR rather than re-exploring unchanged areas.
+**Note**: In "summary mode" (large PR diffs), the diff isn't fully inline — use Explore subagents to read key changed files directly as relevant. When `review_scope=delta` (see pr-context metadata), focus exploration on the delta and how it interacts with the broader PR rather than re-exploring unchanged areas.
 
 ## Phase 1.5: Generate PR TLDR
 
@@ -157,7 +157,7 @@ Spawn each selected reviewer via the Task tool, spawning all relevant agents **i
 
 ### 3.1 Handoff Template
 
-One template for all cases. The orchestrator fills in the conditional lines based on two signals from pr-context: **diff mode** (`inline` vs `summary`) and **review iteration** (first review vs re-review with new commits).
+One template for all cases. The orchestrator fills in the conditional lines based on two signals from pr-context: **diff mode** (`inline` vs `summary`) and **review scope** (`full` vs `delta` — see `Review scope` in pr-context metadata).
 
 Reviewers already know how to use their skills (pr-context, pr-tldr, pr-review-output-contract) — don't re-explain that in the handoff.
 
@@ -169,10 +169,10 @@ Review PR #[NUMBER]: [Title].
 [ONLY if summary mode]
 Diff not inline — read on-demand: git diff origin/[BASE]...HEAD -- <path>
 
-[ONLY if re-review]
+[ONLY if review_scope == 'delta' in pr-context metadata]
 Re-review — scope to delta only.
 
-[ONLY if summary mode OR re-review — include a file list]
+[ONLY if summary mode OR review_scope == 'delta' — include a file list]
 Files:
 - path/to/file.ts
 - path/to/other.ts
@@ -182,11 +182,13 @@ Files:
 
 | Situation | List contains |
 |-----------|---------------|
-| Summary mode, first review | Domain-relevant files from Changed Files (5-15, prioritized by diff size) |
-| Inline mode, re-review | Delta files relevant to this reviewer's domain |
-| Summary mode, re-review | Delta files only (reviewer reads via `git diff`) |
+| Summary mode, `review_scope=full` | Domain-relevant files from Changed Files (5-15, prioritized by diff size) |
+| Inline mode, `review_scope=delta` | Delta files relevant to this reviewer's domain |
+| Summary mode, `review_scope=delta` | Delta files only (reviewer reads via `git diff`) |
 
 **Keep handoffs short.** The reviewer has full access to pr-context and pr-tldr for details. The handoff just points them in the right direction.
+
+**Scope signal:** Use `Review scope` from the pr-context metadata table as the single source of truth for delta vs full scoping. If `review_scope` is absent (e.g. local runs without CI-generated pr-context), default to full-scope behavior.
 
 ## Phase 4: Judge & Filter
 

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -76,6 +76,21 @@ jobs:
           echo "labels=$LABELS" >> $GITHUB_OUTPUT
           echo "draft=$DRAFT" >> $GITHUB_OUTPUT
 
+          # Determine trigger command (issue_comment only; pull_request defaults to auto)
+          # IMPORTANT: read comment body from event payload via jq — do NOT inline
+          # github.event.comment.body into bash source (it can contain quotes/newlines).
+          if [ "${{ github.event_name }}" = "issue_comment" ]; then
+            COMMENT_BODY="$(jq -r '.comment.body // ""' "$GITHUB_EVENT_PATH")"
+            # Check /full-review BEFORE /review (substring overlap: /full-review contains /review)
+            if printf '%s' "$COMMENT_BODY" | grep -Eq '(^|[[:space:]])/full-review([[:space:]]|$)'; then
+              echo "trigger_command=full-review" >> $GITHUB_OUTPUT
+            else
+              echo "trigger_command=review" >> $GITHUB_OUTPUT
+            fi
+          else
+            echo "trigger_command=auto" >> $GITHUB_OUTPUT
+          fi
+
       - name: Checkout
         uses: actions/checkout@v5
         with:
@@ -374,6 +389,7 @@ jobs:
             sort_by(.submittedAt) | last | .commit.oid // ""
           ')
 
+          SINCE_REVIEW_COUNT=0  # default; overwritten below if a prior review SHA exists
           if [ -n "$LAST_REVIEW_SHA" ] && [ "$LAST_REVIEW_SHA" != "null" ] && git cat-file -e "$LAST_REVIEW_SHA" 2>/dev/null; then
             SINCE_REVIEW_COUNT=$(git rev-list --count "$LAST_REVIEW_SHA".."$PR_HEAD")
             if [ "$SINCE_REVIEW_COUNT" = "0" ]; then
@@ -452,6 +468,19 @@ jobs:
             echo "$SINCE_REVIEW_SECTION"
             echo "ENDREVIEW"
           } >> $GITHUB_OUTPUT
+
+          # ── Compute review_scope ──────────────────────────────────────────
+          # review_scope is the single source of truth for delta vs full scoping.
+          #   full  = review entire PR (first review, no new commits, or /full-review override)
+          #   delta = scope to changes since last automated review
+          TRIGGER='${{ steps.pr.outputs.trigger_command }}'
+          if [ "$TRIGGER" = "full-review" ]; then
+            echo "review_scope=full" >> $GITHUB_OUTPUT
+          elif [ "$SINCE_REVIEW_COUNT" -gt 0 ]; then
+            echo "review_scope=delta" >> $GITHUB_OUTPUT
+          else
+            echo "review_scope=full" >> $GITHUB_OUTPUT
+          fi
 
       - name: Get PR Comments
         id: pr_comments
@@ -545,7 +574,9 @@ jobs:
           | **Labels** | ${{ steps.pr.outputs.labels || '_None_' }} |
           | **Review state** | ${{ steps.review_context.outputs.review_decision }} |
           | **Diff mode** | `${{ steps.diff.outputs.diff_mode }}` — ${{ steps.diff.outputs.diff_mode == 'summary' && 'reviewers must read file diffs on-demand via `git diff`' || 'full diff included below' }} |
-          | **Trigger** | `${{ github.event.action }}` |
+          | **Event** | `${{ github.event_name }}:${{ github.event.action }}` |
+          | **Trigger command** | `${{ steps.pr.outputs.trigger_command }}` — ${{ steps.pr.outputs.trigger_command == 'full-review' && 'manual full-scope override' || steps.pr.outputs.trigger_command == 'review' && 'manual review request' || 'automatic CI trigger' }} |
+          | **Review scope** | `${{ steps.review_context.outputs.review_scope }}` — ${{ steps.review_context.outputs.review_scope == 'delta' && 'scoped to changes since last automated review' || 'full PR scope' }} |
 
           ## Description
           Author-provided description (may not fully reflect actual scope):
@@ -585,9 +616,11 @@ jobs:
 
           ${{ steps.review_context.outputs.since_review_section }}
 
-          ${{ steps.review_context.outputs.is_re_review == 'true' && '## Review Focus
+          ${{ steps.review_context.outputs.review_scope == 'delta' && '## Review Focus
 
-          > **RE-REVIEW — scope to the delta.** A prior automated review already covered this PR. Your review scope is the code that changed since that review (see "Changes Since Last Review" above). Apply your normal review process — same quality bar, same severity criteria — but scoped to the delta. Do not re-analyze unchanged files or re-raise issues on code that was already reviewed. If prior feedback appears unaddressed in the delta, note it; otherwise, focus your effort on what is new or modified.' || '' }}
+          > **RE-REVIEW — scope to the delta.** A prior automated review already covered this PR. Your review scope is the code that changed since that review (see "Changes Since Last Review" above). Apply your normal review process — same quality bar, same severity criteria — but scoped to the delta. Do not re-analyze unchanged files or re-raise issues on code that was already reviewed. If prior feedback appears unaddressed in the delta, note it; otherwise, focus your effort on what is new or modified.' || steps.review_context.outputs.review_scope == 'full' && steps.review_context.outputs.is_re_review == 'true' && '## Review Focus
+
+          > **FULL-SCOPE REVIEW (manual override).** A prior automated review exists, but a full-scope review was explicitly requested via `/full-review`. Review the entire PR — do not limit scope to the delta. The "Changes Since Last Review" section above is provided for context only.' || '' }}
 
           ## Prior Feedback
 


### PR DESCRIPTION
## Summary

- Adds `@claude /full-review` manual command that forces full-scope review on re-reviews, overriding delta-only scoping when new commits exist since the last automated review
- Introduces `review_scope` (`full` | `delta`) as the single source of truth for scoping decisions — replaces the previous `is_re_review`-based gating
- Large-PR diff summarization (summary mode) is unaffected by `/full-review` — it always protects reviewer context budgets

## Changes

### `.github/workflows/claude-code-review.yml`
- **`trigger_command` parsing**: Safely reads comment body from `$GITHUB_EVENT_PATH` via `jq` (no shell-quoting hazards). Checks `/full-review` before `/review` to avoid substring false matches. Word-boundary regex prevents accidental triggers (e.g. `/full-reviewers`).
- **`review_scope` computation**: Computed once at end of "Get Review Context" step. `SINCE_REVIEW_COUNT` initialized to 0 before branching to avoid unset variable in first-review path.
- **pr-context metadata**: New `Event`, `Trigger command`, and `Review scope` rows (replaces old `Trigger` row).
- **Review Focus section**: Three-state rendering — delta directive (`review_scope=delta`), full-scope override notice (`review_scope=full` + re-review), or absent (first review).

### `.claude/agents/pr-review.md`
- Phase 1.1, Phase 3.1 handoff template, and file list table updated to key off `review_scope` instead of "re-review"
- Added scope signal fallback note: defaults to `full` when `review_scope` is absent (local runs)

### `.claude/agents/pr-review-architecture/README.md`
- Quick Start: documents manual `/review` and `/full-review` comment triggers
- Phase 3 box: updated to reference `review_scope`
- Re-Review Scoping: rewritten with `review_scope` table, `/full-review` override subsection, concurrency behavior note
- pr-context Sections table: updated metadata and Review Focus descriptions
- Fixed Phase 3.4 reference → Phase 3
- Local Testing: notes `review_scope` defaults to `full` when absent

## What does NOT change
- `claude.yml` exclusion: `!contains(body, '/review')` already excludes `/full-review` (substring match)
- `claude-code-review.yml` trigger: `contains(body, '/review')` already matches `/full-review`

## Test plan
- [x] YAML validation (stripped GHA expressions, parsed successfully)
- [x] Local bash test harness: 41/41 tests passed covering:
  - `trigger_command` parsing (12 tests: ordering, boundaries, quotes, newlines, backticks)
  - `review_scope` computation (8 tests: all 7 variations + edge case)
  - Review Focus rendering (7 tests: delta/full-override/absent)
  - End-to-end integration (14 tests: parse → scope → render for all 7 variations)
- [ ] Real `/full-review` trigger on a test PR to confirm end-to-end


Made with [Cursor](https://cursor.com)