### PR TITLE
fix: increase browser screenshot test timeouts from 20s to 30s

### DIFF
--- a/agents-manage-ui/src/components/agent/nodes/__tests__/nodes.browser.test.tsx
+++ b/agents-manage-ui/src/components/agent/nodes/__tests__/nodes.browser.test.tsx
@@ -79,5 +79,5 @@ describe('Nodes', () => {
     await act(async () => {
       await expect(container).toMatchScreenshot();
     });
-  }, 20_000);
+  }, 30_000);
 });

--- a/agents-manage-ui/src/components/form/__tests__/form.browser.test.tsx
+++ b/agents-manage-ui/src/components/form/__tests__/form.browser.test.tsx
@@ -106,7 +106,7 @@ describe('Form', () => {
     });
 
     await expect(container).toMatchScreenshot();
-  }, 20_000);
+  }, 30_000);
 
   test('should properly highlight nested error state', async () => {
     agentStore.setState({ jsonSchemaMode: true });
@@ -118,5 +118,5 @@ describe('Form', () => {
     });
 
     await expect(container).toMatchScreenshot();
-  }, 20_000);
+  }, 30_000);
 });


### PR DESCRIPTION
## Summary

- Bumps all three browser screenshot test timeouts from `20_000` to `30_000` ms (`form.browser.test.tsx` x2, `nodes.browser.test.tsx` x1)
- Fixes intermittent CI timeout on `should properly highlight nested error state` caused by tight headroom — the `toMatchScreenshot()` matcher alone reserves 15s of the 20s budget, leaving insufficient time for Playwright init + Monaco boot + form validation on slower CI runners
- The timeout is a ceiling, not a delay — passing tests finish at normal speed

## Test plan

- [ ] CI browser tests pass consistently (no more flaky timeout)
- [ ] Non-browser `agents-manage-ui` tests unaffected
- [ ] Lint/format/typecheck clean