### PR TITLE
fix: use connection() for runtime env vars in Docker deployments

### DIFF
--- a/.changeset/fixed-azure-lungfish.md
+++ b/.changeset/fixed-azure-lungfish.md
@@ -1,0 +1,5 @@
+---
+"@inkeep/agents-manage-ui": patch
+---
+
+Fix Docker deployments to evaluate environment variables at request time instead of build time

--- a/agents-manage-ui/src/app/layout.tsx
+++ b/agents-manage-ui/src/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from 'next';
 import { Inter, JetBrains_Mono } from 'next/font/google';
+import { connection } from 'next/server';
 import { ThemeProvider } from 'next-themes';
 import { NuqsAdapter } from 'nuqs/adapters/next/app';
 import { DevAutoLoginProvider } from '@/components/providers/dev-auto-login-provider';
@@ -68,45 +69,48 @@ export const metadata: Metadata = {
   }),
 };
 
-const runtimeConfig: RuntimeConfig = {
-  PUBLIC_INKEEP_AGENTS_RUN_API_BYPASS_SECRET:
-    process.env.PUBLIC_INKEEP_AGENTS_RUN_API_BYPASS_SECRET ||
-    process.env.NEXT_PUBLIC_INKEEP_AGENTS_RUN_API_BYPASS_SECRET,
-  PUBLIC_INKEEP_AGENTS_API_URL:
-    process.env.PUBLIC_INKEEP_AGENTS_API_URL ||
-    process.env.NEXT_PUBLIC_INKEEP_AGENTS_API_URL ||
-    DEFAULT_INKEEP_AGENTS_API_URL,
-  PUBLIC_SIGNOZ_URL:
-    process.env.PUBLIC_SIGNOZ_URL || process.env.NEXT_PUBLIC_SIGNOZ_URL || DEFAULT_SIGNOZ_URL,
-  PUBLIC_NANGO_SERVER_URL:
-    process.env.PUBLIC_NANGO_SERVER_URL ||
-    process.env.NEXT_PUBLIC_NANGO_SERVER_URL ||
-    DEFAULT_NANGO_SERVER_URL,
-  PUBLIC_NANGO_CONNECT_BASE_URL:
-    process.env.PUBLIC_NANGO_CONNECT_BASE_URL ||
-    process.env.NEXT_PUBLIC_NANGO_CONNECT_BASE_URL ||
-    DEFAULT_NANGO_CONNECT_BASE_URL,
-  PUBLIC_INKEEP_COPILOT_AGENT_ID:
-    process.env.PUBLIC_INKEEP_COPILOT_AGENT_ID || process.env.NEXT_PUBLIC_INKEEP_COPILOT_AGENT_ID,
-  PUBLIC_INKEEP_COPILOT_PROJECT_ID:
-    process.env.PUBLIC_INKEEP_COPILOT_PROJECT_ID ||
-    process.env.NEXT_PUBLIC_INKEEP_COPILOT_PROJECT_ID,
-  PUBLIC_INKEEP_COPILOT_TENANT_ID:
-    process.env.PUBLIC_INKEEP_COPILOT_TENANT_ID || process.env.NEXT_PUBLIC_INKEEP_COPILOT_TENANT_ID,
-  PUBLIC_AUTH0_DOMAIN: process.env.PUBLIC_AUTH0_DOMAIN || process.env.NEXT_PUBLIC_AUTH0_DOMAIN,
-  PUBLIC_GOOGLE_CLIENT_ID:
-    process.env.PUBLIC_GOOGLE_CLIENT_ID || process.env.NEXT_PUBLIC_GOOGLE_CLIENT_ID,
-  PUBLIC_IS_INKEEP_CLOUD_DEPLOYMENT:
-    process.env.PUBLIC_IS_INKEEP_CLOUD_DEPLOYMENT ||
-    process.env.NEXT_PUBLIC_IS_INKEEP_CLOUD_DEPLOYMENT ||
-    'false',
-  PUBLIC_POSTHOG_KEY: process.env.PUBLIC_POSTHOG_KEY || process.env.NEXT_PUBLIC_POSTHOG_KEY,
-  PUBLIC_POSTHOG_HOST: process.env.PUBLIC_POSTHOG_HOST || process.env.NEXT_PUBLIC_POSTHOG_HOST,
-  PUBLIC_POSTHOG_SITE_TAG:
-    process.env.PUBLIC_POSTHOG_SITE_TAG || process.env.NEXT_PUBLIC_POSTHOG_SITE_TAG,
-};
+export default async function RootLayout({ children }: LayoutProps<'/'>) {
+  await connection();
 
-export default function RootLayout({ children }: LayoutProps<'/'>) {
+  const runtimeConfig: RuntimeConfig = {
+    PUBLIC_INKEEP_AGENTS_RUN_API_BYPASS_SECRET:
+      process.env.PUBLIC_INKEEP_AGENTS_RUN_API_BYPASS_SECRET ||
+      process.env.NEXT_PUBLIC_INKEEP_AGENTS_RUN_API_BYPASS_SECRET,
+    PUBLIC_INKEEP_AGENTS_API_URL:
+      process.env.PUBLIC_INKEEP_AGENTS_API_URL ||
+      process.env.NEXT_PUBLIC_INKEEP_AGENTS_API_URL ||
+      DEFAULT_INKEEP_AGENTS_API_URL,
+    PUBLIC_SIGNOZ_URL:
+      process.env.PUBLIC_SIGNOZ_URL || process.env.NEXT_PUBLIC_SIGNOZ_URL || DEFAULT_SIGNOZ_URL,
+    PUBLIC_NANGO_SERVER_URL:
+      process.env.PUBLIC_NANGO_SERVER_URL ||
+      process.env.NEXT_PUBLIC_NANGO_SERVER_URL ||
+      DEFAULT_NANGO_SERVER_URL,
+    PUBLIC_NANGO_CONNECT_BASE_URL:
+      process.env.PUBLIC_NANGO_CONNECT_BASE_URL ||
+      process.env.NEXT_PUBLIC_NANGO_CONNECT_BASE_URL ||
+      DEFAULT_NANGO_CONNECT_BASE_URL,
+    PUBLIC_INKEEP_COPILOT_AGENT_ID:
+      process.env.PUBLIC_INKEEP_COPILOT_AGENT_ID || process.env.NEXT_PUBLIC_INKEEP_COPILOT_AGENT_ID,
+    PUBLIC_INKEEP_COPILOT_PROJECT_ID:
+      process.env.PUBLIC_INKEEP_COPILOT_PROJECT_ID ||
+      process.env.NEXT_PUBLIC_INKEEP_COPILOT_PROJECT_ID,
+    PUBLIC_INKEEP_COPILOT_TENANT_ID:
+      process.env.PUBLIC_INKEEP_COPILOT_TENANT_ID ||
+      process.env.NEXT_PUBLIC_INKEEP_COPILOT_TENANT_ID,
+    PUBLIC_AUTH0_DOMAIN: process.env.PUBLIC_AUTH0_DOMAIN || process.env.NEXT_PUBLIC_AUTH0_DOMAIN,
+    PUBLIC_GOOGLE_CLIENT_ID:
+      process.env.PUBLIC_GOOGLE_CLIENT_ID || process.env.NEXT_PUBLIC_GOOGLE_CLIENT_ID,
+    PUBLIC_IS_INKEEP_CLOUD_DEPLOYMENT:
+      process.env.PUBLIC_IS_INKEEP_CLOUD_DEPLOYMENT ||
+      process.env.NEXT_PUBLIC_IS_INKEEP_CLOUD_DEPLOYMENT ||
+      'false',
+    PUBLIC_POSTHOG_KEY: process.env.PUBLIC_POSTHOG_KEY || process.env.NEXT_PUBLIC_POSTHOG_KEY,
+    PUBLIC_POSTHOG_HOST: process.env.PUBLIC_POSTHOG_HOST || process.env.NEXT_PUBLIC_POSTHOG_HOST,
+    PUBLIC_POSTHOG_SITE_TAG:
+      process.env.PUBLIC_POSTHOG_SITE_TAG || process.env.NEXT_PUBLIC_POSTHOG_SITE_TAG,
+  };
+
   return (
     <html lang="en" suppressHydrationWarning>
       <body


### PR DESCRIPTION
## Summary

- Use the stable Next.js `connection()` API (v15+) to opt the root layout into dynamic rendering, ensuring `runtimeConfig` environment variables are evaluated at request time instead of build time
- Move `runtimeConfig` construction inside the component body (cleanliness improvement, not strictly required for correctness)
- Enables a single Docker image to be promoted across environments with different env var values (build once, deploy many)

## Root cause

The existing `RuntimeConfigProvider` pattern is architecturally correct — it reads `PUBLIC_*` env vars server-side in the root layout and passes them to client components via React Context. These `PUBLIC_*` vars (non-`NEXT_PUBLIC_`) are NOT inlined by turbopack — they remain as live `process.env` references in the compiled server-side JavaScript.

**The bug is not about _where_ env vars are read, but _when_ the component renders.**

Without any dynamic rendering signal, Next.js statically prerenders the root layout during `next build`. The component function runs at build time, reads `process.env.PUBLIC_*` (undefined/defaults in the build environment), and the resulting RSC payload — containing the serialized `runtimeConfig` object — is cached as static output. At runtime in Docker, the cached RSC payload is served directly; **the component function never re-runs**, so the containers env vars are never read.

`await connection()` tells Next.js to skip prerendering and re-render the layout per request. The same `process.env.PUBLIC_*` references now execute at request time inside the running Docker container, picking up the correct env var values.

## Why `connection()`?

- **Official Next.js recommendation** for this exact use case ([Self-Hosting guide](https://nextjs.org/docs/app/guides/self-hosting#environment-variables), [API reference](https://nextjs.org/docs/app/api-reference/functions/connection))
- Stabilized in Next.js v15.0.0 (replaces deprecated `unstable_noStore`)
- Minimal change — one import, one await
- Works with the existing `RuntimeConfigProvider` pattern — no new dependencies needed

### Why not alternatives?

| Approach | Why not |
|---|---|
| `export const dynamic = force-dynamic` | Too coarse — applies globally via root layout config. `connection()` is more semantically precise |
| `next-runtime-env` library | Redundant — codebase already has `RuntimeConfigProvider` doing the same thing |
| Docker entrypoint `sed` script | Fragile community hack — breaks source maps, requires placeholder convention |
| `unstable_noStore` | Deprecated in v15, replaced by `connection()` |

## Dual deployment compatibility

The `PUBLIC_* || NEXT_PUBLIC_*` fallback chain in `runtimeConfig` is preserved:
- **Vercel**: `NEXT_PUBLIC_*` vars are inlined at build time (works as before)
- **Docker**: `PUBLIC_*` vars (without prefix) are read at runtime via dynamic rendering

## Relationship to PR #2050

Supersedes #2050. PR #2050 had the right idea (`await connection()`) and would have worked. This PR additionally moves `runtimeConfig` inside the function body as a cleanliness improvement — keeping the env var reads co-located with the dynamic rendering signal — but the critical fix in both PRs is `connection()` itself.

## Build verification

All routes correctly show Dynamic after the change (only `icon.svg` remains static). Verified by inspecting compiled server-side JS that `process.env.PUBLIC_*` references remain as live Node.js references (not inlined). No new build, lint, or format errors introduced.

## Known pre-existing issues (out of scope)

3 client components have direct `process.env.NEXT_PUBLIC_*` references that bypass `RuntimeConfigProvider`. These are inlined at build time regardless of this fix:
- `src/app/page.tsx:20` — `NEXT_PUBLIC_TENANT_ID` (falls back to default — fine for Docker)
- `src/components/sidebar-nav/app-sidebar.tsx:64` — `NEXT_PUBLIC_ENABLE_WORK_APPS` (cloud-only feature flag, off by default)
- `src/features/work-apps/slack/api/slack-api.ts:1` — `NEXT_PUBLIC_INKEEP_AGENTS_API_URL` (gated behind work apps feature flag)

These are low/no impact for Docker deployments and should be tracked independently if needed.

## Test plan

- [x] Build succeeds (pnpm build with agents-core built first)
- [x] All routes show Dynamic in build output
- [x] Inspected compiled server-side JS — `process.env.PUBLIC_*` are live references, not inlined
- [x] Lint passes (biome lint --error-on-warnings)
- [x] Format passes (biome format)
- [x] Pre-commit hooks pass
- [x] **Standalone runtime env var test** — Built standalone output, started the same prebuilt server binary twice with different env vars:
  - With `PUBLIC_INKEEP_AGENTS_API_URL=http://docker-test-api:9999`, `PUBLIC_SIGNOZ_URL=http://docker-test-signoz:7777`, `PUBLIC_NANGO_SERVER_URL=http://docker-test-nango:5555`: response contains custom values, zero default values present
  - Without custom env vars: response contains defaults (`localhost:3002`, `localhost:3050`, `localhost:3080`), zero custom values present
  - Confirms the same prebuilt binary reads env vars at request time, not build time — exactly the Docker deployment requirement

Generated with [Claude Code](https://claude.com/claude-code)