### PR TITLE
fix: skip Claude PR review for bot-initiated PRs instead of erroring

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   pr-review:
     if: |
-      (github.event_name == 'pull_request' && github.event.pull_request.draft == false) ||
+      (github.event_name == 'pull_request' && github.event.pull_request.draft == false && github.event.sender.type != 'Bot') ||
       (
         github.event_name == 'issue_comment' &&
         github.event.issue.pull_request &&


### PR DESCRIPTION
## Summary
- Add `github.event.sender.type != 'Bot'` to the `pull_request` job condition in `claude-code-review.yml`
- Bot-initiated PRs (e.g. from `inkeep`, `dependabot`) now show as **skipped** (neutral) instead of **failed** (red X)
- Human reviewers can still trigger reviews on bot PRs via `@claude --review` comments (the `issue_comment` path is unchanged)

## Context
Bot PRs like [#2034](https://github.com/inkeep/agents/actions/runs/22052306513/job/63712757449?pr=2034) were failing because `claude-code-action` rejects non-human actors not in `allowed_bots`, causing noisy red X check failures.

## Test plan
- [ ] Verify this PR's own Claude PR Review check is skipped (it was triggered by a human, so it should run normally — but confirms YAML is valid)
- [ ] Next bot-initiated PR should show "skipped" instead of "failed"

🤖 Generated with [Claude Code](https://claude.com/claude-code)