### PR TITLE
Fix incomplete scope filtering in 9 data-access layer queries

### DIFF
--- a/.changeset/cautious-tan-anaconda.md
+++ b/.changeset/cautious-tan-anaconda.md
@@ -1,0 +1,5 @@
+---
+"@inkeep/agents-core": patch
+---
+
+Fix incomplete scope filtering in 9 data-access queries that could leak data across project/agent boundaries

--- a/packages/agents-core/src/data-access/manage/agents.ts
+++ b/packages/agents-core/src/data-access/manage/agents.ts
@@ -254,7 +254,7 @@ export const deleteAgent =
 export const fetchComponentRelationships =
   (db: AgentsManageDatabaseClient) =>
   async <T extends Record<string, unknown>>(
-    scopes: ProjectScopeConfig,
+    scopes: AgentScopeConfig,
     subAgentIds: string[],
     config: {
       relationTable: PgTable<any>;
@@ -279,6 +279,7 @@ export const fetchComponentRelationships =
           and(
             eq((config.relationTable as any).tenantId, scopes.tenantId),
             eq((config.relationTable as any).projectId, scopes.projectId),
+            eq((config.relationTable as any).agentId, scopes.agentId),
             inArray(config.subAgentIdField as any, subAgentIds)
           )
         );
@@ -689,7 +690,7 @@ const getFullAgentDefinitionInternal =
     }
 
     try {
-      await fetchComponentRelationships(db)({ tenantId, projectId }, subAgentIds, {
+      await fetchComponentRelationships(db)({ tenantId, projectId, agentId }, subAgentIds, {
         relationTable: subAgentDataComponents,
         componentTable: dataComponents,
         relationIdField: subAgentDataComponents.dataComponentId,
@@ -707,7 +708,7 @@ const getFullAgentDefinitionInternal =
     }
 
     try {
-      await fetchComponentRelationships(db)({ tenantId, projectId }, subAgentIds, {
+      await fetchComponentRelationships(db)({ tenantId, projectId, agentId }, subAgentIds, {
         relationTable: subAgentArtifactComponents,
         componentTable: artifactComponents,
         relationIdField: subAgentArtifactComponents.artifactComponentId,
@@ -812,6 +813,7 @@ const getFullAgentDefinitionInternal =
                         and(
                           eq(subAgents.tenantId, tenantId),
                           eq(subAgents.projectId, projectId),
+                          eq(subAgents.agentId, agentId),
                           eq(subAgents.id, subAgentId)
                         )
                       );

--- a/packages/agents-core/src/data-access/manage/artifactComponents.ts
+++ b/packages/agents-core/src/data-access/manage/artifactComponents.ts
@@ -222,7 +222,11 @@ export const getArtifactComponentsForAgent =
       .from(artifactComponents)
       .innerJoin(
         subAgentArtifactComponents,
-        eq(artifactComponents.id, subAgentArtifactComponents.artifactComponentId)
+        and(
+          eq(artifactComponents.id, subAgentArtifactComponents.artifactComponentId),
+          eq(artifactComponents.tenantId, subAgentArtifactComponents.tenantId),
+          eq(artifactComponents.projectId, subAgentArtifactComponents.projectId)
+        )
       )
       .where(
         and(
@@ -285,6 +289,7 @@ export const deleteAgentArtifactComponentRelationByAgent =
       .where(
         and(
           eq(subAgentArtifactComponents.tenantId, params.scopes.tenantId),
+          eq(subAgentArtifactComponents.projectId, params.scopes.projectId),
           eq(subAgentArtifactComponents.agentId, params.scopes.agentId),
           eq(subAgentArtifactComponents.subAgentId, params.scopes.subAgentId)
         )
@@ -343,7 +348,9 @@ export const agentHasArtifactComponents =
         subAgents,
         and(
           eq(subAgentArtifactComponents.subAgentId, subAgents.id),
-          eq(subAgentArtifactComponents.tenantId, subAgents.tenantId)
+          eq(subAgentArtifactComponents.tenantId, subAgents.tenantId),
+          eq(subAgentArtifactComponents.projectId, subAgents.projectId),
+          eq(subAgentArtifactComponents.agentId, subAgents.agentId)
         )
       )
       .innerJoin(

--- a/packages/agents-core/src/data-access/manage/dataComponents.ts
+++ b/packages/agents-core/src/data-access/manage/dataComponents.ts
@@ -254,7 +254,11 @@ export const getDataComponentsForAgent =
       .from(dataComponents)
       .innerJoin(
         subAgentDataComponents,
-        eq(dataComponents.id, subAgentDataComponents.dataComponentId)
+        and(
+          eq(dataComponents.id, subAgentDataComponents.dataComponentId),
+          eq(dataComponents.tenantId, subAgentDataComponents.tenantId),
+          eq(dataComponents.projectId, subAgentDataComponents.projectId)
+        )
       )
       .where(
         and(
@@ -317,6 +321,7 @@ export const deleteAgentDataComponentRelationByAgent =
       .where(
         and(
           eq(subAgentDataComponents.tenantId, params.scopes.tenantId),
+          eq(subAgentDataComponents.projectId, params.scopes.projectId),
           eq(subAgentDataComponents.agentId, params.scopes.agentId),
           eq(subAgentDataComponents.subAgentId, params.scopes.subAgentId)
         )

--- a/packages/agents-core/src/data-access/manage/subAgentRelations.ts
+++ b/packages/agents-core/src/data-access/manage/subAgentRelations.ts
@@ -321,6 +321,7 @@ export const deleteAgentRelationsByAgent =
       .where(
         and(
           eq(subAgentRelations.tenantId, params.scopes.tenantId),
+          eq(subAgentRelations.projectId, params.scopes.projectId),
           eq(subAgentRelations.agentId, params.scopes.agentId)
         )
       )
@@ -451,6 +452,7 @@ export const getAgentToolRelationByAgent =
           and(
             eq(subAgentToolRelations.tenantId, params.scopes.tenantId),
             eq(subAgentToolRelations.projectId, params.scopes.projectId),
+            eq(subAgentToolRelations.agentId, params.scopes.agentId),
             eq(subAgentToolRelations.subAgentId, params.scopes.subAgentId)
           )
         )
@@ -464,6 +466,7 @@ export const getAgentToolRelationByAgent =
           and(
             eq(subAgentToolRelations.tenantId, params.scopes.tenantId),
             eq(subAgentToolRelations.projectId, params.scopes.projectId),
+            eq(subAgentToolRelations.agentId, params.scopes.agentId),
             eq(subAgentToolRelations.subAgentId, params.scopes.subAgentId)
           )
         ),


### PR DESCRIPTION
## Summary

- Audit of the manage data-access layer found **9 additional queries** (beyond the 2 fixed in #2139) on junction/scoped tables that did not filter on all composite key columns
- Missing scope columns in WHERE clauses and JOIN conditions could cause cross-project or cross-agent data leakage when child entity IDs overlap across scope boundaries
- **3 HIGH-severity DELETE** operations could affect rows in the wrong project
- **1 HIGH-severity SELECT** returned tool relations across agent boundaries
- **5 MEDIUM** fixes for UPDATE, helper function type, and JOIN conditions

### Bugs fixed

| # | File | Function | Op | Missing |
|---|------|----------|----|---------|
| 1 | `subAgentRelations.ts` | `deleteAgentRelationsByAgent` | DELETE | `projectId` |
| 2 | `subAgentRelations.ts` | `getAgentToolRelationByAgent` | SELECT ×2 | `agentId` |
| 3 | `dataComponents.ts` | `deleteAgentDataComponentRelationByAgent` | DELETE | `projectId` |
| 4 | `artifactComponents.ts` | `deleteAgentArtifactComponentRelationByAgent` | DELETE | `projectId` |
| 5 | `agents.ts` | stopWhen inheritance | UPDATE | `agentId` |
| 6 | `agents.ts` | `fetchComponentRelationships` | SELECT | `agentId` (+ wrong scope type) |
| 7 | `dataComponents.ts` | `getDataComponentsForAgent` | JOIN | `tenantId`, `projectId` |
| 8 | `artifactComponents.ts` | `getArtifactComponentsForAgent` | JOIN | `tenantId`, `projectId` |
| 9 | `artifactComponents.ts` | `agentHasArtifactComponents` | JOIN | `projectId`, `agentId` |

## Test plan

- [x] Typecheck passes (`pnpm typecheck`)
- [x] Existing scoping isolation test passes (`agentFull.components-scoping.test.ts`)
- [ ] Verify no regressions in manage UI agent CRUD operations
- [ ] Verify agent definition loading still works correctly end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)