### PR TITLE
fix: add server-side auth gate to tenant layout

### DIFF
--- a/agents-manage-ui/src/app/[tenantId]/layout.tsx
+++ b/agents-manage-ui/src/app/[tenantId]/layout.tsx
@@ -5,6 +5,7 @@ import { SentryScopeProvider } from '@/components/sentry-scope-provider';
 import { AppSidebarProvider } from '@/components/sidebar-nav/app-sidebar-provider';
 import { Separator } from '@/components/ui/separator';
 import { SidebarInset, SidebarTrigger } from '@/components/ui/sidebar';
+import { BETTER_AUTH_SESSION_TOKEN_COOKIE } from '@/lib/auth/constants';
 import { cn } from '@/lib/utils';
 
 export default async function Layout({ children, breadcrumbs }: LayoutProps<'/[tenantId]'>) {
@@ -12,7 +13,7 @@ export default async function Layout({ children, breadcrumbs }: LayoutProps<'/[t
   // This protects all routes under /[tenantId]/* (work-apps, stats, settings, etc.)
   // from being rendered without authentication.
   const cookieStore = await cookies();
-  const sessionToken = cookieStore.get('better-auth.session_token');
+  const sessionToken = cookieStore.get(BETTER_AUTH_SESSION_TOKEN_COOKIE);
 
   if (!sessionToken?.value) {
     redirect('/login');

--- a/agents-manage-ui/src/app/logout/route.ts
+++ b/agents-manage-ui/src/app/logout/route.ts
@@ -1,18 +1,8 @@
 import { cookies } from 'next/headers';
 import { type NextRequest, NextResponse } from 'next/server';
 import { getAgentsApiUrl } from '@/lib/api/api-config';
+import { BETTER_AUTH_COOKIE_PREFIX, BETTER_AUTH_COOKIES } from '@/lib/auth/constants';
 import { getLogger } from '@/lib/logger';
-
-/**
- * Known better-auth cookie names to clear.
- * These follow the pattern: better-auth.{cookie_name}
- */
-const BETTER_AUTH_COOKIES = [
-  'better-auth.session_token',
-  'better-auth.session_data',
-  'better-auth.dont_remember',
-  'better-auth.two_factor',
-];
 
 const DEFAULT_REDIRECT = '/login';
 
@@ -49,7 +39,7 @@ export async function GET(request: NextRequest) {
 
   // Get all better-auth cookies to forward to the sign-out endpoint
   const allCookies = cookieStore.getAll();
-  const authCookies = allCookies.filter((c) => c.name.includes('better-auth'));
+  const authCookies = allCookies.filter((c) => c.name.includes(BETTER_AUTH_COOKIE_PREFIX));
   const cookieHeader = authCookies.map((c) => `${c.name}=${c.value}`).join('; ');
 
   // Call the better-auth sign-out endpoint on the agents API

--- a/agents-manage-ui/src/lib/api/api-config.ts
+++ b/agents-manage-ui/src/lib/api/api-config.ts
@@ -4,6 +4,7 @@
  * Centralized configuration for API endpoints and settings
  */
 
+import { BETTER_AUTH_COOKIE_PREFIX } from '../auth/constants';
 import { DEFAULT_INKEEP_AGENTS_API_URL } from '../runtime-config/defaults';
 import { ApiError } from '../types/errors';
 
@@ -43,7 +44,7 @@ async function makeApiRequestInternal<T>(
       if (rawCookieHeader) {
         // Filter to only forward Better Auth cookies for security
         const cookiePairs = rawCookieHeader.split(';').map((c) => c.trim());
-        const authCookies = cookiePairs.filter((c) => c.includes('better-auth'));
+        const authCookies = cookiePairs.filter((c) => c.includes(BETTER_AUTH_COOKIE_PREFIX));
         cookieHeader = authCookies.join('; ');
       }
 
@@ -52,7 +53,7 @@ async function makeApiRequestInternal<T>(
         const { cookies } = await import('next/headers');
         const cookieStore = await cookies();
         const allCookies = cookieStore.getAll();
-        const authCookies = allCookies.filter((c) => c.name.includes('better-auth'));
+        const authCookies = allCookies.filter((c) => c.name.includes(BETTER_AUTH_COOKIE_PREFIX));
         cookieHeader = authCookies.map((c) => `${c.name}=${c.value}`).join('; ');
       }
     } catch {

--- a/agents-manage-ui/src/lib/auth/constants.ts
+++ b/agents-manage-ui/src/lib/auth/constants.ts
@@ -1,0 +1,23 @@
+/**
+ * Better Auth cookie name constants.
+ *
+ * These follow the pattern: better-auth.{cookie_name}
+ * Used across the app for auth checks, cookie forwarding, and logout cleanup.
+ */
+
+/** The session token cookie — presence indicates an active session. */
+export const BETTER_AUTH_SESSION_TOKEN_COOKIE = 'better-auth.session_token';
+
+/** Common prefix shared by all Better Auth cookies. */
+export const BETTER_AUTH_COOKIE_PREFIX = 'better-auth';
+
+/**
+ * All known Better Auth cookie names.
+ * Used by the logout route to ensure complete cookie cleanup.
+ */
+export const BETTER_AUTH_COOKIES = [
+  BETTER_AUTH_SESSION_TOKEN_COOKIE,
+  'better-auth.session_data',
+  'better-auth.dont_remember',
+  'better-auth.two_factor',
+] as const;


### PR DESCRIPTION
## Summary

- Adds a server-side authentication check in the `[tenantId]/layout.tsx` that redirects unauthenticated users to `/login` before any page content renders
- Fixes Work Apps, Stats, and Settings pages being accessible without login (while Projects already worked due to its server-side API call pattern)
- Protects all current and future routes under `/[tenantId]/*` with a single point of enforcement

## Root Cause

The `[tenantId]/layout.tsx` had no authentication check. Client component pages (`'use client'`) like Work Apps, Stats, and Settings rendered immediately without verifying the user's session. Their API calls happened later in `useEffect` hooks and errors were swallowed silently or shown as empty states.

The Projects page worked by accident because it's a server component that calls `fetchProjects()` at render time — when the API returns 401, `FullPageError` catches it and redirects to `/login`.

## How It Works

The layout now checks for the `better-auth.session_token` cookie server-side using Next.js `cookies()`. If the cookie is absent, `redirect('/login')` sends a 307 response before any rendering happens. This is lightweight (no API call) and consistent with the existing auth cookie patterns used in `api-config.ts` and the `logout` route.

## Test Plan

- [x] Visit `/default/work-apps` while logged out → should redirect to `/login`
- [ ] Visit `/default/stats` while logged out → should redirect to `/login`
- [x] Visit `/default/settings` while logged out → should redirect to `/login`
- [x] Visit `/default/projects` while logged out → should still redirect to `/login`
- [ ] Visit all above pages while logged in → should render normally
- [ ] Log out and verify redirect happens on next navigation to a tenant page

Resolves [PRD-6033](https://linear.app/inkeep/issue/PRD-6033/work-apps-and-stats-pages-accessible-without-login)

Made with [Cursor](https://cursor.com)