### PR TITLE
ci: standardize actions/checkout to v6, add NODE_OPTIONS to Cypress

### DIFF
--- a/.github/workflows/auto-format.yml
+++ b/.github/workflows/auto-format.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Checkout code
         if: steps.pr-check.outputs.skip != 'true'
         id: checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         continue-on-error: true
         with:
           # On PRs, check out the PR branch so we push back to it.

--- a/.github/workflows/ci-maintenance.yml
+++ b/.github/workflows/ci-maintenance.yml
@@ -34,7 +34,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -183,7 +183,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Setup Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -93,7 +93,7 @@ jobs:
           fi
 
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0  # Full history for merge-base
           ref: refs/pull/${{ steps.pr.outputs.number }}/head

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -26,7 +26,7 @@ jobs:
       actions: read # Required for Claude to read CI results on PRs
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 1
 

--- a/.github/workflows/closed-pr-review-auto-improver.yml
+++ b/.github/workflows/closed-pr-review-auto-improver.yml
@@ -27,7 +27,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           ref: main
           fetch-depth: 0

--- a/.github/workflows/coverage.yml.disabled
+++ b/.github/workflows/coverage.yml.disabled
@@ -16,7 +16,7 @@ jobs:
     
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install pnpm
         uses: pnpm/action-setup@v4

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -50,7 +50,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -121,6 +121,7 @@ jobs:
       - name: Run Cypress E2E Tests
         uses: ./.github/composite-actions/cypress-e2e
         env:
+          NODE_OPTIONS: --max-old-space-size=8192
           TURBO_TELEMETRY_DISABLED: 1
           TURBO_CACHE_DIR: .turbo
           TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}

--- a/.github/workflows/inkeep-sync.yml
+++ b/.github/workflows/inkeep-sync.yml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
       - name: Check for changes
         uses: dorny/paths-filter@v2
         id: changes

--- a/.github/workflows/publish-skills.yml
+++ b/.github/workflows/publish-skills.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout agents repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 

--- a/.github/workflows/speakeasy-sdk.yml
+++ b/.github/workflows/speakeasy-sdk.yml
@@ -10,7 +10,7 @@ jobs:
     name: Generate agents-mcp SDK
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Generate SDK
         uses: speakeasy-api/sdk-generation-action@v15

--- a/.github/workflows/vercel-production.yml
+++ b/.github/workflows/vercel-production.yml
@@ -32,7 +32,7 @@ jobs:
             project_id_secret: VERCEL_MANAGE_UI_PROJECT_ID
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.event.release.tag_name || 'main' }}
 


### PR DESCRIPTION
## Summary

Standardize all GitHub Actions workflows on `actions/checkout@v6` (from a mix of v3/v4/v5) and add `NODE_OPTIONS` to the Cypress workflow so turbo builds in the composite action benefit from the larger heap.

## Motivation

Workflow audit found 3 different versions of `actions/checkout` across 13 workflow files (1 on v3, 5 on v4, 7 on v5). This inconsistency is confusing and means some workflows miss security improvements. Additionally, the Cypress workflow was missing `NODE_OPTIONS=--max-old-space-size=8192`, meaning turbo builds inside the composite action ran with the default 2GB heap — potentially causing GC thrashing on larger builds.

## Approach

Mechanical find-and-replace across all workflow files. No behavioral changes expected.

## Architectural decisions

**Why v6 instead of v5:** v6 is the [current latest](https://github.com/actions/checkout/releases) (v6.0.2, Jan 2026). The README defaults all examples to `@v6`. v5 was a stepping stone (Aug→Nov 2025) superseded within 3 months. Going directly to v6 avoids another bump later. Per the [changelog](https://github.com/actions/checkout/blob/main/CHANGELOG.md):
- v4→v5: Node 20→24 runtime only
- v5→v6: Credential storage moved from `.git/config` to `$RUNNER_TEMP` file

Both changes are transparent to workflows. No inputs/outputs changed. All workflows run on GitHub-hosted runners, meeting the runner version requirements.

## Changes

### `actions/checkout` bump (13 files)
- `inkeep-sync.yml`: v3 → v6
- `release.yml`, `publish-skills.yml`, `speakeasy-sdk.yml`, `vercel-production.yml`, `claude.yml`, `coverage.yml.disabled`: v4 → v6
- `ci.yml` (2 occurrences), `cypress.yml`, `auto-format.yml`, `ci-maintenance.yml`, `closed-pr-review-auto-improver.yml`, `claude-code-review.yml`: v5 → v6

### `cypress.yml`
- Add `NODE_OPTIONS: --max-old-space-size=8192` to the step env that calls the cypress-e2e composite action

## Test plan

- [ ] All CI checks pass (the checkout bump is zero-behavioral-change)
- [ ] Cypress E2E tests pass with the new NODE_OPTIONS

Generated with [Claude Code](https://claude.com/claude-code)