### PR TITLE
chore: improve CI performance by splitting build and test phases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,13 +105,18 @@ jobs:
           echo "Cleaning up any existing database files..."
           find . -name "*.db" -o -name "*.sqlite" | grep -v node_modules | xargs -r rm -f
 
-      # Run all CI checks in parallel with Turborepo
+      # Build all packages first so heavy compilation doesn't compete with
+      # browser tests (Playwright + Monaco) for CPU on cache-miss runs.
+      - name: Build packages
+        run: pnpm turbo run build --filter='!agents-cookbook-templates'
+        env:
+          NODE_OPTIONS: --max-old-space-size=4096
+          CI: true
+
+      # Run lint, typecheck, and test with builds already cached.
       - name: Run CI checks
         id: ci-check
-        run: |
-          # Run all checks in parallel using Turborepo's dependency graph
-          # This will build once and cache, then run lint, typecheck, and test in parallel
-          pnpm check
+        run: pnpm check
         env:
           ENVIRONMENT: test
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY || 'sk-test-key-for-ci-testing' }}


### PR DESCRIPTION
## Summary
- Split the single `pnpm check` CI step into two phases: build first, then run quality checks
- Prevents Playwright browser tests (Monaco editor) from competing with heavy builds for CPU on cache-miss runs

## Problem
On PR branches with Turbo cache misses (11-13 out of 44 tasks), the `pnpm check` step runs all builds, lint, typecheck, and tests in parallel with concurrency 15. Heavy builds (Next.js, agents-api, agents-docs) starve Playwright/Monaco of CPU, causing the Monaco editor to stay in skeleton loading state and the screenshot test (`should properly highlight nested error state`) to time out.

This only affects PR branches — main has warm Turbo cache (0 misses) so builds are instant.

## Solution
1. **New "Build packages" step** — runs `pnpm turbo run build` first, completing ALL compilation before tests start
2. **Existing "Run CI checks" step** — runs `pnpm check` (lint + typecheck + test) with builds already cached

When `pnpm check` runs in phase 2, Turbo sees all build outputs are cached → skips builds → only runs lint, typecheck, and test. The browser test gets full CPU instead of competing with Next.js compilation.

## Test plan
- [ ] CI pipeline passes on this PR (especially the Monaco screenshot test on `ubuntu-16gb`)
- [ ] No increase in total CI time (builds still run in parallel, just as a separate step)
- [ ] Verify the 3 previously-failing PRs (#2054, #2037, #2033) pass after merging this fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)