### PR TITLE
Fix Vercel build timeout by running typecheck before compilation

### DIFF
--- a/agents-manage-ui/next.config.ts
+++ b/agents-manage-ui/next.config.ts
@@ -16,6 +16,12 @@ if (process.env.NODE_ENV !== 'production') {
 const isSentryEnabled = Boolean(process.env.NEXT_PUBLIC_SENTRY_DSN);
 
 const nextConfig: NextConfig = {
+  typescript: {
+    // Typecheck runs explicitly before `next build` in the build script
+    // (via `pnpm typecheck`), so skip the redundant built-in check that
+    // runs *after* compilation and causes Vercel builds to timeout/OOM.
+    ignoreBuildErrors: true,
+  },
   experimental: {
     turbopackFileSystemCacheForBuild: true,
   },

--- a/agents-manage-ui/package.json
+++ b/agents-manage-ui/package.json
@@ -35,7 +35,7 @@
     "knip": "knip --directory .. --workspace agents-manage-ui --config agents-manage-ui/knip.config.ts --files --dependencies --fix-type exports --fix-type types --include exports,types",
     "dev": "next --port 3000",
     "build:sync": "cp -r public .next/standalone/agents-manage-ui && mkdir -p .next/standalone/agents-manage-ui/.next/ && cp -r .next/static .next/standalone/agents-manage-ui/.next/static",
-    "build": "next build && pnpm build:sync",
+    "build": "pnpm typecheck && next build && pnpm build:sync",
     "prepublishOnly": "node --experimental-strip-types scripts/append-hash-for-server-only-packages.mts",
     "start": "node .next/standalone/agents-manage-ui/server.js",
     "lint": "biome lint --error-on-warnings",


### PR DESCRIPTION
## Summary
- Vercel build for `agents-manage-ui` was timing out on the 4-core/8GB build machine because Next.js runs TypeScript checking *after* the ~104s Turbopack compilation, causing OOM/timeout pressure
- Moved typecheck to run **before** `next build` in the build script (`pnpm typecheck && next build && pnpm build:sync`) so it fails fast and runs with a clean memory baseline
- Added `typescript.ignoreBuildErrors: true` in `next.config.ts` to skip the now-redundant built-in typecheck that Next.js runs post-compilation

Typecheck still runs and still blocks the build on errors — it just runs earlier and doesn't happen twice.

## Test plan
- [x] Verify Vercel preview deployment builds successfully without timeout
- [ ] Introduce a deliberate type error locally and confirm `pnpm build` in `agents-manage-ui` fails at the typecheck step (before compilation starts)
- [x] Confirm CI still passes (typecheck runs independently via `pnpm check` → `turbo typecheck`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)