### PR TITLE
fix: move review concurrency to job-level to prevent bot self-cancellation

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -6,12 +6,6 @@ on:
   issue_comment:
     types: [created]
 
-concurrency:
-  # Separate groups per trigger type so issue_comment runs (which often skip)
-  # don't cancel in-progress pull_request review runs.
-  group: pr-review-${{ github.event_name }}-${{ github.event.pull_request.number || github.event.issue.number }}
-  cancel-in-progress: true
-
 jobs:
   pr-review:
     if: |
@@ -29,6 +23,12 @@ jobs:
           github.event.comment.author_association == 'COLLABORATOR'
         )
       )
+    # Job-level concurrency so the group is only entered AFTER the if: check.
+    # Workflow-level concurrency would let bot comments (which skip via if:)
+    # cancel in-progress human-triggered runs before they're filtered out.
+    concurrency:
+      group: pr-review-${{ github.event_name }}-${{ github.event.pull_request.number || github.event.issue.number }}
+      cancel-in-progress: true
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
## Summary

- Workflow-level `concurrency` is evaluated **before** job `if:` conditions
- When Claude bot posts its progress comment, the `issue_comment` event enters the same concurrency group (`pr-review-issue_comment-{PR}`) and `cancel-in-progress: true` kills the real human-triggered review run
- The bot run then immediately skips because `!contains(github.actor, '[bot]')` fails -- but the damage is done
- Moving `concurrency` to the **job level** ensures the `if:` filter runs first, so bot comments never enter the concurrency group

## Test plan
- [ ] Post `@claude --full-review` on a PR -- review should run to completion without being cancelled by Claude's own progress comment
- [ ] Post `@claude --review` twice in quick succession -- second run should cancel the first (concurrency still works for legitimate re-triggers)


Made with [Cursor](https://cursor.com)