### PR TITLE
fix: remove empty "Last Used" column from Slack linked users CSV export

### DIFF
--- a/agents-manage-ui/src/features/work-apps/slack/api/slack-api.ts
+++ b/agents-manage-ui/src/features/work-apps/slack/api/slack-api.ts
@@ -325,13 +325,12 @@ export const slackApi = {
       return 'No linked users to export';
     }
 
-    const headers = ['Slack Username', 'Slack Email', 'Slack User ID', 'Linked At', 'Last Used'];
+    const headers = ['Slack Username', 'Slack Email', 'Slack User ID', 'Linked At'];
     const rows = users.map((user) => [
       user.slackUsername || '',
       user.slackEmail || '',
       user.slackUserId,
       new Date(user.linkedAt).toISOString(),
-      user.lastUsedAt ? new Date(user.lastUsedAt).toISOString() : '',
     ]);
 
     const csvContent = [headers.join(','), ...rows.map((row) => row.join(','))].join('\n');


### PR DESCRIPTION
## Summary
- Removes the "Last Used" column from the Slack linked users CSV export, as it was always empty
- The `lastUsedAt` field is retained in the data model/API response for future use

## Test plan
- [ ] Export linked users CSV from a Slack workspace and verify the "Last Used" column is no longer present
- [ ] Verify remaining columns (Slack Username, Slack Email, Slack User ID, Linked At) are correct

Made with [Cursor](https://cursor.com)