### PR TITLE
fix(pr-review): fix tool allowlist, dedup enforcement, and terminology issues

### DIFF
--- a/.agents/skills/pr-review-output-contract/SKILL.md
+++ b/.agents/skills/pr-review-output-contract/SKILL.md
@@ -229,7 +229,7 @@ How confident you are in the proposed fix. Distinct from `confidence` (issue cer
 | Fix Confidence | Meaning |
 |----------------|---------|
 | `HIGH` | Fix is drop-in: complete, correct, includes necessary imports/types, doesn't introduce new issues. **Requires web search verification when the fix changes third-party library/framework usage** (see `pr-review-check-suggestion` Step F2) or reference to other existing code in the existing codebase that illustrates the correct approach. Default to `MEDIUM` until substantiated. Only exception are self-evident fixes (null checks, typos, simple refactors) that are intrinsically obvious (rare). |
-| `MEDIUM` | Fix is directionally correct but may need certail details confirmed by developer. |
+| `MEDIUM` | Fix is directionally correct but may need certain details confirmed by developer. |
 | `LOW` | Fix is a starting point but not sure about exact approach given context; human should verify approach. |
 
 ### `category`

--- a/.claude/agents/pr-review.md
+++ b/.claude/agents/pr-review.md
@@ -89,7 +89,7 @@ Generate the PR context brief so subagent reviewers start from a shared baseline
 
 ## Phase 2: Select Reviewers
 
-Match changed files to the relevant sub-agent reviewers. Each reviewer has a specialized role and returns output as defined in the `pr-review-output-contract`. The descrptions below are rough descriptions, you should assume that they subagents are capable of reviewing any topic that seems reasonably within their scope even if not explicitly listed. Lean on them for specialized review.
+Match changed files to the relevant sub-agent reviewers. Each reviewer has a specialized role and returns output as defined in the `pr-review-output-contract`. The descriptions below are rough descriptions, you should assume that the subagents are capable of reviewing any topic that seems reasonably within their scope even if not explicitly listed. Lean on them for specialized review.
 
 Reviewers are organized into four tiers. For any PR that touches a **product surface** (APIs, SDKs, CLI, UI, docs, config formats, protocols), select all Core reviewers plus applicable Strong Default, Critical Domain, and Domain-Specific reviewers.
 


### PR DESCRIPTION
## Summary

Fixes several bugs, inconsistencies, and ambiguities in the `pr-review` orchestrator agent and `pr-review-output-contract` skill discovered during analysis of PR #1832 review output.

### Bug fixes
- **Add 3 missing `mcp__github__*` tools to frontmatter `tools:` allowlist** — `tools:` is enforced as an allowlist in Claude Code; without these the orchestrator silently fails to post inline comments and falls back to the Bash/REST API path
- **Fix Bash "Do not" constraint** — old phrasing ("non-git/non-mkdir") contradicted the Tool Policy table which explicitly allows `gh api`

### Deduplication enforcement (root cause fix for inline-comment-vs-main-writeup duplication)
- **Add per-finding routing procedure** — embeds the inline-vs-full-writeup decision as an affirmative action step at the point of writing, replacing scattered negative constraints that the model treated as additive rather than exclusive
- **Annotate format template inline-log sections** — clarify they REPLACE full writeups, not appear alongside them
- **Remove 3 redundant restatements** of the No Duplication Principle (the "Remember:" line, the warning box, and the standalone "Inline comment log lines" section) that paradoxically weakened enforcement by giving the model multiple competing statements to reconcile

### Terminology & consistency
- **Rename Pending Recommendations `(R)` → `(P)`** — `(R)` was already defined as "# of reviewers dispatched" in the Reviewers stats section
- **Rename "Task list" → "local checklist"** — "Task" collides with the Task tool used to spawn subagents
- **Remove unreachable `subjectType: "FILE"`** from parameter docs — routing rules make file-level inline comments impossible; documenting it invites hallucinated usage

### Output contract improvements
- Tighten severity definitions (CRITICAL/MAJOR/MINOR) to be more specific and actionable
- Raise the bar for HIGH confidence — must be clearly problematic to experienced engineers
- Strengthen fix_confidence: HIGH requirements — must cite codebase patterns or web references

## Test plan
- [ ] Verify `pr-review.md` frontmatter is valid YAML
- [ ] Run a PR review and confirm inline comments are posted successfully (not falling back to REST)
- [ ] Verify no duplication between inline comments and Main writeups in review body
- [ ] Confirm Pending Recommendations uses `(P)` and Reviewers uses `(R)` in output


Made with [Cursor](https://cursor.com)