### PR TITLE
fix: add server-side auth to Slack install route

### DIFF
--- a/agents-api/src/createApp.ts
+++ b/agents-api/src/createApp.ts
@@ -429,7 +429,8 @@ function createAgentsHono(config: AppConfig) {
   // Mount GitHub routes - unauthenticated, OIDC token is the authentication
   app.route('/work-apps/github', githubRoutes);
 
-  // Work Apps auth - session/API key auth for protected routes (workspace management, user endpoints)
+  // Work Apps auth - session/API key auth for protected routes (workspace management, user endpoints, install)
+  app.use('/work-apps/slack/install', workAppsAuth);
   app.use('/work-apps/slack/workspaces/*', workAppsAuth);
   app.use('/work-apps/slack/users/*', workAppsAuth);
 

--- a/packages/agents-work-apps/src/__tests__/slack/install-auth.test.ts
+++ b/packages/agents-work-apps/src/__tests__/slack/install-auth.test.ts
@@ -1,0 +1,306 @@
+/**
+ * Tests for Slack install route server-side authorization.
+ *
+ * Verifies that GET /install requires:
+ * - Authentication (userId set in context)
+ * - Organization admin or owner role
+ * - tenant_id query param matches session tenant (when provided)
+ */
+
+import { OpenAPIHono } from '@hono/zod-openapi';
+import { OrgRoles } from '@inkeep/agents-core';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import oauthRouter from '../../slack/routes/oauth';
+import type { WorkAppsVariables } from '../../slack/types';
+
+vi.mock('@inkeep/agents-core', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@inkeep/agents-core')>();
+  return {
+    ...actual,
+    getUserOrganizationsFromDb: vi.fn(() => async () => []),
+    createWorkAppSlackWorkspace: vi.fn(() => async () => ({})),
+  };
+});
+
+vi.mock('../../env', () => ({
+  env: {
+    SLACK_CLIENT_ID: 'test-client-id',
+    SLACK_CLIENT_SECRET: 'test-client-secret',
+    SLACK_SIGNING_SECRET: 'test-signing-secret',
+    SLACK_APP_URL: 'https://test.example.com',
+    INKEEP_AGENTS_MANAGE_UI_URL: 'http://localhost:3000',
+    ENVIRONMENT: 'test',
+  },
+}));
+
+vi.mock('../../slack/services/nango', () => ({
+  getSlackNango: vi.fn(() => ({
+    listConnections: vi.fn(async () => ({ connections: [] })),
+    getConnection: vi.fn(async () => ({})),
+  })),
+  getSlackIntegrationId: vi.fn(() => 'slack'),
+  findWorkspaceConnectionByTeamId: vi.fn(async () => null),
+  listWorkspaceInstallations: vi.fn(async () => []),
+  storeWorkspaceInstallation: vi.fn(async () => ({ connectionId: 'test', success: true })),
+  deleteWorkspaceInstallation: vi.fn(async () => true),
+  getWorkspaceDefaultAgentFromNango: vi.fn(async () => null),
+  computeWorkspaceConnectionId: vi.fn(() => 'E:E123:T:T123'),
+  clearWorkspaceConnectionCache: vi.fn(),
+}));
+
+vi.mock('../../slack/services/client', () => ({
+  getSlackClient: vi.fn(),
+  getSlackTeamInfo: vi.fn(),
+  getSlackUserInfo: vi.fn(),
+  setBotTokenForTeam: vi.fn(),
+  getBotTokenForTeam: vi.fn(),
+  checkUserIsChannelMember: vi.fn(),
+}));
+
+vi.mock('../../db/runDbClient', () => ({
+  default: {},
+}));
+
+function createTestApp(contextOverrides: Record<string, unknown> = {}) {
+  const testApp = new OpenAPIHono<{ Variables: WorkAppsVariables }>();
+  testApp.use('*', async (c, next) => {
+    for (const [key, value] of Object.entries(contextOverrides)) {
+      c.set(key as never, value as never);
+    }
+    await next();
+  });
+  testApp.route('/', oauthRouter);
+  return testApp;
+}
+
+describe('Slack Install Route Authorization', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.ENVIRONMENT = 'test';
+  });
+
+  describe('when x-test-bypass-auth header is set', () => {
+    it('should bypass auth checks and redirect to Slack OAuth', async () => {
+      const app = createTestApp();
+      const response = await app.request('/install?tenant_id=tenant-1', {
+        method: 'GET',
+        headers: { 'x-test-bypass-auth': 'true' },
+      });
+
+      expect(response.status).toBe(302);
+      const location = response.headers.get('Location');
+      expect(location).toContain('slack.com/oauth/v2/authorize');
+    });
+  });
+
+  describe('when user is not authenticated', () => {
+    it('should return 401 when no userId in context', async () => {
+      const app = createTestApp();
+      const response = await app.request('/install?tenant_id=tenant-1', {
+        method: 'GET',
+      });
+
+      expect(response.status).toBe(401);
+    });
+  });
+
+  describe('when user has no organization context', () => {
+    it('should return 401 when userId set but no tenantId', async () => {
+      const app = createTestApp({ userId: 'user_123' });
+      const response = await app.request('/install?tenant_id=tenant-1', {
+        method: 'GET',
+      });
+
+      expect(response.status).toBe(401);
+    });
+  });
+
+  describe('when tenant_id query param does not match session tenant', () => {
+    it('should return 403 for tenant ID mismatch', async () => {
+      const app = createTestApp({
+        userId: 'user_123',
+        tenantId: 'my-tenant',
+      });
+      const response = await app.request('/install?tenant_id=other-tenant', {
+        method: 'GET',
+      });
+
+      expect(response.status).toBe(403);
+      const json = await response.json();
+      expect(json.detail).toContain('Tenant ID mismatch');
+    });
+  });
+
+  describe('when user is not an org admin', () => {
+    it('should return 403 when user has member role', async () => {
+      const { getUserOrganizationsFromDb } = await import('@inkeep/agents-core');
+      vi.mocked(getUserOrganizationsFromDb).mockReturnValue(() =>
+        Promise.resolve([
+          {
+            id: 'mem_1',
+            organizationId: 'tenant-1',
+            role: OrgRoles.MEMBER,
+            userId: 'user_123',
+            createdAt: new Date(),
+            organizationName: 'Test Org',
+            organizationSlug: 'test-org',
+          },
+        ])
+      );
+
+      const app = createTestApp({
+        userId: 'user_123',
+        tenantId: 'tenant-1',
+      });
+      const response = await app.request('/install?tenant_id=tenant-1', {
+        method: 'GET',
+      });
+
+      expect(response.status).toBe(403);
+      const json = await response.json();
+      expect(json.detail).toContain('Only organization administrators');
+    });
+
+    it('should return 403 when user has no org membership', async () => {
+      const { getUserOrganizationsFromDb } = await import('@inkeep/agents-core');
+      vi.mocked(getUserOrganizationsFromDb).mockReturnValue(() => Promise.resolve([]));
+
+      const app = createTestApp({
+        userId: 'user_123',
+        tenantId: 'tenant-1',
+      });
+      const response = await app.request('/install?tenant_id=tenant-1', {
+        method: 'GET',
+      });
+
+      expect(response.status).toBe(403);
+    });
+  });
+
+  describe('when user is an org admin', () => {
+    it('should redirect to Slack OAuth for admin role', async () => {
+      const { getUserOrganizationsFromDb } = await import('@inkeep/agents-core');
+      vi.mocked(getUserOrganizationsFromDb).mockReturnValue(() =>
+        Promise.resolve([
+          {
+            id: 'mem_2',
+            organizationId: 'tenant-1',
+            role: OrgRoles.ADMIN,
+            userId: 'user_123',
+            createdAt: new Date(),
+            organizationName: 'Test Org',
+            organizationSlug: 'test-org',
+          },
+        ])
+      );
+
+      const app = createTestApp({
+        userId: 'user_123',
+        tenantId: 'tenant-1',
+      });
+      const response = await app.request('/install?tenant_id=tenant-1', {
+        method: 'GET',
+      });
+
+      expect(response.status).toBe(302);
+      const location = response.headers.get('Location');
+      expect(location).toContain('slack.com/oauth/v2/authorize');
+      expect(location).toContain('client_id=test-client-id');
+    });
+
+    it('should redirect to Slack OAuth for owner role', async () => {
+      const { getUserOrganizationsFromDb } = await import('@inkeep/agents-core');
+      vi.mocked(getUserOrganizationsFromDb).mockReturnValue(() =>
+        Promise.resolve([
+          {
+            id: 'mem_3',
+            organizationId: 'tenant-1',
+            role: OrgRoles.OWNER,
+            userId: 'user_123',
+            createdAt: new Date(),
+            organizationName: 'Test Org',
+            organizationSlug: 'test-org',
+          },
+        ])
+      );
+
+      const app = createTestApp({
+        userId: 'user_123',
+        tenantId: 'tenant-1',
+      });
+      const response = await app.request('/install?tenant_id=tenant-1', {
+        method: 'GET',
+      });
+
+      expect(response.status).toBe(302);
+      const location = response.headers.get('Location');
+      expect(location).toContain('slack.com/oauth/v2/authorize');
+    });
+
+    it('should work without tenant_id query param when session has tenantId', async () => {
+      const { getUserOrganizationsFromDb } = await import('@inkeep/agents-core');
+      vi.mocked(getUserOrganizationsFromDb).mockReturnValue(() =>
+        Promise.resolve([
+          {
+            id: 'mem_4',
+            organizationId: 'tenant-1',
+            role: OrgRoles.OWNER,
+            userId: 'user_123',
+            createdAt: new Date(),
+            organizationName: 'Test Org',
+            organizationSlug: 'test-org',
+          },
+        ])
+      );
+
+      const app = createTestApp({
+        userId: 'user_123',
+        tenantId: 'tenant-1',
+      });
+      const response = await app.request('/install', {
+        method: 'GET',
+      });
+
+      expect(response.status).toBe(302);
+      const location = response.headers.get('Location');
+      expect(location).toContain('slack.com/oauth/v2/authorize');
+    });
+  });
+
+  describe('system and API key users', () => {
+    it('should allow system user to bypass admin check', async () => {
+      const app = createTestApp({
+        userId: 'system',
+        tenantId: 'tenant-1',
+      });
+      const response = await app.request('/install?tenant_id=tenant-1', {
+        method: 'GET',
+      });
+
+      expect(response.status).toBe(302);
+    });
+
+    it('should allow API key user to bypass admin check', async () => {
+      const app = createTestApp({
+        userId: 'apikey:key_123',
+        tenantId: 'tenant-1',
+      });
+      const response = await app.request('/install?tenant_id=tenant-1', {
+        method: 'GET',
+      });
+
+      expect(response.status).toBe(302);
+    });
+  });
+
+  describe('OAuth redirect (callback) remains accessible', () => {
+    it('should not require auth for oauth_redirect', async () => {
+      const app = createTestApp();
+      const response = await app.request('/oauth_redirect?error=access_denied&state=dummy', {
+        method: 'GET',
+      });
+
+      expect(response.status).toBe(302);
+    });
+  });
+});

