### PR TITLE
chore: Remove test log statement from agentFull route

### DIFF
--- a/agents-api/src/domains/manage/routes/agentFull.ts
+++ b/agents-api/src/domains/manage/routes/agentFull.ts
@@ -198,7 +198,6 @@ app.openapi(
     const agentData = c.req.valid('json');
 
     try {
-      logger.info({}, 'test agent data');
       const validatedAgentData = AgentWithinContextOfProjectSchema.parse(agentData);
 
       if (agentId !== validatedAgentData.id) {


### PR DESCRIPTION
## Summary
Remove debug `logger.info` call that was left in the PUT `/agents/:agentId` endpoint.

## Changes
- Remove `logger.info({}, 'test agent data');` from `agentFull.ts`

## Test Plan
- [x] Linting passed
- [x] Tests passed via lint-staged

Made with [Cursor](https://cursor.com)