### PR TITLE
fix(pr-review): ensure review is delivered via Pending Review API

### DIFF
--- a/.claude/agents/pr-review.md
+++ b/.claude/agents/pr-review.md
@@ -1,12 +1,17 @@
 ---
 name: pr-review
 description: |
-  PR review orchestrator. Dispatches domain-specific reviewer subagents, aggregates findings, submits batched PR review.
-  Invoked via: `/pr-review` skill or `claude --agent pr-review`.
+  PR review orchestrator. Dispatches domain-specific reviewer subagents, aggregates findings, submits batched PR review via GitHub Pending Review API.
 tools: Task, Read, Write, Grep, Glob, Bash, mcp__exa__web_search_exa, mcp__github__create_pending_pull_request_review, mcp__github__add_comment_to_pending_review, mcp__github__submit_pending_pull_request_review
 skills: [pr-context, pr-tldr, product-surface-areas, internal-surface-areas, find-similar, pr-review-output-contract]
 model: opus
 ---
+
+# Execution
+
+You are the pr-review orchestrator. Your instructions are this document — start at Phase 1.
+
+**Review delivery:** Submit via the GitHub Pending Review API (`create_pending` → `add_comment` → `submit`), not PR comments. The progress comment (`mcp__github_comment__update_claude_comment`) is for status updates only — it is deleted after each run.
 
 # Role
 

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -690,7 +690,7 @@ jobs:
             --mcp-config '{"mcpServers":{"exa":{"command":"npx","args":["-y","exa-mcp-server"],"env":{"EXA_API_KEY":"${{ secrets.EXA_API_KEY }}"}}}}'
             --allowedTools "Task,Read,Write,Grep,Glob,mcp__exa__web_search_exa,mcp__github__create_pending_pull_request_review,mcp__github__add_comment_to_pending_review,mcp__github__submit_pending_pull_request_review,Bash(git diff:*),Bash(git log:*),Bash(git show:*),Bash(git merge-base:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh api:*),Bash(mkdir:*)"
           prompt: |
-            Review PR #${{ steps.pr.outputs.number }}.
+            Review PR #${{ steps.pr.outputs.number }}. Begin Phase 1.
 
       - name: Clean up progress comment
         if: success()


### PR DESCRIPTION
## Summary

- Fixes intermittent issue where the pr-review agent posted its review as a PR comment instead of a formal GitHub PR review, causing the cleanup step to delete it
- Root cause: Claude sometimes attempted `Skill("pr-review")` (which fails — pr-review is an agent, not a skill), then fell back to the base prompt's comment workflow
- Adds an `# Execution` entry point to `pr-review.md` anchoring Claude to the Pending Review API delivery contract
- Removes the misleading "/pr-review skill" invocation reference from the agent description
- Adds "Begin Phase 1." cue to the workflow prompt for deterministic entry

## Test plan

- [x] Verified changes to `pr-review.md` and `claude-code-review.yml` are minimal and targeted
- [ ] Next PR opened against this repo should trigger a formal GitHub PR review (not just a comment)


Made with [Cursor](https://cursor.com)