### PR TITLE
fix: Clean up Slack bot message tone

### DIFF
--- a/packages/agents-work-apps/src/__tests__/slack/blocks.test.ts
+++ b/packages/agents-work-apps/src/__tests__/slack/blocks.test.ts
@@ -57,10 +57,11 @@ describe('Slack Block Builders', () => {
       expect(JSON.stringify(result)).toContain(errorText);
     });
 
-    it('should include error emoji', () => {
+    it('should include the error text directly without emoji prefix', () => {
       const result = createErrorMessage('Error occurred');
 
-      expect(JSON.stringify(result)).toContain('❌');
+      expect(JSON.stringify(result)).toContain('Error occurred');
+      expect(JSON.stringify(result)).not.toContain('❌');
     });
   });
 
@@ -86,7 +87,7 @@ describe('Slack Block Builders', () => {
       const result = createAlreadyLinkedMessage(email, linkedAt, dashboardUrl);
 
       expect(result.blocks).toBeDefined();
-      expect(JSON.stringify(result)).toContain('Already Linked');
+      expect(JSON.stringify(result)).toContain('Already linked');
       expect(JSON.stringify(result)).toContain(email);
       expect(JSON.stringify(result)).toContain('/inkeep unlink');
     });
@@ -97,7 +98,7 @@ describe('Slack Block Builders', () => {
       const result = createUnlinkSuccessMessage();
 
       expect(result.blocks).toBeDefined();
-      expect(JSON.stringify(result)).toContain('Account Unlinked');
+      expect(JSON.stringify(result)).toContain('Account unlinked');
       expect(JSON.stringify(result)).toContain('/inkeep link');
     });
   });
@@ -107,7 +108,7 @@ describe('Slack Block Builders', () => {
       const result = createNotLinkedMessage();
 
       expect(result.blocks).toBeDefined();
-      expect(JSON.stringify(result)).toContain('Not Linked');
+      expect(JSON.stringify(result)).toContain('Not linked');
       expect(JSON.stringify(result)).toContain('/inkeep link');
     });
   });

--- a/packages/agents-work-apps/src/slack/i18n/strings.ts
+++ b/packages/agents-work-apps/src/slack/i18n/strings.ts
@@ -12,7 +12,7 @@ export const SlackStrings = {
     send: 'Send',
     followUp: 'Follow Up',
     cancel: 'Cancel',
-    openDashboard: '⚙️ Open Dashboard',
+    openDashboard: 'Open Dashboard',
   },
 
   // Modal titles
