### PR TITLE
fix: add --full-review to workflow trigger conditions

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -21,7 +21,7 @@ jobs:
         github.event.issue.pull_request &&
         github.event.issue.state == 'open' &&
         contains(github.event.comment.body, '@claude') &&
-        contains(github.event.comment.body, '--review') &&
+        (contains(github.event.comment.body, '--review') || contains(github.event.comment.body, '--full-review')) &&
         !contains(github.actor, '[bot]') &&
         (
           github.event.comment.author_association == 'OWNER' ||

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -13,9 +13,9 @@ on:
 jobs:
   claude:
     if: |
-      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude') && !contains(github.event.comment.body, '--review')) ||
-      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude') && !contains(github.event.comment.body, '--review')) ||
-      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude') && !contains(github.event.review.body, '--review')) ||
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude') && !contains(github.event.comment.body, '--review') && !contains(github.event.comment.body, '--full-review')) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude') && !contains(github.event.comment.body, '--review') && !contains(github.event.comment.body, '--full-review')) ||
+      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude') && !contains(github.event.review.body, '--review') && !contains(github.event.review.body, '--full-review')) ||
       (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
## Summary

- `contains('--full-review', '--review')` is `false` in GitHub Actions because `--review` is not a substring of `--full-review` (after `--`, the next char is `f`, not `r`)
- This caused `@claude --full-review` to skip `claude-code-review.yml` entirely and fall through to `claude.yml` (general Claude), which then errored or had no review logic
- Adds explicit `|| contains(body, '--full-review')` to the review workflow and `&& !contains(body, '--full-review')` exclusions to the general workflow

## Test plan
- [ ] Comment `@claude --review` on a PR → `claude-code-review.yml` runs, `claude.yml` skips
- [ ] Comment `@claude --full-review` on a PR → `claude-code-review.yml` runs, `claude.yml` skips
- [ ] Comment `@claude fix typo` on a PR → `claude.yml` runs, `claude-code-review.yml` skips (for issue_comment path)


Made with [Cursor](https://cursor.com)