### PR TITLE
fix: preserve user image parts through agent transfers and delegations

### DIFF
--- a/agents-api/src/__tests__/run/agents/relationTools.test.ts
+++ b/agents-api/src/__tests__/run/agents/relationTools.test.ts
@@ -535,6 +535,7 @@ describe('Relationship Tools', () => {
           role: 'agent',
           content: {
             text: 'Test message',
+            parts: [{ text: 'Test message', kind: 'text' }],
           },
           visibility: 'external',
           messageType: 'a2a-request',
@@ -659,6 +660,7 @@ describe('Relationship Tools', () => {
           role: 'agent',
           content: {
             text: 'Test message',
+            parts: [{ text: 'Test message', kind: 'text' }],
           },
           visibility: 'internal',
           messageType: 'a2a-request',

--- a/agents-api/src/domains/run/agents/relationTools.ts
+++ b/agents-api/src/domains/run/agents/relationTools.ts
@@ -4,6 +4,7 @@ import {
   type CredentialStoreRegistry,
   CredentialStuffer,
   createMessage,
+  type FilePart,
   type FullExecutionContext,
   generateId,
   generateServiceToken,
@@ -260,6 +261,7 @@ export function createDelegateToAgentTool({
   metadata,
   sessionId,
   credentialStoreRegistry,
+  userImageParts,
 }: {
   delegateConfig: DelegateRelation;
   callingAgentId: string;
@@ -274,6 +276,7 @@ export function createDelegateToAgentTool({
   };
   sessionId?: string;
   credentialStoreRegistry?: CredentialStoreRegistry;
+  userImageParts?: FilePart[];
 }) {
   const { tenantId, projectId, agentId, project } = executionContext;
 
@@ -387,7 +390,7 @@ export function createDelegateToAgentTool({
 
       const messageToSend = {
         role: 'agent' as const,
-        parts: [{ text: input.message, kind: 'text' as const }],
+        parts: [{ text: input.message, kind: 'text' as const }, ...(userImageParts ?? [])],
         messageId: generateId(),
         kind: 'message' as const,
         contextId,
@@ -410,6 +413,7 @@ export function createDelegateToAgentTool({
         role: 'agent',
         content: {
           text: input.message,
+          parts: messageToSend.parts,
         },
         visibility: isInternal ? 'internal' : 'external',
         messageType: 'a2a-request',

--- a/agents-api/src/domains/run/handlers/executionHandler.ts
+++ b/agents-api/src/domains/run/handlers/executionHandler.ts
@@ -235,6 +235,10 @@ export class ExecutionHandler {
 
       let currentMessage = userMessage;
 
+      const originalNonTextParts: Part[] = messageParts
+        ? messageParts.filter((p) => p.kind === 'file' || p.kind === 'data')
+        : [];
+
       const maxTransfers =
         agent?.stopWhen?.transferCountIs ?? AGENT_EXECUTION_TRANSFER_COUNT_DEFAULT;
 
@@ -281,12 +285,10 @@ export class ExecutionHandler {
           messageMetadata.fromSubAgentId = fromSubAgentId;
         }
 
-        // On the first iteration, use the original message parts if provided (includes data parts from triggers)
-        // On subsequent iterations (after transfers), use text-only since currentMessage is updated
         const partsToSend: Part[] =
           iterations === 1 && messageParts && messageParts.length > 0
             ? messageParts
-            : [{ kind: 'text', text: currentMessage }];
+            : [{ kind: 'text', text: currentMessage }, ...originalNonTextParts];
 
         messageResponse = await a2aClient.sendMessage({
           message: {

--- a/agents-api/src/domains/run/routes/chat.ts
+++ b/agents-api/src/domains/run/routes/chat.ts
@@ -329,12 +329,16 @@ app.openapi(chatCompletionsRoute, async (c) => {
       }
       const userMessageId = generateId();
 
-      const messageContent = await buildPersistedMessageContent(userMessage, messageParts, {
-        tenantId,
-        projectId,
-        conversationId,
-        messageId: userMessageId,
-      });
+      const { content: messageContent, uploadedParts } = await buildPersistedMessageContent(
+        userMessage,
+        messageParts,
+        {
+          tenantId,
+          projectId,
+          conversationId,
+          messageId: userMessageId,
+        }
+      );
 
       await createMessage(runDbClient)({
         id: userMessageId,
@@ -477,7 +481,7 @@ app.openapi(chatCompletionsRoute, async (c) => {
             executionContext,
             conversationId,
             userMessage,
-            messageParts: messageParts.length > 0 ? messageParts : undefined,
+            messageParts: uploadedParts.length > 0 ? uploadedParts : undefined,
             initialAgentId: subAgentId,
             requestId,
             sseHelper,

--- a/agents-api/src/domains/run/routes/chatDataStream.ts
+++ b/agents-api/src/domains/run/routes/chatDataStream.ts
@@ -355,12 +355,16 @@ app.openapi(chatDataStreamRoute, async (c) => {
       }
       const userMessageId = generateId();
 
-      const messageContent = await buildPersistedMessageContent(userText, messageParts, {
-        tenantId,
-        projectId,
-        conversationId,
-        messageId: userMessageId,
-      });
+      const { content: messageContent, uploadedParts } = await buildPersistedMessageContent(
+        userText,
+        messageParts,
+        {
+          tenantId,
+          projectId,
+          conversationId,
+          messageId: userMessageId,
+        }
+      );
 
       await createMessage(runDbClient)({
         id: userMessageId,
@@ -392,7 +396,7 @@ app.openapi(chatDataStreamRoute, async (c) => {
           executionContext,
           conversationId,
           userMessage: userText,
-          messageParts: messageParts.length > 0 ? messageParts : undefined,
+          messageParts: uploadedParts.length > 0 ? uploadedParts : undefined,
           initialAgentId: subAgentId,
           requestId: `chat-${Date.now()}`,
           sseHelper: bufferingHelper,
@@ -499,7 +503,7 @@ app.openapi(chatDataStreamRoute, async (c) => {
               executionContext,
               conversationId,
               userMessage: userText,
-              messageParts: messageParts.length > 0 ? messageParts : undefined,
+              messageParts: uploadedParts.length > 0 ? uploadedParts : undefined,
               initialAgentId: subAgentId,
               requestId,
               sseHelper: streamHelper,

--- a/agents-api/src/domains/run/services/__tests__/blob-storage.test.ts
+++ b/agents-api/src/domains/run/services/__tests__/blob-storage.test.ts
@@ -364,7 +364,8 @@ describe('buildPersistedMessageContent', () => {
 
     const result = await buildPersistedMessageContent('Hello', parts, ctx);
 
-    expect(result).toEqual({ text: 'Hello' });
+    expect(result.content).toEqual({ text: 'Hello' });
+    expect(result.uploadedParts).toEqual(parts);
     expect(mockUpload).not.toHaveBeenCalled();
   });
 
@@ -391,11 +392,13 @@ describe('buildPersistedMessageContent', () => {
 
     const result = await buildPersistedMessageContent('Look at this', parts, ctx);
 
-    expect(result.text).toBe('Look at this');
-    expect(result.parts).toBeDefined();
-    expect(result.parts?.length).toBe(2);
-    expect(result.parts?.[0].kind).toBe('text');
-    expect(result.parts?.[1].kind).toBe('file');
+    expect(result.content.text).toBe('Look at this');
+    expect(result.content.parts).toBeDefined();
+    expect(result.content.parts?.length).toBe(2);
+    expect(result.content.parts?.[0].kind).toBe('text');
+    expect(result.content.parts?.[1].kind).toBe('file');
+    expect(result.uploadedParts).toBeDefined();
+    expect(result.uploadedParts.length).toBe(2);
     expect(mockUpload).toHaveBeenCalledOnce();
   });
 });

--- a/agents-api/src/domains/run/services/blob-storage/image-upload-helpers.ts
+++ b/agents-api/src/domains/run/services/blob-storage/image-upload-helpers.ts
@@ -11,13 +11,18 @@ interface PersistContext {
   messageId: string;
 }
 
+interface PersistedMessageResult {
+  content: MessageContent;
+  uploadedParts: Part[];
+}
+
 export async function buildPersistedMessageContent(
   text: string,
   parts: Part[],
   ctx: PersistContext
-): Promise<MessageContent> {
+): Promise<PersistedMessageResult> {
   if (!hasFileParts(parts)) {
-    return { text };
+    return { content: { text }, uploadedParts: parts };
   }
 
   try {
@@ -34,7 +39,7 @@ export async function buildPersistedMessageContent(
       'Built persisted message content with uploaded images'
     );
 
-    return { text, parts: contentParts };
+    return { content: { text, parts: contentParts }, uploadedParts };
   } catch (error) {
     logger.error(
       {
@@ -43,6 +48,6 @@ export async function buildPersistedMessageContent(
       },
       'Failed to upload images, persisting text only'
     );
-    return { text };
+    return { content: { text }, uploadedParts: parts };
   }
 }

--- a/agents-api/src/domains/run/services/blob-storage/resolve-blob-uris.ts
+++ b/agents-api/src/domains/run/services/blob-storage/resolve-blob-uris.ts
@@ -5,27 +5,33 @@ import { fromBlobUri, isBlobUri } from './index';
 
 const logger = getLogger('resolve-blob-uris');
 
+export function blobUriToProxyUrl(blobUri: string, baseUrl?: string): string | null {
+  const apiBaseUrl = baseUrl || env.INKEEP_AGENTS_API_URL;
+  const key = fromBlobUri(blobUri);
+  const keyParts = key.split('/');
+  if (keyParts.length >= 4) {
+    const [tenantId, projectId, conversationId, ...mediaParts] = keyParts;
+    const mediaKey = mediaParts.join('/');
+    return `${apiBaseUrl}/manage/tenants/${tenantId}/projects/${projectId}/conversations/${conversationId}/media/${encodeURIComponent(mediaKey)}`;
+  }
+  logger.error(
+    { key },
+    'Malformed blob key (expected tenantId/projectId/conversationId/...), cannot resolve'
+  );
+  return null;
+}
+
 export function resolveMessageBlobUris(content: MessageContent, baseUrl?: string): MessageContent {
   if (!content.parts || content.parts.length === 0) {
     return content;
   }
 
-  const apiBaseUrl = baseUrl || env.INKEEP_AGENTS_API_URL;
-
   const resolvedParts = content.parts.flatMap((part) => {
     if (part.kind === 'file' && typeof part.data === 'string' && isBlobUri(part.data)) {
-      const key = fromBlobUri(part.data);
-      const keyParts = key.split('/');
-      if (keyParts.length >= 4) {
-        const [tenantId, projectId, conversationId, ...mediaParts] = keyParts;
-        const mediaKey = mediaParts.join('/');
-        const proxyUrl = `${apiBaseUrl}/manage/tenants/${tenantId}/projects/${projectId}/conversations/${conversationId}/media/${encodeURIComponent(mediaKey)}`;
+      const proxyUrl = blobUriToProxyUrl(part.data, baseUrl);
+      if (proxyUrl) {
         return [{ ...part, data: proxyUrl }];
       }
-      logger.error(
-        { key },
-        'Malformed blob key (expected tenantId/projectId/conversationId/...), filtering part out'
-      );
       return [];
     }
 


### PR DESCRIPTION
Images attached to user messages were silently dropped when a request
was transferred or delegated to another agent. Three root causes:

- Transfer loop rebuilt parts as text-only after the first iteration
- Delegation tool had no access to the caller's image parts
- blob:// URIs were passed directly to the AI SDK which cannot fetch them

Thread original non-text parts across transfer iterations, pass image
parts into delegation tools via closure, resolve blob:// URIs to the
media proxy before handing to the AI SDK, and refactor
buildPersistedMessageContent to return uploaded parts so the execution
pipeline carries lightweight blob URIs instead of raw base64.
