### PR TITLE
feat(pr-review): sweep assessment framework + filtered diff metrics

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -128,6 +128,20 @@ jobs:
           echo "$FILES" >> $GITHUB_OUTPUT
           echo "EOF" >> $GITHUB_OUTPUT
 
+          # Compute filtered size metrics from numstat (respects EXCLUDE_PATTERNS,
+          # unlike the raw GitHub API additions/deletions which include lockfiles etc.)
+          NUMSTAT=$(git diff --numstat "$BASE"...HEAD -- . "${EXCLUDE_PATTERNS[@]}")
+          FILTERED_ADDITIONS=$(printf '%s\n' "$NUMSTAT" | awk '$1 != "-" {s+=$1} END{print s+0}')
+          FILTERED_DELETIONS=$(printf '%s\n' "$NUMSTAT" | awk '$2 != "-" {s+=$2} END{print s+0}')
+          if [ -n "$FILES" ]; then
+            FILTERED_FILE_COUNT=$(printf '%s\n' "$FILES" | wc -l | tr -d ' ')
+          else
+            FILTERED_FILE_COUNT=0
+          fi
+          echo "filtered_additions=$FILTERED_ADDITIONS" >> $GITHUB_OUTPUT
+          echo "filtered_deletions=$FILTERED_DELETIONS" >> $GITHUB_OUTPUT
+          echo "filtered_file_count=$FILTERED_FILE_COUNT" >> $GITHUB_OUTPUT
+
           # Per-file diff stats (compact size overview)
           DIFF_STATS=$(git diff --stat "$BASE"...HEAD -- . "${EXCLUDE_PATTERNS[@]}")
           {
@@ -571,7 +585,7 @@ jobs:
           | **Base** | `${{ steps.pr.outputs.base_ref }}` |
           | **Repo** | ${{ github.repository }} |
           | **Head SHA** | `${{ steps.pr.outputs.head_sha }}` |
-          | **Size** | ${{ steps.diff.outputs.commit_count }} commits · +${{ steps.pr.outputs.additions }}/-${{ steps.pr.outputs.deletions }} · ${{ steps.pr.outputs.changed_files_count }} files |
+          | **Size** | ${{ steps.diff.outputs.commit_count }} commits · +${{ steps.diff.outputs.filtered_additions }}/-${{ steps.diff.outputs.filtered_deletions }} · ${{ steps.diff.outputs.filtered_file_count }} files |
           | **Labels** | ${{ steps.pr.outputs.labels || '_None_' }} |
           | **Review state** | ${{ steps.review_context.outputs.review_decision }} |
           | **Diff mode** | `${{ steps.diff.outputs.diff_mode }}` — ${{ steps.diff.outputs.diff_mode == 'summary' && 'reviewers must read file diffs on-demand via `git diff`' || 'full diff included below' }} |


### PR DESCRIPTION
## Summary

- **Filtered diff metrics:** The `pr-context` Size row now reports additions/deletions/file counts computed from `git diff --numstat` with the same `EXCLUDE_PATTERNS` applied to the diff. Previously these came from the GitHub API (unfiltered), which inflated counts with lockfiles, snapshots, changelogs, etc.
- **Sweep assessment framework:** Adds a structured decision framework to the PR review orchestrator for re-reviews (`review_scope=delta`). Instead of the vague "very large surface area" heuristic, the orchestrator now evaluates five qualitative factors — **Size**, **Novelty**, **Sensitivity**, **Blast radius**, and **Precedent** — to decide whether a broader sweep beyond the delta is warranted. All three downstream references updated to point to the new framework.
- **Cross-type deduplication:** Adds a rule to Phase 4.1 to cluster and merge findings across different finding types when they address the same underlying concern.

## Files changed

| File | What changed |
|---|---|
| `.github/workflows/claude-code-review.yml` | Compute `filtered_additions`, `filtered_deletions`, `filtered_file_count` from `git diff --numstat` (respects `EXCLUDE_PATTERNS`). Use these in the pr-context Size metadata row instead of raw GitHub API values. |
| `.claude/agents/pr-review.md` | Add `### Sweep assessment (re-reviews only)` subsection in Phase 1.1 with five-factor decision table and "two or more" threshold. Replace all three "very large surface area" references to point to the new framework. |

## Test plan

- [ ] Trigger a review on a PR with excluded files (lockfiles, snapshots) and verify the Size row in pr-context shows filtered counts, not inflated GitHub API values
- [ ] Trigger a re-review (`review_scope=delta`) on a large PR and verify the orchestrator performs the sweep assessment and notes its determination
- [ ] Trigger a re-review on a small delta PR and verify the orchestrator defaults to delta-only (no sweep)

Made with [Cursor](https://cursor.com)