### PR TITLE
Fix pixelmatch type error breaking CI builds

### DIFF
--- a/agents-manage-ui/vitest.config.ts
+++ b/agents-manage-ui/vitest.config.ts
@@ -130,7 +130,7 @@ export default defineConfig({
                         ? (actual.data as Uint8Array)
                         : cropRgba(actual.data, aW, w, h);
 
-                    const diffBuf = createDiff ? new Uint8Array(w * h * 4) : null;
+                    const diffBuf = createDiff ? new Uint8Array(w * h * 4) : undefined;
                     const mismatched = pixelmatch(refData, actData, diffBuf, w, h, { threshold });
 
                     const total = w * h;
@@ -138,7 +138,7 @@ export default defineConfig({
 
                     return {
                       pass: ratio <= allowedMismatchedPixelRatio,
-                      diff: diffBuf,
+                      diff: diffBuf ?? null,
                       message:
                         ratio > allowedMismatchedPixelRatio
                           ? `${mismatched} pixels (${(ratio * 100).toFixed(2)}%) mismatched, allowed: ${(allowedMismatchedPixelRatio * 100).toFixed(2)}%`


### PR DESCRIPTION
## Summary
- Fixed TypeScript type error in `agents-manage-ui/vitest.config.ts:133-141` that was failing all three CI workflows (CI, Cypress, Publish) on main
- The `pixelmatch` function's third parameter accepts `Uint8Array | undefined` but was being passed `Uint8Array | null` — changed to use `undefined` for the call and `?? null` for the return type which expects `TypedArray | null`

## Test plan
- [ ] `pnpm typecheck` passes for agents-manage-ui
- [ ] CI, Cypress, and Publish workflows go green

🤖 Generated with [Claude Code](https://claude.com/claude-code)