### PR TITLE
fix: Slack Work App — resolve tenantRole and forward real JWT for A2A

### DIFF
--- a/agents-api/src/middleware/runAuth.ts
+++ b/agents-api/src/middleware/runAuth.ts
@@ -278,7 +278,7 @@ async function trySlackUserJwtAuth(token: string, reqData: RequestData): Promise
 
   return {
     authResult: {
-      apiKey: 'slack-user-jwt',
+      apiKey: token,
       tenantId: payload.tenantId,
       projectId: reqData.projectId,
       agentId: reqData.agentId,

--- a/packages/agents-work-apps/src/slack/middleware/permissions.ts
+++ b/packages/agents-work-apps/src/slack/middleware/permissions.ts
@@ -83,9 +83,10 @@ export const requireWorkspaceAdmin = <
       return;
     }
 
-    // Resolve tenant context from teamId for session-based users
+    // Resolve tenant context from teamId if tenantId or tenantRole is missing
+    // workAppsAuth sets tenantId from session but not tenantRole — we need both
     const teamId = c.req.param('teamId') || c.req.param('workspaceId');
-    if (teamId && !c.get('tenantId')) {
+    if (teamId && !c.get('tenantRole')) {
       await resolveWorkAppTenantContext(c, teamId, userId);
     }
 
@@ -101,6 +102,10 @@ export const requireWorkspaceAdmin = <
     }
 
     if (!isOrgAdmin(tenantRole)) {
+      logger.warn(
+        { userId, tenantId, tenantRole, path: c.req.path },
+        'User does not have admin role for workspace operation'
+      );
       throw createApiError({
         code: 'forbidden',
         message: 'Only organization administrators can modify workspace settings',
@@ -147,9 +152,10 @@ export const requireChannelMemberOrAdmin = <
       return;
     }
 
-    // Resolve tenant context from teamId for session-based users
+    // Resolve tenant context from teamId if tenantRole is missing
+    // workAppsAuth sets tenantId from session but not tenantRole — we need both
     const teamId = c.req.param('teamId');
-    if (teamId && !c.get('tenantId')) {
+    if (teamId && !c.get('tenantRole')) {
       await resolveWorkAppTenantContext(c, teamId, userId);
     }
 


### PR DESCRIPTION
## Summary

Fixes two production issues with the Slack Work App:

1. **403 on all admin operations** (set default agent, channel config, uninstall) — `requireWorkspaceAdmin` middleware checked `!c.get('tenantId')` to decide whether to resolve the user's org role. Since `workAppsAuth` now sets `tenantId` from the session, the condition was always false and `tenantRole` was never resolved. Changed to `!c.get('tenantRole')`.

2. **A2A 401 "Invalid API key format"** on agent execution — `trySlackUserJwtAuth` stored the literal string `'slack-user-jwt'` as `apiKey` in the execution context. The `ExecutionHandler` forwards this as `Authorization: Bearer ${apiKey}` for internal A2A calls, so the agent card endpoint received `Bearer slack-user-jwt` instead of a real JWT. Changed to pass the actual token through, matching how temp JWT already works.

## Test plan

- [ ] Set workspace default agent via dashboard
- [ ] Set channel default agent
- [ ] `/inkeep run "agent" hello` returns a response (not timeout)
- [ ] `@Inkeep hello` streams a response in thread