### PR TITLE
fix: add client-side auth guard to tenant pages (defense-in-depth)

### DIFF
--- a/agents-manage-ui/src/app/[tenantId]/settings/page.tsx
+++ b/agents-manage-ui/src/app/[tenantId]/settings/page.tsx
@@ -6,6 +6,7 @@ import { MembersTable } from '@/components/settings/members-table';
 import { CopyableSingleLineCode } from '@/components/ui/copyable-single-line-code';
 import { OrgRoles } from '@/constants/signoz';
 import { useAuthClient } from '@/contexts/auth-client';
+import { useRequireAuth } from '@/hooks/use-require-auth';
 import { getUserProviders, type UserProvider } from '@/lib/actions/user-accounts';
 import SettingsLoadingSkeleton from './loading';
 
@@ -16,6 +17,7 @@ type FullOrganization = NonNullable<
 >;
 
 export default function SettingsPage({ params }: PageProps<'/[tenantId]/settings'>) {
+  useRequireAuth();
   const authClient = useAuthClient();
   const { tenantId } = use(params);
   const [organization, setOrganization] = useState<FullOrganization | null>();

--- a/agents-manage-ui/src/app/[tenantId]/stats/ai-calls/page.tsx
+++ b/agents-manage-ui/src/app/[tenantId]/stats/ai-calls/page.tsx
@@ -22,6 +22,7 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Combobox } from '@/components/ui/combobox';
 import { Skeleton } from '@/components/ui/skeleton';
 import { UNKNOWN_VALUE } from '@/constants/signoz';
+import { useRequireAuth } from '@/hooks/use-require-auth';
 import { type TimeRange, useTracesQueryState } from '@/hooks/use-traces-query-state';
 import { fetchProjectsAction } from '@/lib/actions/projects';
 import { getSigNozStatsClient } from '@/lib/api/signoz-stats';
