### PR TITLE
fix(work-apps): make Slack migration idempotent and improve OAuth error logging

### DIFF
--- a/packages/agents-core/drizzle/runtime/0012_greedy_hulk.sql
+++ b/packages/agents-core/drizzle/runtime/0012_greedy_hulk.sql
@@ -1,4 +1,4 @@
-CREATE TABLE "work_app_slack_channel_agent_configs" (
+CREATE TABLE IF NOT EXISTS "work_app_slack_channel_agent_configs" (
 	"id" varchar(256) PRIMARY KEY NOT NULL,
 	"tenant_id" varchar(256) NOT NULL,
 	"slack_team_id" varchar(256) NOT NULL,
@@ -15,7 +15,7 @@ CREATE TABLE "work_app_slack_channel_agent_configs" (
 	CONSTRAINT "work_app_slack_channel_agent_configs_unique" UNIQUE("tenant_id","slack_team_id","slack_channel_id")
 );
 --> statement-breakpoint
-CREATE TABLE "work_app_slack_user_mappings" (
+CREATE TABLE IF NOT EXISTS "work_app_slack_user_mappings" (
 	"id" varchar(256) PRIMARY KEY NOT NULL,
 	"tenant_id" varchar(256) NOT NULL,
 	"client_id" varchar(256) DEFAULT 'work-apps-slack' NOT NULL,
@@ -32,7 +32,7 @@ CREATE TABLE "work_app_slack_user_mappings" (
 	CONSTRAINT "work_app_slack_user_mappings_unique" UNIQUE("tenant_id","client_id","slack_team_id","slack_user_id")
 );
 --> statement-breakpoint
-CREATE TABLE "work_app_slack_workspaces" (
+CREATE TABLE IF NOT EXISTS "work_app_slack_workspaces" (
 	"id" varchar(256) PRIMARY KEY NOT NULL,
 	"tenant_id" varchar(256) NOT NULL,
 	"slack_team_id" varchar(256) NOT NULL,
@@ -49,18 +49,36 @@ CREATE TABLE "work_app_slack_workspaces" (
 	CONSTRAINT "work_app_slack_workspaces_nango_connection_unique" UNIQUE("nango_connection_id")
 );
 --> statement-breakpoint
-ALTER TABLE "work_app_slack_channel_agent_configs" ADD CONSTRAINT "work_app_slack_channel_agent_configs_tenant_id_organization_id_fk" FOREIGN KEY ("tenant_id") REFERENCES "public"."organization"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
-ALTER TABLE "work_app_slack_channel_agent_configs" ADD CONSTRAINT "work_app_slack_channel_agent_configs_configured_by_user_id_user_id_fk" FOREIGN KEY ("configured_by_user_id") REFERENCES "public"."user"("id") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
-ALTER TABLE "work_app_slack_user_mappings" ADD CONSTRAINT "work_app_slack_user_mappings_tenant_id_organization_id_fk" FOREIGN KEY ("tenant_id") REFERENCES "public"."organization"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
-ALTER TABLE "work_app_slack_user_mappings" ADD CONSTRAINT "work_app_slack_user_mappings_inkeep_user_id_user_id_fk" FOREIGN KEY ("inkeep_user_id") REFERENCES "public"."user"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
-ALTER TABLE "work_app_slack_workspaces" ADD CONSTRAINT "work_app_slack_workspaces_tenant_id_organization_id_fk" FOREIGN KEY ("tenant_id") REFERENCES "public"."organization"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
-ALTER TABLE "work_app_slack_workspaces" ADD CONSTRAINT "work_app_slack_workspaces_installed_by_user_id_user_id_fk" FOREIGN KEY ("installed_by_user_id") REFERENCES "public"."user"("id") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
-CREATE INDEX "work_app_slack_channel_agent_configs_tenant_idx" ON "work_app_slack_channel_agent_configs" USING btree ("tenant_id");--> statement-breakpoint
-CREATE INDEX "work_app_slack_channel_agent_configs_team_idx" ON "work_app_slack_channel_agent_configs" USING btree ("slack_team_id");--> statement-breakpoint
-CREATE INDEX "work_app_slack_channel_agent_configs_channel_idx" ON "work_app_slack_channel_agent_configs" USING btree ("slack_channel_id");--> statement-breakpoint
-CREATE INDEX "work_app_slack_user_mappings_tenant_idx" ON "work_app_slack_user_mappings" USING btree ("tenant_id");--> statement-breakpoint
-CREATE INDEX "work_app_slack_user_mappings_user_idx" ON "work_app_slack_user_mappings" USING btree ("inkeep_user_id");--> statement-breakpoint
-CREATE INDEX "work_app_slack_user_mappings_team_idx" ON "work_app_slack_user_mappings" USING btree ("slack_team_id");--> statement-breakpoint
-CREATE INDEX "work_app_slack_user_mappings_slack_user_idx" ON "work_app_slack_user_mappings" USING btree ("slack_user_id");--> statement-breakpoint
-CREATE INDEX "work_app_slack_workspaces_tenant_idx" ON "work_app_slack_workspaces" USING btree ("tenant_id");--> statement-breakpoint
-CREATE INDEX "work_app_slack_workspaces_team_idx" ON "work_app_slack_workspaces" USING btree ("slack_team_id");
+DO $$ BEGIN
+  ALTER TABLE "work_app_slack_channel_agent_configs" ADD CONSTRAINT "work_app_slack_channel_agent_configs_tenant_id_organization_id_fk" FOREIGN KEY ("tenant_id") REFERENCES "public"."organization"("id") ON DELETE cascade ON UPDATE no action;
+EXCEPTION WHEN duplicate_object THEN NULL;
+END $$;--> statement-breakpoint
+DO $$ BEGIN
+  ALTER TABLE "work_app_slack_channel_agent_configs" ADD CONSTRAINT "work_app_slack_channel_agent_configs_configured_by_user_id_user_id_fk" FOREIGN KEY ("configured_by_user_id") REFERENCES "public"."user"("id") ON DELETE set null ON UPDATE no action;
+EXCEPTION WHEN duplicate_object THEN NULL;
+END $$;--> statement-breakpoint
+DO $$ BEGIN
+  ALTER TABLE "work_app_slack_user_mappings" ADD CONSTRAINT "work_app_slack_user_mappings_tenant_id_organization_id_fk" FOREIGN KEY ("tenant_id") REFERENCES "public"."organization"("id") ON DELETE cascade ON UPDATE no action;
+EXCEPTION WHEN duplicate_object THEN NULL;
+END $$;--> statement-breakpoint
+DO $$ BEGIN
+  ALTER TABLE "work_app_slack_user_mappings" ADD CONSTRAINT "work_app_slack_user_mappings_inkeep_user_id_user_id_fk" FOREIGN KEY ("inkeep_user_id") REFERENCES "public"."user"("id") ON DELETE cascade ON UPDATE no action;
+EXCEPTION WHEN duplicate_object THEN NULL;
+END $$;--> statement-breakpoint
+DO $$ BEGIN
+  ALTER TABLE "work_app_slack_workspaces" ADD CONSTRAINT "work_app_slack_workspaces_tenant_id_organization_id_fk" FOREIGN KEY ("tenant_id") REFERENCES "public"."organization"("id") ON DELETE cascade ON UPDATE no action;
+EXCEPTION WHEN duplicate_object THEN NULL;
+END $$;--> statement-breakpoint
+DO $$ BEGIN
+  ALTER TABLE "work_app_slack_workspaces" ADD CONSTRAINT "work_app_slack_workspaces_installed_by_user_id_user_id_fk" FOREIGN KEY ("installed_by_user_id") REFERENCES "public"."user"("id") ON DELETE set null ON UPDATE no action;
+EXCEPTION WHEN duplicate_object THEN NULL;
+END $$;--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "work_app_slack_channel_agent_configs_tenant_idx" ON "work_app_slack_channel_agent_configs" USING btree ("tenant_id");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "work_app_slack_channel_agent_configs_team_idx" ON "work_app_slack_channel_agent_configs" USING btree ("slack_team_id");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "work_app_slack_channel_agent_configs_channel_idx" ON "work_app_slack_channel_agent_configs" USING btree ("slack_channel_id");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "work_app_slack_user_mappings_tenant_idx" ON "work_app_slack_user_mappings" USING btree ("tenant_id");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "work_app_slack_user_mappings_user_idx" ON "work_app_slack_user_mappings" USING btree ("inkeep_user_id");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "work_app_slack_user_mappings_team_idx" ON "work_app_slack_user_mappings" USING btree ("slack_team_id");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "work_app_slack_user_mappings_slack_user_idx" ON "work_app_slack_user_mappings" USING btree ("slack_user_id");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "work_app_slack_workspaces_tenant_idx" ON "work_app_slack_workspaces" USING btree ("tenant_id");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "work_app_slack_workspaces_team_idx" ON "work_app_slack_workspaces" USING btree ("slack_team_id");


### PR DESCRIPTION
## Summary
- Make runtime migration 0012 (Slack tables) idempotent so it can be safely re-run on databases where tables were partially created — uses `IF NOT EXISTS` for tables/indexes and `DO $$ EXCEPTION WHEN duplicate_object $$` for FK constraints
- Fix swallowed error logging in the Slack OAuth callback — DB errors were being reduced to just the message string, losing stack traces, PG error codes, and constraint details. Now logs the full error object via pino's `err` serializer along with `pgCode`, `tenantId`, and `connectionId`
- Add context to Nango fallback and outer catch error logs

## Context
Slack workspace install was failing with `installation_failed` on app.inkeep.com but production logs had no actionable error details. The migration was also failing with `relation already exists` when tables had been partially created outside the migration tracker.

## Test plan
- [ ] Run `pnpm db:migrate` against a database where Slack tables already exist — should succeed without errors
- [ ] Run `pnpm db:migrate` against a fresh database — should create all tables, constraints, and indexes normally
- [ ] Trigger a Slack install failure (e.g. with an invalid tenantId) and verify the logs include the full error object with `pgCode`, `tenantId`, and stack trace

Made with [Cursor](https://cursor.com)