### PR TITLE
fix: restore @types/react hoisting for pnpm 10

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -12,6 +12,10 @@ catalog:
   better-auth: ~1.4.10
   "@better-auth/sso": ~1.4.10
 
+publicHoistPattern:
+  - "@types/react"
+  - "@types/react-dom"
+
 ignorePatchFailures: false
 
 patchedDependencies:


### PR DESCRIPTION
## Summary

- Adds `publicHoistPattern` to `pnpm-workspace.yaml` to hoist `@types/react` and `@types/react-dom` to the monorepo root
- Fixes TypeScript resolution escape that causes dual-`@types/react` compilation errors in `agents-docs`

## Problem

pnpm 10 changed `publicHoistPattern` default from `['*types*', '*eslint*']` to `[]` ([pnpm v10 release notes](https://github.com/orgs/pnpm/discussions/8945)). This removed the `@types/react` symlink at the monorepo root that previously acted as a TypeScript resolution firewall.

`agents-docs` has cross-boundary imports from `agents-api/` (OpenAPI snapshot, model utilities). When TypeScript resolves `@types/react` from those external file locations, it walks up the directory tree:

```
agents-api/node_modules/          → no @types/react
agents/node_modules/@types/        → doesn't exist (pnpm 10 removed hoisting)
../node_modules/@types/react       → stale v18.2.47 if parent has one
```

This creates two incompatible React type instances (v18 + v19) in the same compilation = type errors.

## Fix

Add targeted `publicHoistPattern` in `pnpm-workspace.yaml` (the canonical pnpm 10 location for this setting):

```yaml
publicHoistPattern:
  - "@types/react"
  - "@types/react-dom"
```

The pattern is intentionally narrow (not `@types/*`) because hoisting `@types/bun` pollutes the global `fetch` type with Bun-specific `preconnect` extension, breaking `ai-sdk-provider` typecheck.

## After applying

Contributors need to run `pnpm install` after pulling this change to regenerate the hoisting symlinks. No lockfile changes.

## Test plan

- [x] `pnpm --filter agents-docs typecheck` passes
- [x] `pnpm typecheck` (full monorepo, 15/15 tasks) passes
- [x] `pnpm format:check` passes
- [x] Verified `node_modules/@types/react` exists at monorepo root after install
- [x] Verified `@types/bun` is NOT hoisted (prevents fetch type pollution)
- [x] No pnpm-lock.yaml changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)