### PR TITLE
fix: remove zodResolver `as any` casts in agents-manage-ui

### DIFF
--- a/agents-manage-ui/src/components/credentials/views/generic-auth-form.tsx
+++ b/agents-manage-ui/src/components/credentials/views/generic-auth-form.tsx
@@ -76,11 +76,12 @@ export function GenericAuthForm({
     ? createFormSchema(formConfig)
     : z.object({ _placeholder: z.string().optional() });
 
-  type FormData = Record<string, string>;
-  const defaultValues: FormData = Object.fromEntries(allFields.map((field) => [field.key, '']));
+  const defaultValues: Record<string, string> = Object.fromEntries(
+    allFields.map((field) => [field.key, ''])
+  );
 
-  const form = useForm<FormData>({
-    resolver: formConfig ? zodResolver(FormSchema as any) : undefined,
+  const form = useForm({
+    resolver: formConfig ? zodResolver(FormSchema) : undefined,
     defaultValues,
   });
 
@@ -102,7 +103,7 @@ export function GenericAuthForm({
     );
   }
 
-  const handleSubmit = (data: FormData) => {
+  const handleSubmit = (data: Record<string, unknown>) => {
     // Prepare credentials object - only include non-empty values
     const credentials: Record<string, any> = {};
 

--- a/agents-manage-ui/src/components/datasets/form/dataset-run-config-form.tsx
+++ b/agents-manage-ui/src/components/datasets/form/dataset-run-config-form.tsx
@@ -58,8 +58,8 @@ export function DatasetRunConfigForm({
   const { data: agents, isFetching: loadingAgents } = useAgentsQuery();
   const { data: evaluators, isFetching: loadingEvaluators } = useEvaluatorsQuery();
 
-  const form = useForm<DatasetRunConfigFormData>({
-    resolver: zodResolver(datasetRunConfigSchema) as any,
+  const form = useForm({
+    resolver: zodResolver(datasetRunConfigSchema),
     defaultValues: {
       name: initialData?.name || '',
       description: initialData?.description || '',

--- a/agents-manage-ui/src/components/scheduled-triggers/scheduled-trigger-form.tsx
+++ b/agents-manage-ui/src/components/scheduled-triggers/scheduled-trigger-form.tsx
@@ -126,8 +126,8 @@ export function ScheduledTriggerForm({
 
   const defaultValues = getDefaultValues();
 
-  const form = useForm<ScheduledTriggerFormData>({
-    resolver: zodResolver(scheduledTriggerFormSchema) as any,
+  const form = useForm({
+    resolver: zodResolver(scheduledTriggerFormSchema),
     defaultValues,
   });
 
@@ -265,9 +265,9 @@ export function ScheduledTriggerForm({
                   <FormItem>
                     <FormControl>
                       <FriendlyScheduleBuilder
-                        value={field.value}
+                        value={field.value ?? ''}
                         onChange={field.onChange}
-                        timezone={form.watch('cronTimezone')}
+                        timezone={form.watch('cronTimezone') ?? 'UTC'}
                       />
                     </FormControl>
                     <FormMessage />
@@ -284,7 +284,7 @@ export function ScheduledTriggerForm({
                   <FormItem>
                     <FormControl>
                       <DateTimePicker
-                        value={field.value}
+                        value={field.value ?? ''}
                         onChange={field.onChange}
                         minDate={new Date()}
                       />
@@ -363,7 +363,13 @@ export function ScheduledTriggerForm({
                   <FormItem>
                     <FormLabel>Max Retries</FormLabel>
                     <FormControl>
-                      <Input {...field} type="number" min={0} max={10} />
+                      <Input
+                        {...field}
+                        value={Number(field.value)}
+                        type="number"
+                        min={0}
+                        max={10}
+                      />
                     </FormControl>
                     <FormDescription>Number of retry attempts (0-10)</FormDescription>
                     <FormMessage />
@@ -378,7 +384,13 @@ export function ScheduledTriggerForm({
                   <FormItem>
                     <FormLabel>Retry Delay (seconds)</FormLabel>
                     <FormControl>
-                      <Input {...field} type="number" min={10} max={3600} />
+                      <Input
+                        {...field}
+                        value={Number(field.value)}
+                        type="number"
+                        min={10}
+                        max={3600}
+                      />
                     </FormControl>
                     <FormDescription>Seconds between retries (10-3600)</FormDescription>
                     <FormMessage />
@@ -393,7 +405,13 @@ export function ScheduledTriggerForm({
                   <FormItem>
                     <FormLabel>Timeout (seconds)</FormLabel>
                     <FormControl>
-                      <Input {...field} type="number" min={30} max={900} />
+                      <Input
+                        {...field}
+                        value={Number(field.value)}
+                        type="number"
+                        min={30}
+                        max={900}
+                      />
                     </FormControl>
                     <FormDescription>Execution timeout (30-780)</FormDescription>
                     <FormMessage />

--- a/agents-manage-ui/src/components/triggers/trigger-form.tsx
+++ b/agents-manage-ui/src/components/triggers/trigger-form.tsx
@@ -402,8 +402,8 @@ export function TriggerForm({ tenantId, projectId, agentId, trigger, mode }: Tri
 
   const defaultValues = getDefaultValues();
 
-  const form = useForm<TriggerFormData>({
-    resolver: zodResolver(triggerFormSchema) as any,
+  const form = useForm({
+    resolver: zodResolver(triggerFormSchema),
     defaultValues,
   });
 


### PR DESCRIPTION
## Summary

- Remove all 4 `as any` casts on `zodResolver()` calls that masked Zod v4 + @hookform/resolvers type incompatibility
- Fix by dropping explicit `useForm<T>()` generics and letting TypeScript infer types from the resolver (upstream recommended pattern)
- Handle downstream type narrowing at point of use for `.default()` and `z.coerce` fields

## Problem

Zod v4 schemas using `.default('')`, `z.coerce.number()`, and `.refine()` have different input and output types. When an explicit `useForm<OutputType>()` generic is provided, `zodResolver()` produces `Resolver<InputType, any, OutputType>` which is incompatible with the expected `Resolver<OutputType, any, OutputType>`. This was masked by `as any` casts.

## Approach

Following the [upstream recommendation](https://github.com/colinhacks/zod/issues/4992) and partial fix in @hookform/resolvers@5.2.2:

1. **Remove `useForm<T>()` explicit generics** — let TypeScript infer from the resolver
2. **Handle downstream type narrowing** for fields whose input types differ from output types:
   - `.default('')` fields: add `?? ''` fallback for `string | undefined` input type  
   - `z.coerce.number()` fields: explicitly pass `value={Number(field.value)}` for `unknown` input type
   - Dynamic schema: widen submit handler parameter from `Record<string, string>` to `Record<string, unknown>`

## Files changed

| File | Change |
|---|---|
| `generic-auth-form.tsx` | Remove `as any`, drop generic, widen submit handler type |
| `dataset-run-config-form.tsx` | Remove `as any`, drop generic |
| `scheduled-trigger-form.tsx` | Remove `as any`, drop generic, fix field value types |
| `trigger-form.tsx` | Remove `as any`, drop generic |

## Test plan

- [x] `pnpm typecheck` passes with zero errors
- [x] `pnpm lint` passes
- [x] `pnpm format:check` passes
- [ ] CI pipeline green
- [ ] Manual: verify all 4 forms render and submit correctly (credentials, dataset run config, scheduled triggers, triggers)

🤖 Generated with [Claude Code](https://claude.com/claude-code)