### PR TITLE
fix: use OpenAPI brace syntax for path params in createRoute definitions

### DIFF
--- a/agents-api/__snapshots__/openapi.json
+++ b/agents-api/__snapshots__/openapi.json
@@ -10848,7 +10848,7 @@
         ]
       }
     },
-    "/manage/tenants/{tenantId}/github/installations/:installationId": {
+    "/manage/tenants/{tenantId}/github/installations/{installationId}": {
       "delete": {
         "description": "Permanently deletes a GitHub App installation from the tenant. This hard deletes the installation record, all associated repositories, and project repository access entries. This action cannot be undone. Use POST /disconnect for soft delete instead. Note: This does NOT uninstall the GitHub App from GitHub - the user can do that separately from GitHub settings.",
         "operationId": "delete-github-installation",
@@ -11161,7 +11161,7 @@
         ]
       }
     },
-    "/manage/tenants/{tenantId}/github/installations/:installationId/disconnect": {
+    "/manage/tenants/{tenantId}/github/installations/{installationId}/disconnect": {
       "post": {
         "description": "Disconnects a GitHub App installation from the tenant. This soft deletes the installation (sets status to \"disconnected\") and removes all project repository access entries. The installation record is preserved for audit purposes. Note: This does NOT uninstall the GitHub App from GitHub - the user can do that separately from GitHub settings.",
         "operationId": "disconnect-github-installation",
@@ -11266,7 +11266,7 @@
         ]
       }
     },
-    "/manage/tenants/{tenantId}/github/installations/:installationId/reconnect": {
+    "/manage/tenants/{tenantId}/github/installations/{installationId}/reconnect": {
       "post": {
         "description": "Reconnects a previously disconnected GitHub App installation by setting its status back to \"active\" and syncing the available repositories from GitHub. This can only be used on installations with \"disconnected\" status.",
         "operationId": "reconnect-github-installation",
@@ -11450,7 +11450,7 @@
         ]
       }
     },
