### PR TITLE
chore: add specs to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -99,6 +99,7 @@ node-compile-cache/
 
 tmp
 .claude/specs
+specs
 tasks
 prd.json
 progress.txt


### PR DESCRIPTION
Adds `specs` to .gitignore (complements existing `.claude/specs`).

Made with [Cursor](https://cursor.com)