### PR TITLE
fix: change PR review command prefix from / to -- to avoid claude-code-action skill conflict

### DIFF
--- a/.claude/agents/pr-review-architecture/README.md
+++ b/.claude/agents/pr-review-architecture/README.md
@@ -30,8 +30,8 @@ pr-review (orchestrator, opus)
 # Triggered on: pull_request [opened, synchronize, ready_for_review]
 
 # CI (manual via PR comment)
-# @claude /review        — triggers review (delta-scoped if re-review)
-# @claude /full-review   — triggers full-scope review (overrides delta scoping)
+# @claude --review        — triggers review (delta-scoped if re-review)
+# @claude --full-review   — triggers full-scope review (overrides delta scoping)
 
 # Local testing
 claude --agent pr-review "Review the changes in this branch"
@@ -207,8 +207,8 @@ The system uses a `review_scope` signal (`full` | `delta`) in pr-context metadat
 
 | `review_scope` | When | Behavior |
 |----------------|------|----------|
-| `full` | First review, no new commits, or `/full-review` override | Review entire PR |
-| `delta` | New commits since last automated review (and no `/full-review`) | Scope to changes since last review |
+| `full` | First review, no new commits, or `--full-review` override | Review entire PR |
+| `delta` | New commits since last automated review (and no `--full-review`) | Scope to changes since last review |
 
 On re-reviews (new commits since the last automated review), the default is `review_scope=delta`:
 
@@ -222,11 +222,11 @@ On re-reviews (new commits since the last automated review), the default is `rev
 
 **Same quality bar, narrower scope:** Reviewers apply the same review process and severity criteria — the scoping is purely about which code to analyze, not what to flag.
 
-#### `/full-review` Override
+#### `--full-review` Override
 
-Commenting `@claude /full-review` on a PR forces `review_scope=full` even when a prior automated review exists and new commits have been pushed. This disables delta-only scoping so reviewers assess the entire PR.
+Commenting `@claude --full-review` on a PR forces `review_scope=full` even when a prior automated review exists and new commits have been pushed. This disables delta-only scoping so reviewers assess the entire PR.
 
-Large-PR diff summarization (summary mode) is **not** overridden by `/full-review` — it protects reviewer context budgets regardless of scope.
+Large-PR diff summarization (summary mode) is **not** overridden by `--full-review` — it protects reviewer context budgets regardless of scope.
 
 The `## Changes Since Last Review` section is still included for context, but a `## Review Focus` directive clarifies that the review is full-scope and delta data is informational only.
 
@@ -234,9 +234,9 @@ The `## Changes Since Last Review` section is still included for context, but a 
 
 CI runs use separate concurrency groups per trigger type:
 - `pr-review-pull_request-<PR#>` (automatic runs)
-- `pr-review-issue_comment-<PR#>` (manual `/review` or `/full-review`)
+- `pr-review-issue_comment-<PR#>` (manual `--review` or `--full-review`)
 
-A `/full-review` comment will **not** cancel an in-progress automatic `pull_request` review (different groups). Within each group, `cancel-in-progress: true` applies (e.g. a second `/full-review` cancels the first). This is intentional — the alternative (shared group) previously caused bot comments to cancel in-progress PR reviews.
+A `--full-review` comment will **not** cancel an in-progress automatic `pull_request` review (different groups). Within each group, `cancel-in-progress: true` applies (e.g. a second `--full-review` cancels the first). This is intentional — the alternative (shared group) previously caused bot comments to cancel in-progress PR reviews.
 
 ### pr-context Sections (complete reference)
 

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -21,7 +21,7 @@ jobs:
         github.event.issue.pull_request &&
         github.event.issue.state == 'open' &&
         contains(github.event.comment.body, '@claude') &&
