### PR TITLE
refactor(agents-core): enforce data-access layer boundary for auth queries

### DIFF
--- a/package.json
+++ b/package.json
@@ -121,6 +121,9 @@
     ],
     "scripts/generate-jwt-keys.sh": [
       "bash -c 'cp scripts/generate-jwt-keys.sh create-agents-template/scripts/generate-jwt-keys.sh && git add create-agents-template/scripts/generate-jwt-keys.sh'"
+    ],
+    "packages/agents-core/src/**/*.{ts,tsx}": [
+      "bash scripts/lint-data-access-boundary.sh"
     ]
   },
   "packageManager": "pnpm@10.10.0"

--- a/packages/agents-core/src/data-access/index.ts
+++ b/packages/agents-core/src/data-access/index.ts
@@ -26,9 +26,9 @@ export * from './manage/subAgents';
 export * from './manage/subAgentTeamAgentRelations';
 export * from './manage/tools';
 export * from './manage/triggers';
-
-// Runtime data access (Postgres - not versioned)
 export * from './runtime/apiKeys';
+// Runtime data access (Postgres - not versioned)
+export * from './runtime/auth';
 export * from './runtime/cascade-delete';
 export * from './runtime/contextCache';
 export * from './runtime/conversations';

--- a/packages/agents-core/src/data-access/runtime/auth.ts
+++ b/packages/agents-core/src/data-access/runtime/auth.ts
@@ -1,0 +1,51 @@
+import { eq } from 'drizzle-orm';
+import { member, ssoProvider } from '../../auth/auth-schema';
+import type { AgentsRunDatabaseClient } from '../../db/runtime/runtime-client';
+
+export const getInitialOrganizationForUser =
+  (db: AgentsRunDatabaseClient) =>
+  async (userId: string): Promise<{ organizationId: string } | null> => {
+    const [result] = await db
+      .select({ organizationId: member.organizationId })
+      .from(member)
+      .where(eq(member.userId, userId))
+      .orderBy(member.createdAt)
+      .limit(1);
+
+    return result ?? null;
+  };
+
+export const getSSOProviderByProviderId =
+  (db: AgentsRunDatabaseClient) =>
+  async (providerId: string): Promise<{ id: string } | null> => {
+    const [result] = await db
+      .select({ id: ssoProvider.id })
+      .from(ssoProvider)
+      .where(eq(ssoProvider.providerId, providerId))
+      .limit(1);
+
+    return result ?? null;
+  };
+
+export const createSSOProvider =
+  (db: AgentsRunDatabaseClient) =>
+  async (data: {
+    id: string;
+    providerId: string;
+    issuer: string;
+    domain: string;
+    oidcConfig?: string | null;
+    samlConfig?: string | null;
+    organizationId?: string | null;
+  }): Promise<void> => {
+    await db.insert(ssoProvider).values({
+      id: data.id,
+      providerId: data.providerId,
+      issuer: data.issuer,
+      domain: data.domain,
+      oidcConfig: data.oidcConfig ?? null,
+      samlConfig: data.samlConfig ?? null,
+      userId: null,
+      organizationId: data.organizationId ?? null,
+    });
+  };

--- a/scripts/lint-data-access-boundary.sh
+++ b/scripts/lint-data-access-boundary.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# Enforces that drizzle-orm imports only appear in allowed directories.
+# Designed to run via lint-staged on staged files only.
+#
+# Usage: scripts/lint-data-access-boundary.sh file1.ts file2.ts ...
+
+set -euo pipefail
+
+VIOLATIONS=()
+
+for file in "$@"; do
+  # Skip allowed directories
+  case "$file" in
+    */data-access/* | */db/* | */dolt/* | */__tests__/* | *.test.ts | *.spec.ts | */test-*)
+      continue
+      ;;
+  esac
+
+  # Check for drizzle-orm imports
+  if grep -qE "from ['\"]drizzle-orm" "$file" 2>/dev/null; then
+    VIOLATIONS+=("$file")
+  fi
+done
+
+if [ ${#VIOLATIONS[@]} -gt 0 ]; then
+  echo ""
+  echo "ERROR: drizzle-orm imports found outside the data-access layer:"
+  echo ""
+  for v in "${VIOLATIONS[@]}"; do
+    echo "  $v"
+  done
+  echo ""
+  echo "Move database queries to packages/agents-core/src/data-access/ and import"
+  echo "the data-access functions instead. See CLAUDE.md for architecture guidelines."
+  echo ""
+  exit 1
+fi


### PR DESCRIPTION
## Summary

- Extract 3 inline Drizzle queries from `auth/auth.ts` into new `data-access/runtime/auth.ts` (curried pattern matching existing conventions)
- Add `scripts/lint-data-access-boundary.sh` lint-staged rule that prevents new `drizzle-orm` imports outside allowed directories (`data-access/`, `db/`, `dolt/`, `__tests__/`, test files)
- Barrel export added to `data-access/index.ts`

## Test plan

- [x] `pnpm typecheck` passes (agents-core)
- [x] `pnpm lint` passes (285 files, no warnings)
- [x] `pnpm test` passes (96 files, 1512 tests)
- [x] `knip` passes (no unused exports)
- [x] Lint script catches violations: file outside allowed dirs with `from 'drizzle-orm'` → exit 1
- [x] Lint script allows: `data-access/`, `db/`, `dolt/`, `__tests__/`, `*.test.ts`, `*.spec.ts`, `test-*` files
- [x] Pre-commit hook runs the new lint-staged entry on staged `agents-core` files (confirmed during commit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)