### PR TITLE
feat: add revoke invitation action for pending invitations

### DIFF
--- a/agents-manage-ui/src/components/settings/members-table.tsx
+++ b/agents-manage-ui/src/components/settings/members-table.tsx
@@ -449,7 +449,7 @@ export function MembersTable({
                             )}
                             <DropdownMenuItem
                               onClick={() => setRevokingInvitation(invitation)}
-                              className="text-destructive focus:text-destructive"
+                              variant="destructive"
                             >
                               <XCircle className="h-4 w-4" />
                               Revoke invite
@@ -502,7 +502,7 @@ export function MembersTable({
             <AlertDialogTitle>Revoke invitation?</AlertDialogTitle>
             <AlertDialogDescription>
               This will revoke the pending invitation to {revokingInvitation?.email}. They will no
-              longer be able to accept it.
+              longer be able to accept it. You can send a new invitation if needed.
             </AlertDialogDescription>
           </AlertDialogHeader>
           <AlertDialogFooter>


### PR DESCRIPTION
## Summary

- Adds a "Revoke invite" action in the members table dropdown for all pending invitations (email-password, Google, SSO)
- Shows a confirmation dialog before revoking (destructive action)
- Uses Better Auth's built-in `cancelInvitation` API — no new API routes or schema changes needed

## Changes

**`agents-manage-ui/src/components/settings/members-table.tsx`**
- All pending invitations now show a unified dropdown menu with:
  - "Copy invite link" (email-password) or "Sign in via Google/SSO" info (non-email-password)
  - "Revoke invite" action (all auth methods)
- Added confirmation `AlertDialog` before revoking
- Added `handleRevokeInvitation` function that calls `authClient.organization.cancelInvitation`
- Toast notifications for success/error
- List refreshes after successful revocation via `onMemberUpdated` callback
- Removed unused Tooltip imports (previously used for SSO info, now replaced with dropdown item)

## Test plan

_Manual QA scenarios verified via browser automation._

- [x] **Dropdown: email-password invitation** — "Revoke invite" appears alongside "Copy invite link" in actions dropdown
- [x] **Confirmation dialog** — Shows "Revoke invitation?" with invitee email, Cancel + destructive Revoke buttons
- [x] **Cancel dismisses dialog** — Clicking Cancel closes dialog, invitation remains in list
- [x] **Revoke removes invitation** — Clicking Revoke calls cancelInvitation, invitation disappears from list
- [x] **No console errors** — No JS errors during the full revoke flow
- [ ] **Dropdown: Google/SSO invitation** — Skipped: no Google/SSO invitations in local dev data. Code path verified by inspection (conditional renders info item + revoke item).
- [ ] **Non-admin gate** — Skipped: only admin user in local dev. Code path verified by inspection (`isOrgAdmin` gate unchanged from existing pattern).
- [ ] **Error toast on failure** — Skipped: would require network failure simulation. Code path verified by inspection (catch block shows error toast).

🤖 Generated with [Claude Code](https://claude.com/claude-code)