--- a/packages/agents-work-apps/src/slack/middleware/permissions.ts
+++ b/packages/agents-work-apps/src/slack/middleware/permissions.ts
@@ -121,6 +121,79 @@ export const requireWorkspaceAdmin = <
   });
 
 /**
+ * Middleware that requires Inkeep org admin/owner role for Slack app installation.
+ * Unlike requireWorkspaceAdmin which resolves tenant from a workspace teamId,
+ * this middleware works with the tenantId already set by workAppsAuth (from session).
+ *
+ * It also validates that any tenant_id query parameter matches the session tenant
+ * to prevent IDOR attacks (e.g. installing into another org's tenant).
+ */
+export const requireOrgAdminForInstall = <
+  Env extends { Variables: ManageAppVariables } = { Variables: ManageAppVariables },
+>() =>
+  createMiddleware<Env>(async (c: Context, next: Next) => {
+    if (process.env.ENVIRONMENT === 'test' && c.req.header('x-test-bypass-auth') === 'true') {
+      await next();
+      return;
+    }
+
+    const userId = c.get('userId');
+
+    if (!userId) {
+      throw createApiError({
+        code: 'unauthorized',
+        message: 'Authentication required to install Slack app',
+        instance: c.req.path,
+      });
+    }
+
+    if (userId === 'system' || userId.startsWith('apikey:')) {
+      await next();
+      return;
+    }
+
+    const sessionTenantId = c.get('tenantId');
+    if (!sessionTenantId) {
+      throw createApiError({
+        code: 'unauthorized',
+        message: 'Organization context not found',
+        instance: c.req.path,
+      });
+    }
+
+    const queryTenantId = new URL(c.req.url).searchParams.get('tenant_id');
+    if (queryTenantId && queryTenantId !== sessionTenantId) {
+      throw createApiError({
+        code: 'forbidden',
+        message: 'Tenant ID mismatch — you can only install apps for your active organization',
+        instance: c.req.path,
+      });
+    }
+
+    const userOrganizations = await getUserOrganizationsFromDb(runDbClient)(userId);
+    const orgAccess = userOrganizations.find((org) => org.organizationId === sessionTenantId);
+
+    if (!orgAccess || !isOrgAdmin(orgAccess.role)) {
+      logger.warn(
+        { userId, tenantId: sessionTenantId, tenantRole: orgAccess?.role, path: c.req.path },
+        'User does not have admin role for Slack app installation'
+      );
+      throw createApiError({
+        code: 'forbidden',
+        message: 'Only organization administrators can install the Slack app',
+        instance: c.req.path,
+        extensions: {
+          requiredRole: 'admin or owner',
+          currentRole: orgAccess?.role,
+        },
+      });
+    }
+
+    c.set('tenantRole', orgAccess.role);
+    await next();
+  });
+
+/**
  * Middleware that requires either:
  * 1. Org admin/owner role (can modify any channel), OR
  * 2. Member role AND membership in the specific Slack channel


### PR DESCRIPTION
## Summary

- **Security fix**: The `GET /work-apps/slack/install` endpoint previously had no server-side authorization. Enforcement was only at the UI level (the "Add Workspace" button is hidden for non-admins). Anyone who discovered the URL could initiate a Slack OAuth flow and link a workspace to any tenant by passing a `tenant_id` query parameter.
- Adds `workAppsAuth` middleware to the install route, ensuring session or API key authentication is required
- Adds a new `requireOrgAdminForInstall` middleware that verifies the authenticated user holds an `admin` or `owner` role in the target organization
- Validates that the `tenant_id` query parameter (if provided) matches the session's active tenant to prevent IDOR attacks
- Uses the session `tenantId` as the authoritative source for the OAuth state, falling back to the query param only when session tenant is unavailable
- The `/oauth_redirect` callback remains unauthenticated (standard OAuth pattern — it is transitively protected by the HMAC-signed state generated only through the now-authenticated install route)

## Files changed

| File | Change |
|---|---|
| `agents-api/src/createApp.ts` | Apply `workAppsAuth` to `/work-apps/slack/install` |
| `packages/agents-work-apps/src/slack/middleware/permissions.ts` | Add `requireOrgAdminForInstall` middleware |
| `packages/agents-work-apps/src/slack/routes/oauth.ts` | Apply middleware + prefer session tenantId |
| `packages/agents-work-apps/src/__tests__/slack/install-auth.test.ts` | 12 new tests |

## Test plan

- [x] 12 unit tests covering all authorization scenarios:
  - Test bypass header works in test env
  - Unauthenticated requests return 401
  - Missing org context returns 401
  - Tenant ID mismatch returns 403
  - Non-admin (member) role returns 403
  - No org membership returns 403
  - Admin role redirects to Slack OAuth (302)
  - Owner role redirects to Slack OAuth (302)
  - Works without tenant_id query param
  - System user bypasses admin check
  - API key user bypasses admin check
  - OAuth redirect callback remains accessible without auth
- [x] All 150 existing Slack tests pass
- [x] All 298 agents-work-apps tests pass
- [x] Typecheck clean on both agents-api and agents-work-apps
- [x] Lint passes across all packages


Made with [Cursor](https://cursor.com)