### PR TITLE
fix(work-apps): detect agent completion event to finalize Slack stream immediately

### DIFF
--- a/packages/agents-work-apps/src/slack/services/events/streaming.ts
+++ b/packages/agents-work-apps/src/slack/services/events/streaming.ts
@@ -219,6 +219,8 @@ export async function streamAgentResponse(params: {
     });
 
     try {
+      let agentCompleted = false;
+
       while (true) {
         const { done, value } = await reader.read();
         if (done) break;
@@ -236,6 +238,10 @@ export async function streamAgentResponse(params: {
             const data = JSON.parse(jsonStr);
 
             if (data.type === 'data-operation') {
+              if (data.data?.type === 'completion') {
+                agentCompleted = true;
+                break;
+              }
               continue;
             }
 
@@ -274,6 +280,8 @@ export async function streamAgentResponse(params: {
             // Skip invalid JSON
           }
         }
+
+        if (agentCompleted) break;
       }
 
       clearTimeout(timeoutId);


### PR DESCRIPTION
## Summary

- Fixes the Slack "@mention" streaming flow where the "preparing a response..." thinking message was never deleted and the chatStream was never finalized after the agent completed
- **Root cause**: The SSE stream from `/run/api/chat` stays open after the agent finishes because the `execute` callback in `createUIMessageStream` waits for cleanup operations (`agentSessionManager.endSession`, two `flushBatchProcessor()` calls with network I/O to the telemetry backend) before returning. The Slack streaming code's `reader.read()` blocks during this window — up to 2 minutes — preventing `streamer.stop()` and the thinking message deletion from running
- **Fix**: Detects the `completion` data-operation event in the SSE stream and breaks out of the read loop immediately, so the chatStream is finalized and the thinking message is deleted within seconds of the agent completing — without waiting for the HTTP connection to close

## Test plan

- [ ] Trigger a Slack @mention that invokes an agent with tool calls (e.g., the Linear Ticket Filer)
- [ ] Verify the "preparing a response..." message is deleted promptly after the agent response appears
- [ ] Verify the chatStream message is finalized with the context block footer
- [ ] Verify that error paths (agent failure, stream timeout) still behave correctly

Made with [Cursor](https://cursor.com)