### PR TITLE
fix: increase Monaco waitFor timeout for CI reliability

### DIFF
--- a/agents-manage-ui/src/components/form/__tests__/form.browser.test.tsx
+++ b/agents-manage-ui/src/components/form/__tests__/form.browser.test.tsx
@@ -119,9 +119,9 @@ describe('Form', () => {
         // Wait for form validation error message to render
         expect(container.querySelector('[data-slot="form-message"]')).toBeInTheDocument();
       },
-      { timeout: 20_000 }
+      { timeout: 30_000 }
     );
 
     await expect(container).toMatchScreenshot();
-  }, 45_000);
+  }, 60_000);
 });


### PR DESCRIPTION
## Summary
- Bump `waitFor` timeout from 20s to 30s for Monaco editor initialization in browser screenshot tests
- Bump test timeout from 45s to 60s to accommodate

## Context
PRs with Turbo cache misses on `ubuntu-16gb` runners cause parallel build/test jobs to compete for CPU/memory. Under this resource contention, Monaco editor's dynamic imports take longer than 20s to complete, causing `waitFor` to timeout before `.monaco-editor` appears in DOM.

This was observed consistently (3/3 attempts) on PRs #2054, #2037, and #2033 after merging main. The `ubuntu-latest` runner passed every time.

## Test plan
- [ ] CI passes on both `ubuntu-16gb` and `ubuntu-latest` runners
- [ ] Browser screenshot test still captures correct state

🤖 Generated with [Claude Code](https://claude.com/claude-code)