### PR TITLE
chore: Add .cursorignore to prevent duplicate AGENTS.md context

### DIFF
--- a/.cursorignore
+++ b/.cursorignore
@@ -1,0 +1,2 @@
+# CLAUDE.md is a symlink to AGENTS.md — avoid loading duplicate content into context
+CLAUDE.md


### PR DESCRIPTION
## Summary
- Adds a `.cursorignore` file that excludes `CLAUDE.md` from Cursor's workspace rules
- `CLAUDE.md` is a symlink to `AGENTS.md`, so Cursor was loading the same content twice into context, wasting tokens

## Test plan
- [x] Verify Cursor only loads `AGENTS.md` (not both) after this change

Made with [Cursor](https://cursor.com)