### PR TITLE
fix: pin release tag to exact commit and use GitHub App token

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -82,6 +82,16 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           HUSKY: 0
 
+      # Generate a GitHub App token so the release event triggers downstream
+      # workflows (the default GITHUB_TOKEN cannot do this).
+      - name: Generate GitHub App Token
+        if: steps.changesets.outputs.published == 'true'
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.INTERNAL_CI_APP_ID }}
+          private-key: ${{ secrets.INTERNAL_CI_APP_PRIVATE_KEY }}
+
       - name: Create GitHub Release
         if: steps.changesets.outputs.published == 'true'
         shell: bash
@@ -117,17 +127,13 @@ jobs:
 
             ${CHANGELOG}"
 
+            # Pin the release tag to the exact commit that was built and published.
+            # The app token ensures the release:published event triggers the
+            # downstream Vercel production deploy workflow.
             gh release create "v${VERSION}" \
+              --target "${{ github.sha }}" \
               --title "${RELEASE_DATE}" \
               --notes "$RELEASE_NOTES"
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-
-      # The default GITHUB_TOKEN cannot trigger downstream workflows,
-      # so we use a PAT that can.
-      - name: Trigger Vercel Production Deploy
-        if: steps.changesets.outputs.published == 'true'
-        run: gh workflow run vercel-production.yml --ref main
-        env:
-          GITHUB_TOKEN: ${{ secrets.GH_PAT }}


### PR DESCRIPTION
## Summary
- **Pins the release tag to `${{ github.sha }}`** via `--target` on `gh release create`, ensuring the tag points to the exact commit that was built and published to npm — not whatever happens to be HEAD of `main` at the time of the API call.
- **Replaces `GH_PAT` with a GitHub App token** (`INTERNAL_CI_APP_ID` / `INTERNAL_CI_APP_PRIVATE_KEY`) using `actions/create-github-app-token`. Events from app tokens trigger downstream workflows, so the natural `release:published` event now fires the Vercel production deploy.
- **Removes the explicit `gh workflow run --ref main` trigger step**, which was deploying whatever was on `main` rather than the released commit. The `vercel-production.yml` workflow already listens to `release: [published]` and checks out the tag — so this now works end-to-end with the correct ref.

## What was wrong
The old flow had two problems:
1. `gh release create` without `--target` defaults to remote HEAD of default branch at API call time — a race with other pushes could tag the wrong commit.
2. The explicit `gh workflow run vercel-production.yml --ref main` deployed main HEAD, not the released commit.

## Test plan
- [x] Verify `INTERNAL_CI_APP_ID` and `INTERNAL_CI_APP_PRIVATE_KEY` secrets are configured in the repo
- [ ] Trigger a release and confirm the tag points to the correct commit (`git log --oneline v<version>`)
- [ ] Confirm `vercel-production.yml` is triggered by the `release:published` event (check Actions tab)
- [ ] Confirm the Vercel deploy checks out the release tag, not `main`

Made with [Cursor](https://cursor.com)