@@ -55,44 +55,44 @@ export const SlackStrings = {
   // Usage hints
   usage: {
     mentionEmpty:
-      '*To use your Inkeep agent, include a message:*\n\n' +
-      '• `@Inkeep <message>` — Send a message to the default agent for the channel (reply appears in a thread)\n' +
-      '• `@Inkeep <message>` in a thread — Includes the thread as context for your agent\n' +
-      '• `@Inkeep` in a thread — Triggers your agent using the full thread as context\n\n' +
-      '💡 Use `/inkeep help` for all available commands.',
+      '*Include a message to use your Inkeep agent:*\n\n' +
+      '• `@Inkeep <message>` — Message the default agent (reply appears in a thread)\n' +
+      '• `@Inkeep <message>` in a thread — Includes thread as context\n' +
+      '• `@Inkeep` in a thread — Uses the full thread as context\n\n' +
+      'Use `/inkeep help` for all available commands.',
   },
 
   // Status messages
   status: {
     thinking: (agentName: string) => `_${agentName} is thinking..._`,
     noAgentsAvailable: 'No agents available',
-    noProjectsConfigured: '⚙️ No projects configured. Please set up projects in the dashboard.',
+    noProjectsConfigured: 'No projects configured. Set up projects in the dashboard.',
   },
 
   // Error messages
   errors: {
-    generic: 'Sorry, something went wrong. Please try again.',
-    failedToOpenSelector: '❌ Failed to open agent selector. Please try again.',
+    generic: 'Something went wrong. Please try again.',
+    failedToOpenSelector: 'Failed to open agent selector. Please try again.',
   },
 
   // Help message
   help: {
     title: 'Inkeep — How to Use',
     publicSection:
-      '🔊 *Public* — everyone in the channel can see the response\n\n' +
-      '• `@Inkeep <message>` — message the default agent in this channel\n' +
+      '*Public* — visible to everyone in the channel\n\n' +
+      '• `@Inkeep <message>` — Message the default agent in this channel\n' +
       '• `@Inkeep <message>` in a thread — Includes thread as context\n' +
       '• `@Inkeep` in a thread — Uses the full thread as context',
     privateSection:
-      '🔒 *Private* — only you can see the response\n\n' +
-      '• `/inkeep <message>` — message the default agent in this channel\n' +
+      '*Private* — only visible to you\n\n' +
+      '• `/inkeep <message>` — Message the default agent in this channel\n' +
       '• `/inkeep` — Open the agent picker to choose an agent and write a prompt',
     otherCommands:
-      '⚙️ *Other Commands*\n\n' +
+      '*Other Commands*\n\n' +
       '• `/inkeep status` — Check your connection and agent config\n' +
       '• `/inkeep link` / `/inkeep unlink` — Manage account connection\n' +
       '• `/inkeep help` — Show this message',
-    docsLink: '📖 <https://docs.inkeep.com/talk-to-your-agents/slack/overview|Learn more>',
+    docsLink: '<https://docs.inkeep.com/talk-to-your-agents/slack/overview|Learn more>',
   },
 
   // Message context (for message shortcut modal)

--- a/packages/agents-work-apps/src/slack/routes/workspaces.ts
+++ b/packages/agents-work-apps/src/slack/routes/workspaces.ts
@@ -1154,7 +1154,7 @@ app.openapi(
       const slackClient = getSlackClient(workspace.botToken);
 
       const testMessage =
-        message || '✅ *Test message from Inkeep*\n\nYour Slack integration is working correctly!';
+        message || '*Test message from Inkeep*\n\nYour Slack integration is working correctly.';
 
       const result = await slackClient.chat.postMessage({
         channel: channelId,

--- a/packages/agents-work-apps/src/slack/services/blocks/index.ts
+++ b/packages/agents-work-apps/src/slack/services/blocks/index.ts
@@ -2,9 +2,7 @@ import { Blocks, Elements, Md, Message } from 'slack-block-builder';
 import { SlackStrings } from '../../i18n';
 
 export function createErrorMessage(message: string) {
-  return Message()
-    .blocks(Blocks.Section().text(`❌ ${message}`))
-    .buildToObject();
+  return Message().blocks(Blocks.Section().text(message)).buildToObject();
 }
 
 export interface ContextBlockParams {
@@ -66,7 +64,7 @@ export function buildConversationResponseBlocks(params: {
   const blocks: any[] = [
     {
       type: 'context',
-      elements: [{ type: 'mrkdwn', text: `💬 *You:* ${displayMessage}` }],
+      elements: [{ type: 'mrkdwn', text: `*You:* ${displayMessage}` }],
     },
     { type: 'divider' },
     {
@@ -103,9 +101,9 @@ export function createAlreadyLinkedMessage(email: string, linkedAt: string, dash
   return Message()
     .blocks(
       Blocks.Section().text(
-        Md.bold('✅ Already Linked!') +
-          '\n\nYour Slack account is already connected to Inkeep.\n\n' +
-          Md.bold('Inkeep Account:') +
+        Md.bold('Already linked') +
+          '\n\nYour Slack account is connected to Inkeep.\n\n' +
+          Md.bold('Account:') +
           ` ${email}\n` +
           Md.bold('Linked:') +
           ` ${new Date(linkedAt).toLocaleDateString()}\n\n` +
@@ -125,9 +123,9 @@ export function createUnlinkSuccessMessage() {
   return Message()
     .blocks(
       Blocks.Section().text(
-        Md.bold('✅ Account Unlinked') +
+        Md.bold('Account unlinked') +
           '\n\nYour Slack account has been disconnected from Inkeep.\n\n' +
-          'To use Inkeep agents again, run `/inkeep link` to connect a new account.'
+          'Run `/inkeep link` to connect a new account.'
       )
     )
     .buildToObject();
@@ -137,9 +135,8 @@ export function createNotLinkedMessage() {
   return Message()
     .blocks(
       Blocks.Section().text(
-        Md.bold('❌ Not Linked') +
-          '\n\nYour Slack account is not connected to Inkeep.\n\n' +
-          'Run `/inkeep link` to connect your account.'
+        Md.bold('Not linked') +
+          '\n\nYour Slack account is not connected to Inkeep. Run `/inkeep link` to connect.'
       )
     )
     .buildToObject();
@@ -171,7 +168,7 @@ export function createStatusMessage(
   return Message()
     .blocks(
       Blocks.Section().text(
-        Md.bold('✅ Connected to Inkeep') +
+        Md.bold('Connected to Inkeep') +
           `\n\n${Md.bold('Account:')} ${email}\n` +
           `${Md.bold('Linked:')} ${new Date(linkedAt).toLocaleDateString()}\n` +
           agentLine
@@ -190,25 +187,13 @@ export function createJwtLinkMessage(linkUrl: string, expiresInMinutes: number) 
   return Message()
     .blocks(
       Blocks.Section().text(
-        `${Md.bold('🔗 Link your Inkeep account')}\n\n` +
-          'Connect your Slack and Inkeep accounts to unlock AI-powered assistance:'
-      ),
-      Blocks.Section().text(
-        `${Md.bold('What you can do after linking:')}\n` +
-          '• Ask questions with `/inkeep [question]` or `@Inkeep`\n' +
-          '• Get personalized responses from AI agents\n' +
-          '• Set your own default agent preferences'
-      ),
-      Blocks.Section().text(
-        `${Md.bold('How to link:')}\n` +
-          '1. Click the button below\n' +
-          '2. Sign in to Inkeep (or create an account)\n' +
-          '3. Done! Come back here and start asking questions'
+        `${Md.bold('Link your Inkeep account')}\n\n` +
+          'Connect your Slack and Inkeep accounts to use Inkeep agents.'
       ),
       Blocks.Actions().elements(
-        Elements.Button().text('🔗 Link Account').url(linkUrl).actionId('link_account').primary()
+        Elements.Button().text('Link Account').url(linkUrl).actionId('link_account').primary()
       ),
-      Blocks.Context().elements(`This link expires in ${expiresInMinutes} minutes`)
+      Blocks.Context().elements(`This link expires in ${expiresInMinutes} minutes.`)
     )
     .buildToObject();
 }

--- a/packages/agents-work-apps/src/slack/services/events/app-mention.ts
+++ b/packages/agents-work-apps/src/slack/services/events/app-mention.ts
@@ -118,7 +118,7 @@ export async function handleAppMention(params: {
         .postEphemeral({
           channel,
           user: slackUserId,
-          text: '⚠️ This workspace is not properly configured. Please reinstall the Slack app from the Inkeep dashboard.',
+          text: 'This workspace is not properly configured. Please reinstall the Slack app from the Inkeep dashboard.',
         })
         .catch((e) =>
           logger.warn({ error: e, channel }, 'Failed to send ephemeral workspace config error')
@@ -156,7 +156,7 @@ export async function handleAppMention(params: {
           channel,
           user: slackUserId,
           thread_ts: isInThread ? threadTs : undefined,
-          text: `⚙️ No agents configured for this workspace.\n\n👉 *<${dashboardUrl}|Set up agents in the dashboard>*`,
+          text: `No agents configured for this workspace. *<${dashboardUrl}|Set up agents in the dashboard>*`,
         });
         span.end();
         return;
@@ -173,9 +173,8 @@ export async function handleAppMention(params: {
           user: slackUserId,
           thread_ts: isInThread ? threadTs : undefined,
           text:
-            `🔗 *Link your account to use @Inkeep*\n\n` +
-            `Run \`/inkeep link\` to connect your Slack and Inkeep accounts.\n\n` +
-            `This workspace uses: *${agentDisplayName}*`,
+            `*Link your account to use @Inkeep*\n\n` +
+            `Run \`/inkeep link\` to connect your Slack and Inkeep accounts.`,
         });
         span.end();
         return;
@@ -214,10 +213,9 @@ export async function handleAppMention(params: {
             user: slackUserId,
             thread_ts: threadTs,
             text:
-              `💬 *Continue the conversation*\n\n` +
-              `Just type your follow-up — no need to mention me in this thread.\n` +
-              `Or use \`@Inkeep <prompt>\` to run a new prompt.\n\n` +
-              `_Using: ${agentDisplayName}_`,
+              `*Continue the conversation*\n\n` +
+              `Type your follow-up directly in this thread — no need to mention me.\n` +
+              `Or use \`@Inkeep <prompt>\` to start a new prompt.`,
           });
           span.end();
           return;

--- a/packages/agents-work-apps/src/slack/services/events/modal-submission.ts
+++ b/packages/agents-work-apps/src/slack/services/events/modal-submission.ts
@@ -158,7 +158,7 @@ export async function handleModalSubmission(view: {
         await slackClient.chat.postEphemeral({
           channel: metadata.channel,
           user: metadata.slackUserId,
-          text: '🔗 You need to link your account first. Use `/inkeep link` to get started.',
+          text: 'Link your account first. Run `/inkeep link` to connect.',
         });
         span.end();
         return;
@@ -313,7 +313,7 @@ export async function handleFollowUpSubmission(view: {
         await slackClient.chat.postEphemeral({
           channel,
           user: slackUserId,
-          text: '🔗 You need to link your account first. Use `/inkeep link` to get started.',
+          text: 'Link your account first. Run `/inkeep link` to connect.',
         });
         span.end();
         return;

--- a/packages/agents-work-apps/src/slack/services/events/utils.ts
+++ b/packages/agents-work-apps/src/slack/services/events/utils.ts
@@ -183,19 +183,19 @@ export function getUserFriendlyErrorMessage(errorType: SlackErrorType, agentName
 
   switch (errorType) {
     case SlackErrorType.TIMEOUT:
-      return `⏱️ *Request timed out*\n\n${agent} took too long to respond. This can happen with complex queries.\n\n*Try:*\n• Simplifying your question\n• Breaking it into smaller parts\n• Trying again in a moment`;
+      return `*Request timed out.* ${agent} took too long to respond. Try again with a simpler question.`;
 
     case SlackErrorType.RATE_LIMIT:
-      return `⚠️ *Too many requests*\n\nYou've hit the rate limit. Please wait a moment before trying again.\n\n*Tip:* Space out your requests to avoid this.`;
+      return '*Rate limited.* Wait a moment and try again.';
 
     case SlackErrorType.AUTH_ERROR:
-      return `🔐 *Authentication issue*\n\nThere was a problem with your account connection.\n\n*Try:*\n• Running \`/inkeep link\` to re-link your account\n• Contacting your workspace admin if the issue persists`;
+      return '*Authentication error.* Run `/inkeep link` to reconnect your account.';
 
     case SlackErrorType.API_ERROR:
-      return `❌ *Something went wrong*\n\n${agent} encountered an error processing your request.\n\n*Try:*\n• Rephrasing your question\n• Trying again in a moment\n• Using \`/inkeep help\` for more options`;
+      return `*Something went wrong.* ${agent} encountered an error. Try again in a moment.`;
 
     default:
-      return `❌ *Unexpected error*\n\nSomething went wrong while processing your request.\n\n*Try:*\n• Trying again in a moment\n• Using \`/inkeep help\` for more options`;
+      return '*Unexpected error.* Something went wrong. Try again in a moment.';
   }
 }
 

--- a/packages/agents-work-apps/src/slack/services/modals.ts
+++ b/packages/agents-work-apps/src/slack/services/modals.ts
@@ -207,7 +207,7 @@ export function buildAgentSelectorModal(params: BuildAgentSelectorModalParams): 
     elements: [
       {
         type: 'mrkdwn',
-        text: `⚙️ <${manageUiBaseUrl}${dashboardUrl}|Open Dashboard>`,
+        text: `<${manageUiBaseUrl}${dashboardUrl}|Open Dashboard>`,
       },
     ],
   } as unknown as (typeof blocks)[number]);
@@ -425,7 +425,7 @@ export function buildMessageShortcutModal(params: BuildMessageShortcutModalParam
     elements: [
       {
         type: 'mrkdwn',
-        text: `⚙️ <${manageUiBaseUrl}${dashboardUrl}|Open Dashboard>`,
+        text: `<${manageUiBaseUrl}${dashboardUrl}|Open Dashboard>`,
       },
     ],
   } as unknown as (typeof blocks)[number]);


### PR DESCRIPTION
## Summary

- Remove all emojis from Slack bot user-facing messages (~14 different emoji types)
- Condense error messages to single sentences (removed verbose "Try:" bullet sections)
- Trim the account link flow — cut "What you can do after linking" and "How to link" multi-step instructions
- Use plain bold headers in help text instead of emoji-prefixed headers
- Update test assertions to match new copy

## Changes

**8 files changed** across `packages/agents-work-apps/src/slack/`:

| File | What changed |
|---|---|
| `i18n/strings.ts` | Removed emojis from buttons, usage hints, status, errors, help text |
| `services/blocks/index.ts` | Removed emoji prefixes from error/link/unlink/status/JWT messages, trimmed link flow |
| `services/events/utils.ts` | Rewrote all 5 error types to single-sentence format |
| `services/events/app-mention.ts` | Removed emojis from ephemeral workspace/agent/link/thread messages |
| `services/events/modal-submission.ts` | Removed emoji from "link account" prompts |
| `services/modals.ts` | Removed gear emoji from "Open Dashboard" context links |
| `routes/workspaces.ts` | Removed emoji from test message |
| `__tests__/slack/blocks.test.ts` | Updated assertions to match new copy (no emoji, sentence case) |

## Test plan

- [x] All 299 tests pass (`pnpm vitest --run` in agents-work-apps)
- [x] Typecheck passes (`tsc --noEmit`)
- [x] Lint passes (Biome, no warnings)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)