### PR TITLE
fix: suppress spurious timeout error in Slack when streaming finalization fails

### DIFF
--- a/packages/agents-work-apps/src/__tests__/slack/streaming.test.ts
+++ b/packages/agents-work-apps/src/__tests__/slack/streaming.test.ts
@@ -148,4 +148,105 @@ describe('streamAgentResponse', () => {
     expect(body.conversationId).toBe('conv-123');
     expect(body.stream).toBe(true);
   });
+
+  describe('contentAlreadyDelivered error suppression', () => {
+    it('should return success and suppress error message when content was already streamed', async () => {
+      // Simulate a stream that delivers content then throws on the next read
+      const sseData = 'data: {"type":"text-delta","delta":"Hello world"}\n';
+      let readCount = 0;
+      const stream = new ReadableStream({
+        pull(controller) {
+          if (readCount === 0) {
+            controller.enqueue(new TextEncoder().encode(sseData));
+            readCount++;
+          } else {
+            controller.error(new Error('streamer.append timed out after 10000ms'));
+          }
+        },
+      });
+
+      const localAppend = vi.fn().mockResolvedValue(undefined);
+      const localStop = vi.fn().mockResolvedValue(undefined);
+      mockSlackClient.chatStream.mockReturnValue({
+        append: localAppend,
+        stop: localStop,
+      });
+
+      vi.spyOn(global, 'fetch').mockResolvedValue(new Response(stream, { status: 200 }));
+
+      const result = await streamAgentResponse(baseParams);
+
+      expect(result.success).toBe(true);
+      // Should NOT post any error message to the user
+      expect(mockPostMessage).not.toHaveBeenCalled();
+      // Should still clean up thinking message
+      expect(mockChatDelete).toHaveBeenCalledWith(
+        expect.objectContaining({ channel: 'C456', ts: '1234.9999' })
+      );
+    });
+
+    it('should post error message when no content was delivered', async () => {
+      // Stream that errors immediately before any content
+      const stream = new ReadableStream({
+        pull(controller) {
+          controller.error(new Error('connection reset'));
+        },
+      });
+
+      const localAppend = vi.fn().mockResolvedValue(undefined);
+      const localStop = vi.fn().mockResolvedValue(undefined);
+      mockSlackClient.chatStream.mockReturnValue({
+        append: localAppend,
+        stop: localStop,
+      });
+
+      vi.spyOn(global, 'fetch').mockResolvedValue(new Response(stream, { status: 200 }));
+
+      const result = await streamAgentResponse(baseParams);
+
+      expect(result.success).toBe(false);
+      expect(result.errorType).toBeDefined();
+      // Should post error message since no content was delivered
+      expect(mockPostMessage).toHaveBeenCalledWith(
+        expect.objectContaining({
+          channel: 'C456',
+          thread_ts: '1234.5678',
+        })
+      );
+    });
+
+    it('should return success when streamer.stop() finalization times out after content delivery', async () => {
+      const sseData =
+        'data: {"type":"text-delta","delta":"Hello "}\n' +
+        'data: {"type":"text-delta","delta":"world"}\n' +
+        'data: [DONE]\n';
+
+      const stream = new ReadableStream({
+        start(controller) {
+          controller.enqueue(new TextEncoder().encode(sseData));
+          controller.close();
+        },
+      });
+
+      const localAppend = vi.fn().mockResolvedValue(undefined);
+      // streamer.stop() rejects to simulate finalization timeout
+      const localStop = vi
+        .fn()
+        .mockRejectedValue(new Error('streamer.stop timed out after 10000ms'));
+      mockSlackClient.chatStream.mockReturnValue({
+        append: localAppend,
+        stop: localStop,
+      });
+
+      vi.spyOn(global, 'fetch').mockResolvedValue(new Response(stream, { status: 200 }));
+
+      const result = await streamAgentResponse(baseParams);
+
+      expect(result.success).toBe(true);
+      // Should NOT post any error message to the user
+      expect(mockPostMessage).not.toHaveBeenCalled();
+      // Should still clean up thinking message
+      expect(mockChatDelete).toHaveBeenCalledWith(expect.objectContaining({ ts: '1234.9999' }));
+    });
+  });
 });

--- a/packages/agents-work-apps/src/slack/tracer.ts
+++ b/packages/agents-work-apps/src/slack/tracer.ts
@@ -36,6 +36,8 @@ export const SLACK_SPAN_KEYS = {
   IS_BOT_MESSAGE: 'slack.is_bot_message',
   HAS_QUERY: 'slack.has_query',
   IS_IN_THREAD: 'slack.is_in_thread',
+  STREAM_FINALIZATION_FAILED: 'slack.stream_finalization_failed',
+  CONTENT_ALREADY_DELIVERED: 'slack.content_already_delivered',
 } as const;
 
 export type SlackOutcome =
@@ -43,6 +45,7 @@ export type SlackOutcome =
   | 'ignored_bot_message'
   | 'ignored_unknown_event'
   | 'ignored_no_action_match'
+  | 'ignored_slack_retry'
   | 'url_verification'
   | 'validation_error'
   | 'signature_invalid'


### PR DESCRIPTION
## Summary

- **Fixes spurious "Request timed out" message** appearing in Slack threads after the agent's response was already successfully delivered. The root cause was `streamer.stop()` (chatStream finalization) exceeding its 10s timeout, which triggered the error handler to post a user-facing error even though the user already had the full response.
- **Adds Slack event retry deduplication** by checking the `X-Slack-Retry-Num` header and immediately acknowledging retries without re-processing, preventing potential duplicate agent invocations.

## Details

### Problem

When a user @mentioned the bot in a Slack thread, the agent would run successfully and stream its full response to the user. However, the `streamer.stop()` call (which finalizes the chatStream and adds a context block) would sometimes exceed its 10-second timeout (`CHATSTREAM_OP_TIMEOUT_MS`). This caused the error to propagate to the main catch block, which classified it as `SlackErrorType.TIMEOUT` and posted a "Request timed out / [agent] took too long to respond" message — confusing because the user already had the answer.

### Changes

**`streaming.ts`:**
1. Wrapped `streamer.stop()` in the success path with its own try/catch — a finalization timeout after content delivery is now logged as a warning instead of throwing into the error handler
2. Added a `contentAlreadyDelivered` check (`fullText.length > 0`) in the main catch block — if content was already streamed, suppress the user-facing error message and return success

**`events.ts`:**
1. Added early check for `X-Slack-Retry-Num` header before processing events — retried events are acknowledged immediately with `{ ok: true }` to prevent duplicate processing

## Test plan

- [ ] Trigger a Slack @mention in a thread and verify the agent responds without a spurious timeout error
- [ ] Verify that genuine errors (no content delivered) still surface user-facing error messages
- [ ] Verify Slack retry events are acknowledged without duplicate agent invocations (check logs for "Acknowledging Slack retry without re-processing")

Made with [Cursor](https://cursor.com)