### PR TITLE
fix(ci): limit Turbo concurrency to prevent browser test CPU starvation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,8 +110,9 @@ jobs:
         id: ci-check
         run: |
           # Run all checks in parallel using Turborepo's dependency graph
-          # This will build once and cache, then run lint, typecheck, and test in parallel
-          pnpm check
+          # Limit concurrency to 8 (runner has 4 vCPUs) to prevent CPU starvation
+          # during cache-miss runs, which causes Playwright browser tests to time out
+          pnpm check -- --concurrency=8
         env:
           ENVIRONMENT: test
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY || 'sk-test-key-for-ci-testing' }}


### PR DESCRIPTION
## Summary

- Limits Turbo concurrency from 15 → 8 in CI via `--concurrency` CLI flag
- The `ubuntu-16gb` runner has 4 vCPUs; 15 concurrent tasks causes CPU starvation during cache-miss runs, which makes Playwright browser tests (Monaco editor initialization) time out
- Uses CI-only CLI override — `turbo.json` stays at 15 for local dev on beefier machines
- Replaces the build/check split approach from #2092 (reverted in #2093) with a cleaner, first-class Turbo mechanism

## Why `--concurrency=8`?

| Factor | Value |
|---|---|
| Runner vCPUs | 4 |
| Concurrency | 8 (2x vCPUs) |
| Rationale | Standard oversubscription for mixed I/O + CPU workloads. Cache hits complete instantly and free slots. |

## What was ruled out

- **Per-task concurrency** — doesn't exist in Turborepo
- **Cross-package `dependsOn` overrides** — artificial coupling, maintenance burden
- **Vitest `fileParallelism: false`** — unnecessary if Turbo concurrency is properly constrained
- **CI step splitting** (#2092) — works but bypasses Turbo's scheduler

## Test plan

- [ ] CI passes on this PR (validates the fix works on cache-miss run)
- [ ] Re-run CI on PRs #2054, #2037, #2033 after merge to confirm they pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)