### PR TITLE
fix: resolve agent-tools.cy.ts E2E test flakiness

### DIFF
--- a/agents-manage-ui/cypress/e2e/agent-tools.cy.ts
+++ b/agents-manage-ui/cypress/e2e/agent-tools.cy.ts
@@ -24,12 +24,14 @@ describe('Agent Tools', () => {
     cy.contains('Create agent').click();
     cy.get('[name=name]').type(generateId(), { delay: 0 });
     cy.get('button[type=submit]').click();
-    cy.get('.react-flow__node').should('exist');
+    cy.get('.react-flow__node', { timeout: 10000 }).should('have.length', 1);
 
     dragNode('[aria-label="Drag Function Tool node"]');
+    cy.get('.react-flow__node', { timeout: 10000 }).should('have.length', 2);
     connectEdge('[data-handleid="target-function-tool"]');
     cy.typeInMonaco('code.jsx', 'function () {}');
     dragNode('[aria-label="Drag MCP node"]');
+    cy.get('.react-flow__node', { timeout: 10000 }).should('have.length', 3);
     cy.contains('Geocode address').click();
     connectEdge('[data-handleid="target-mcp"]');
     saveAndAssert();
@@ -38,10 +40,12 @@ describe('Agent Tools', () => {
     saveAndAssert();
 
     function saveAndAssert() {
+      cy.intercept('POST', '**/agents/*').as('saveAgent');
       cy.contains('Save changes').click();
-      cy.contains('Agent saved').should('exist');
+      cy.wait('@saveAgent');
+      cy.contains('Agent saved', { timeout: 10000 }).should('exist');
       cy.reload();
-      cy.get('.react-flow__node').should('have.length', 3);
+      cy.get('.react-flow__node', { timeout: 10000 }).should('have.length', 3);
     }
   });
 


### PR DESCRIPTION
## Summary

Fixes the flaky "Editing sub-agent ID should not removes linked tools" test in `agent-tools.cy.ts` which failed ~30% of the time in CI with `Found '2', expected '3'` after save+reload.

## Root Cause

Three contributing factors:
1. **No verification of drag-and-drop success** — `dragNode()` triggered drag events but never asserted a new node was created. Silent drag failures meant the test proceeded with fewer nodes than expected.
2. **No wait for save completion before reload** — `saveAndAssert()` waited for the "Agent saved" toast but immediately called `cy.reload()` without ensuring the server action response was fully processed. The save uses Next.js server actions (POST to current page URL), not a direct PUT to the API.
3. **Insufficient timeout after reload** — the default 4s Cypress timeout was not enough for CI to load JS, fetch agent data, and render React Flow nodes.

## Changes

- Assert node count after each `dragNode()` call (1→2→3) to catch drag failures early
- Use `cy.intercept('POST', '**/agents/*')` + `cy.wait('@saveAgent')` to deterministically wait for the Next.js server action save response before reloading
- Wait for "Agent saved" toast after the intercept to confirm UI processed the response
- Increase post-reload assertion timeout to 10s

## Test plan
- [ ] `agent-tools.cy.ts` passes consistently in CI (all 3 retry attempts)
- [ ] No other E2E tests regressed
- [ ] Format/JSON and Format/JavaScript tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)