@@ -75,6 +76,7 @@ export default function AllProjectsAICallsBreakdown({
 }: {
   params: Promise<{ tenantId: string }>;
 }) {
+  useRequireAuth();
   const { tenantId } = use(params);
 
   const backLink = `/${tenantId}/stats`;

--- a/agents-manage-ui/src/app/[tenantId]/stats/page.tsx
+++ b/agents-manage-ui/src/app/[tenantId]/stats/page.tsx
@@ -23,6 +23,7 @@ import {
   TableRow,
 } from '@/components/ui/table';
 import { DOCS_BASE_URL } from '@/constants/theme';
+import { useRequireAuth } from '@/hooks/use-require-auth';
 import { useSignozConfig } from '@/hooks/use-signoz-config';
 import {
   useConversationsPerDayAcrossProjects,
@@ -41,6 +42,7 @@ const TIME_RANGES = {
 } as const;
 
 export default function ProjectsStatsPage({ params }: { params: Promise<{ tenantId: string }> }) {
+  useRequireAuth();
   const { tenantId } = use(params);
   const router = useRouter();
   const {

--- a/agents-manage-ui/src/app/[tenantId]/stats/tool-calls/page.tsx
+++ b/agents-manage-ui/src/app/[tenantId]/stats/tool-calls/page.tsx
@@ -12,6 +12,7 @@ import { ToolCallsByServerCard } from '@/components/traces/tool-calls/tool-calls
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Combobox } from '@/components/ui/combobox';
+import { useRequireAuth } from '@/hooks/use-require-auth';
 import { type TimeRange, useTracesQueryState } from '@/hooks/use-traces-query-state';
 import { fetchProjectsAction } from '@/lib/actions/projects';
 import { getSigNozStatsClient } from '@/lib/api/signoz-stats';
@@ -29,6 +30,7 @@ export default function AllProjectsToolCallsBreakdown({
 }: {
   params: Promise<{ tenantId: string }>;
 }) {
+  useRequireAuth();
   const { tenantId } = use(params);
 
   const backLink = `/${tenantId}/stats`;

--- a/agents-manage-ui/src/app/[tenantId]/work-apps/github/[installationId]/page.tsx
+++ b/agents-manage-ui/src/app/[tenantId]/work-apps/github/[installationId]/page.tsx
@@ -17,6 +17,7 @@ import {
   TableHeader,
   TableRow,
 } from '@/components/ui/table';
+import { useRequireAuth } from '@/hooks/use-require-auth';
 import type { WorkAppGitHubInstallationDetail, WorkAppGitHubRepository } from '@/lib/api/github';
 import {
   disconnectWorkAppGitHubInstallation,
@@ -70,6 +71,7 @@ const ItemValue = ({ children }: { children: React.ReactNode }) => {
 };
 
 export default function GitHubInstallationDetailPage({ params }: PageParams) {
+  useRequireAuth();
   const { tenantId, installationId } = use(params);
   const router = useRouter();
   const [data, setData] = useState<WorkAppGitHubInstallationDetail | null>(null);

--- a/agents-manage-ui/src/app/[tenantId]/work-apps/github/page.tsx
+++ b/agents-manage-ui/src/app/[tenantId]/work-apps/github/page.tsx
@@ -8,6 +8,7 @@ import { ErrorContent } from '@/components/errors/full-page-error';
 import EmptyState from '@/components/layout/empty-state';
 import { WorkAppGitHubInstallButton } from '@/components/settings/work-app-github-install-button';
 import { WorkAppGitHubInstallationsList } from '@/components/settings/work-app-github-installations-list';
+import { useRequireAuth } from '@/hooks/use-require-auth';
 import type { WorkAppGitHubInstallation } from '@/lib/api/github';
 import { fetchWorkAppGitHubInstallations } from '@/lib/api/github';
 import GitHubSettingsLoading from './loading';
@@ -17,6 +18,7 @@ interface PageParams {
 }
 
 export default function WorkAppGitHubSettingsPage({ params }: PageParams) {
+  useRequireAuth();
   const { tenantId } = use(params);
   const router = useRouter();
   const searchParams = useSearchParams();

--- a/agents-manage-ui/src/app/[tenantId]/work-apps/page.tsx
+++ b/agents-manage-ui/src/app/[tenantId]/work-apps/page.tsx
@@ -3,8 +3,10 @@
 import { use } from 'react';
 import { WorkAppsOverview } from '@/features/work-apps/common';
 import { SlackProvider } from '@/features/work-apps/slack';
+import { useRequireAuth } from '@/hooks/use-require-auth';
 
 function WorkAppsPage({ params }: { params: Promise<{ tenantId: string }> }) {
+  useRequireAuth();
   const { tenantId } = use(params);
 
   return (

--- a/agents-manage-ui/src/app/[tenantId]/work-apps/slack/page.tsx
+++ b/agents-manage-ui/src/app/[tenantId]/work-apps/slack/page.tsx
@@ -2,8 +2,10 @@
 
 import { use } from 'react';
 import { SlackDashboard, SlackProvider } from '@/features/work-apps/slack';
+import { useRequireAuth } from '@/hooks/use-require-auth';
 
 function SlackWorkAppPage({ params }: { params: Promise<{ tenantId: string }> }) {
+  useRequireAuth();
   const { tenantId } = use(params);
 
   return (

--- a/agents-manage-ui/src/hooks/use-require-auth.ts
+++ b/agents-manage-ui/src/hooks/use-require-auth.ts
@@ -1,0 +1,27 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+import { useEffect } from 'react';
+import { buildLoginUrlWithCurrentPath } from '@/lib/utils/auth-redirect';
+import { useAuthSession } from './use-auth';
+
+/**
+ * Client-side auth guard hook. Redirects to login if the user session
+ * is not present after loading completes. Use as defense-in-depth
+ * alongside the server-side cookie check in the tenant layout.
+ *
+ * Handles the case where a session expires while the user is already
+ * on a page (the server-side layout check only runs on initial render).
+ */
+export function useRequireAuth() {
+  const { user, isLoading, isAuthenticated } = useAuthSession();
+  const router = useRouter();
+
+  useEffect(() => {
+    if (!isLoading && !user) {
+      router.replace(buildLoginUrlWithCurrentPath());
+    }
+  }, [isLoading, user, router]);
+
+  return { user, isLoading, isAuthenticated };
+}


### PR DESCRIPTION
## Summary

- Introduces a `useRequireAuth()` hook that monitors the client-side session and redirects to `/login` if the session is absent or expires
- Wires the hook into all 8 client-component pages under `/[tenantId]` that previously had no auth protection: Work Apps (overview, Slack, GitHub, GitHub installation detail), Stats (overview, AI calls, tool calls), and Settings
- Complements the server-side layout cookie check in PR #1976 as a defense-in-depth layer

## Why Both Layers?

| Scenario | Server-side layout check (PR #1976) | Client-side `useRequireAuth` (this PR) |
|---|---|---|
| User navigates to page while logged out | Blocks at server, redirects to `/login` | N/A (page never renders) |
| User's session expires while on page | Won't catch (only runs on initial render) | Detects session loss, redirects to `/login` |

## Changes

**New file:** `agents-manage-ui/src/hooks/use-require-auth.ts`
- Uses existing `useAuthSession()` hook to monitor session state
- Uses existing `buildLoginUrlWithCurrentPath()` to preserve return URL
- Redirects via `router.replace()` when session is absent after loading completes

**Modified pages (added `useRequireAuth()` call):**
- `[tenantId]/work-apps/page.tsx`
- `[tenantId]/work-apps/slack/page.tsx`
- `[tenantId]/work-apps/github/page.tsx`
- `[tenantId]/work-apps/github/[installationId]/page.tsx`
- `[tenantId]/stats/page.tsx`
- `[tenantId]/stats/ai-calls/page.tsx`
- `[tenantId]/stats/tool-calls/page.tsx`
- `[tenantId]/settings/page.tsx`

## Test Plan

- [ ] Visit `/default/work-apps` while logged out → should redirect to `/login`
- [ ] Visit `/default/stats` while logged out → should redirect to `/login`
- [ ] Visit `/default/settings` while logged out → should redirect to `/login`
- [ ] Log in, navigate to Work Apps, then clear `better-auth.session_token` cookie manually → should redirect to `/login`
- [ ] All pages render normally when logged in (no redirect flicker)

Resolves [PRD-6033](https://linear.app/inkeep/issue/PRD-6033/work-apps-and-stats-pages-accessible-without-login)

Made with [Cursor](https://cursor.com)