### PR TITLE
fix(ci): use turbo directly for API server in Cypress E2E

### DIFF
--- a/.github/composite-actions/cypress-e2e/action.yml
+++ b/.github/composite-actions/cypress-e2e/action.yml
@@ -66,7 +66,7 @@ runs:
         ENVIRONMENT: development
         INKEEP_AGENTS_MANAGE_API_BYPASS_SECRET: ${{ env.INKEEP_AGENTS_MANAGE_API_BYPASS_SECRET }}
         BETTER_AUTH_SECRET: ${{ env.BETTER_AUTH_SECRET }}
-      run: pnpm dev --filter='@inkeep/agents-api' & # & means run job in background
+      run: pnpm exec turbo dev --filter='@inkeep/agents-api' &
 
     - name: Wait for API server to be ready
       shell: bash


### PR DESCRIPTION
## Summary

Fixes the Cypress E2E `EADDRINUSE` failure on main caused by #2162.

**Root cause:** The Cypress composite action started the API server with:
```yaml
run: pnpm dev --filter='@inkeep/agents-api' &
```

When `--filter` appears after the script name, pnpm forwards it as extra arguments to the underlying command (the root `dev` script) rather than interpreting it as a workspace filter. After #2162 switched to inclusive turbo filters, the effective command became:

```
turbo dev --filter=@inkeep/agents-api --filter=@inkeep/agents-manage-ui --filter=@inkeep/agents-docs --filter=@inkeep/agents-core --filter=@inkeep/agents-sdk --filter='@inkeep/agents-api'
```

All positive filters = union → all 5 packages started, including `agents-manage-ui` on port 3000. When Cypress later tried to start the standalone server on the same port: `EADDRINUSE`.

**Why it worked before:** The old exclusion-based filters (`--filter='!create-agents' --filter='!work-apps'`) intersected with the single positive filter, yielding only `agents-api`.

**Fix:** Call turbo directly (`pnpm exec turbo dev --filter=...`), matching the pattern already used by all other turbo invocations in this file.

## Test plan

- [ ] Cypress E2E workflow passes on this PR (the CI run itself is the test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)