-    "/manage/tenants/{tenantId}/github/installations/:installationId/sync": {
+    "/manage/tenants/{tenantId}/github/installations/{installationId}/sync": {
       "post": {
         "description": "Manually refreshes the repository list for a GitHub App installation by fetching the current list from GitHub API. This is useful if webhooks were missed or to ensure the local data is in sync with GitHub.",
         "operationId": "sync-github-installation-repositories",

--- a/agents-api/src/domains/manage/routes/github.ts
+++ b/agents-api/src/domains/manage/routes/github.ts
@@ -214,7 +214,7 @@ const InstallationDetailResponseSchema = z.object({
 app.openapi(
   createRoute({
     method: 'get',
-    path: '/installations/:installationId',
+    path: '/installations/{installationId}',
     summary: 'Get GitHub App installation details',
     operationId: 'get-github-installation-details',
     tags: ['GitHub'],
@@ -288,7 +288,7 @@ const DisconnectInstallationResponseSchema = z.object({
 app.openapi(
   createRoute({
     method: 'post',
-    path: '/installations/:installationId/disconnect',
+    path: '/installations/{installationId}/disconnect',
     summary: 'Disconnect a GitHub App installation',
     operationId: 'disconnect-github-installation',
     tags: ['GitHub'],
@@ -413,7 +413,7 @@ const serviceUnavailableSchema = {
 app.openapi(
   createRoute({
     method: 'post',
-    path: '/installations/:installationId/reconnect',
+    path: '/installations/{installationId}/reconnect',
     summary: 'Reconnect a disconnected GitHub App installation',
     operationId: 'reconnect-github-installation',
     tags: ['GitHub'],
@@ -540,7 +540,7 @@ app.openapi(
 app.openapi(
   createRoute({
     method: 'delete',
-    path: '/installations/:installationId',
+    path: '/installations/{installationId}',
     summary: 'Delete a GitHub App installation permanently',
     operationId: 'delete-github-installation',
     tags: ['GitHub'],
@@ -603,7 +603,7 @@ const SyncRepositoriesResponseSchema = z.object({
 app.openapi(
   createRoute({
     method: 'post',
-    path: '/installations/:installationId/sync',
+    path: '/installations/{installationId}/sync',
     summary: 'Sync repositories for a GitHub App installation',
     operationId: 'sync-github-installation-repositories',
     tags: ['GitHub'],

--- a/packages/agents-work-apps/src/slack/routes/workspaces.ts
+++ b/packages/agents-work-apps/src/slack/routes/workspaces.ts
@@ -171,7 +171,7 @@ app.openapi(
 app.openapi(
   createRoute({
     method: 'get',
-    path: '/:teamId',
+    path: '/{teamId}',
     summary: 'Get Workspace',
     description: 'Get details of a specific Slack workspace',
     operationId: 'slack-get-workspace',
@@ -234,7 +234,7 @@ app.openapi(
 app.openapi(
   createRoute({
     method: 'get',
-    path: '/:teamId/settings',
+    path: '/{teamId}/settings',
     summary: 'Get Workspace Settings',
     description: 'Get settings for a Slack workspace including default agent',
     operationId: 'slack-get-workspace-settings',
@@ -287,7 +287,7 @@ app.openapi(
 app.openapi(
   createRoute({
     method: 'put',
-    path: '/:teamId/settings',
+    path: '/{teamId}/settings',
     summary: 'Update Workspace Settings',
     description: 'Update workspace settings including default agent',
     operationId: 'slack-update-workspace-settings',
@@ -354,7 +354,7 @@ app.openapi(
 app.openapi(
   createRoute({
     method: 'delete',
-    path: '/:teamId',
+    path: '/{teamId}',
     summary: 'Uninstall Workspace',
     description: 'Uninstall Slack app from workspace. Accepts either teamId or connectionId.',
     operationId: 'slack-delete-workspace',
@@ -469,7 +469,7 @@ app.openapi(
 app.openapi(
   createRoute({
     method: 'get',
-    path: '/:teamId/channels',
+    path: '/{teamId}/channels',
     summary: 'List Channels',
     description: 'List Slack channels in the workspace that the bot can see',
     operationId: 'slack-list-channels',
@@ -575,7 +575,7 @@ app.openapi(
 app.openapi(
   createRoute({
     method: 'get',
-    path: '/:teamId/channels/:channelId/settings',
+    path: '/{teamId}/channels/{channelId}/settings',
     summary: 'Get Channel Settings',
     description: 'Get default agent configuration for a specific channel',
     operationId: 'slack-get-channel-settings',
@@ -632,7 +632,7 @@ app.openapi(
 app.openapi(
   createRoute({
     method: 'put',
-    path: '/:teamId/channels/:channelId/settings',
+    path: '/{teamId}/channels/{channelId}/settings',
     summary: 'Set Channel Default Agent',
     description: 'Set or update the default agent for a specific channel',
     operationId: 'slack-set-channel-settings',
@@ -710,7 +710,7 @@ app.use('/:teamId/channels/bulk', async (c, next) => {
 app.openapi(
   createRoute({
     method: 'put',
-    path: '/:teamId/channels/bulk',
+    path: '/{teamId}/channels/bulk',
     summary: 'Bulk Set Channel Agents',
     description: 'Apply the same agent configuration to multiple channels at once',
     operationId: 'slack-bulk-set-channel-agents',
@@ -821,7 +821,7 @@ app.openapi(
 app.openapi(
   createRoute({
     method: 'delete',
-    path: '/:teamId/channels/bulk',
+    path: '/{teamId}/channels/bulk',
     summary: 'Bulk Remove Channel Configs',
     description: 'Remove agent configuration from multiple channels at once',
     operationId: 'slack-bulk-delete-channel-agents',
@@ -886,7 +886,7 @@ app.openapi(
 app.openapi(
   createRoute({
     method: 'delete',
-    path: '/:teamId/channels/:channelId/settings',
+    path: '/{teamId}/channels/{channelId}/settings',
     summary: 'Remove Channel Config',
     description: 'Remove the default agent configuration for a channel',
     operationId: 'slack-delete-channel-settings',
@@ -933,7 +933,7 @@ app.openapi(
 app.openapi(
   createRoute({
     method: 'get',
-    path: '/:teamId/users',
+    path: '/{teamId}/users',
     summary: 'List Linked Users',
     description: 'List all users linked to Inkeep in this workspace',
     operationId: 'slack-list-linked-users',
@@ -999,7 +999,7 @@ app.openapi(
 app.openapi(
   createRoute({
     method: 'get',
-    path: '/:teamId/health',
+    path: '/{teamId}/health',
     summary: 'Check Workspace Health',
     description:
       'Verify the bot token is valid and check permissions. Returns bot info and permission status.',
@@ -1116,7 +1116,7 @@ app.openapi(
 app.openapi(
   createRoute({
     method: 'post',
-    path: '/:teamId/test-message',
+    path: '/{teamId}/test-message',
     summary: 'Send Test Message',
     description: 'Send a test message to verify the bot is working correctly.',
     operationId: 'slack-test-message',


### PR DESCRIPTION
## Summary
- Fixes 21 OpenAPI validation errors caused by using `:paramName` (Hono/Express syntax) instead of `{paramName}` (OpenAPI standard) in `createRoute` path strings
- Affected routes: all Slack workspace routes (`workspaces.ts`) and GitHub installation routes (`github.ts`)
- Root cause: `@hono/zod-openapi` converts colon-to-brace at the parent `app.route()` mount level, but not inside `createRoute({ path })` strings

## Changed files
- `packages/agents-work-apps/src/slack/routes/workspaces.ts` — 13 path fixes (`:teamId`, `:channelId`)
- `agents-api/src/domains/manage/routes/github.ts` — 5 path fixes (`:installationId`)
- `agents-api/__snapshots__/openapi.json` — updated snapshot

## Test plan
- [x] OpenAPI snapshot test passes with updated paths
- [x] All pre-commit hook tests pass (1413 passed)
- [ ] Verify `speakeasy lint` no longer reports `path-params` errors for these endpoints

Made with [Cursor](https://cursor.com)