### PR TITLE
fix(work-apps): Remove MCP server cache

### DIFF
--- a/.changeset/secret-aqua-deer.md
+++ b/.changeset/secret-aqua-deer.md
@@ -1,0 +1,5 @@
+---
+"@inkeep/agents-work-apps": patch
+---
+
+remove server cache


### PR DESCRIPTION
Every request called server.connect(transport) on that shared cached instance. The MCP SDK doesn't allow connecting a server to a second transport without closing the first. When concurrent requests hit the same toolId, the second request would get "Already connected to a transport".