-        contains(github.event.comment.body, '/review') &&
+        contains(github.event.comment.body, '--review') &&
         !contains(github.actor, '[bot]') &&
         (
           github.event.comment.author_association == 'OWNER' ||
@@ -81,8 +81,9 @@ jobs:
           # github.event.comment.body into bash source (it can contain quotes/newlines).
           if [ "${{ github.event_name }}" = "issue_comment" ]; then
             COMMENT_BODY="$(jq -r '.comment.body // ""' "$GITHUB_EVENT_PATH")"
-            # Check /full-review BEFORE /review (substring overlap: /full-review contains /review)
-            if printf '%s' "$COMMENT_BODY" | grep -Eq '(^|[[:space:]])/full-review([[:space:]]|$)'; then
+            # Check --full-review BEFORE --review (substring overlap).
+            # We use -- prefix (not /) because claude-code-action reserves /xxx for skill invocations.
+            if printf '%s' "$COMMENT_BODY" | grep -Eq '(^|[[:space:]])--full-review([[:space:]]|$)'; then
               echo "trigger_command=full-review" >> $GITHUB_OUTPUT
             else
               echo "trigger_command=review" >> $GITHUB_OUTPUT
@@ -471,7 +472,7 @@ jobs:
 
           # ── Compute review_scope ──────────────────────────────────────────
           # review_scope is the single source of truth for delta vs full scoping.
-          #   full  = review entire PR (first review, no new commits, or /full-review override)
+          #   full  = review entire PR (first review, no new commits, or --full-review override)
           #   delta = scope to changes since last automated review
           TRIGGER='${{ steps.pr.outputs.trigger_command }}'
           if [ "$TRIGGER" = "full-review" ]; then
@@ -620,7 +621,7 @@ jobs:
 
           > **RE-REVIEW — scope to the delta.** A prior automated review already covered this PR. Your review scope is the code that changed since that review (see "Changes Since Last Review" above). Apply your normal review process — same quality bar, same severity criteria — but scoped to the delta. Do not re-analyze unchanged files or re-raise issues on code that was already reviewed. If prior feedback appears unaddressed in the delta, note it; otherwise, focus your effort on what is new or modified.' || steps.review_context.outputs.review_scope == 'full' && steps.review_context.outputs.is_re_review == 'true' && '## Review Focus
 
-          > **FULL-SCOPE REVIEW (manual override).** A prior automated review exists, but a full-scope review was explicitly requested via `/full-review`. Review the entire PR — do not limit scope to the delta. The "Changes Since Last Review" section above is provided for context only.' || '' }}
+          > **FULL-SCOPE REVIEW (manual override).** A prior automated review exists, but a full-scope review was explicitly requested via `--full-review`. Review the entire PR — do not limit scope to the delta. The "Changes Since Last Review" section above is provided for context only.' || '' }}
 
           ## Prior Feedback
 

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -13,9 +13,9 @@ on:
 jobs:
   claude:
     if: |
-      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude') && !contains(github.event.comment.body, '/review')) ||
-      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude') && !contains(github.event.comment.body, '/review')) ||
-      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude') && !contains(github.event.review.body, '/review')) ||
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude') && !contains(github.event.comment.body, '--review')) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude') && !contains(github.event.comment.body, '--review')) ||
+      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude') && !contains(github.event.review.body, '--review')) ||
       (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
## Summary

- Changes the manual PR review trigger commands from `@claude /review` / `@claude /full-review` to `@claude --review` / `@claude --full-review`
- `claude-code-action` reserves the `/` prefix for CLI slash-command skill invocations — `@claude /full-review` was being parsed as a skill named "full-review" (producing "Unknown skill: full-review") and never reaching the PR review workflow
- The `--` prefix is treated as plain text by the action, avoiding the conflict

## Changes

- **`claude-code-review.yml`**: `contains(body, '/review')` → `contains(body, '--review')`, grep patterns updated for `--full-review` trigger detection
- **`claude.yml`**: `!contains(body, '/review')` → `!contains(body, '--review')` on all event paths
- **`pr-review-architecture/README.md`**: All command references updated

## Test plan

- [ ] Comment `@claude --review` on a test PR — verify `claude-code-review.yml` runs (not skipped) and `claude.yml` is excluded
- [ ] Comment `@claude --full-review` on a test PR — verify `trigger_command=full-review` and `review_scope=full` in pr-context
- [ ] Comment `@claude fix this bug` on a PR — verify `claude.yml` runs normally (no `--review` in body)


Made with [Cursor](https://cursor.com)