### PR TITLE
fix: use table recreation for sub_agent_skills unique constraint migration

### DIFF
--- a/packages/agents-core/drizzle/manage/0010_oval_angel.sql
+++ b/packages/agents-core/drizzle/manage/0010_oval_angel.sql
@@ -1,2 +1,20 @@
-ALTER TABLE "sub_agent_skills" DROP CONSTRAINT "sub_agent_skills_sub_agent_skill_unique";--> statement-breakpoint
-ALTER TABLE "sub_agent_skills" ADD CONSTRAINT "sub_agent_skills_sub_agent_skill_unique" UNIQUE("tenant_id","project_id","agent_id","sub_agent_id","skill_id");
+CREATE TABLE "sub_agent_skills_new" (
+	"tenant_id" varchar(256) NOT NULL,
+	"id" varchar(256) NOT NULL,
+	"project_id" varchar(256) NOT NULL,
+	"agent_id" varchar(256) NOT NULL,
+	"sub_agent_id" varchar(256) NOT NULL,
+	"skill_id" varchar(64) NOT NULL,
+	"index" numeric DEFAULT 0 NOT NULL,
+	"always_loaded" boolean DEFAULT false NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp DEFAULT now() NOT NULL,
+	CONSTRAINT "sub_agent_skills_tenant_id_project_id_agent_id_id_pk" PRIMARY KEY("tenant_id","project_id","agent_id","id"),
+	CONSTRAINT "sub_agent_skills_sub_agent_skill_unique" UNIQUE("tenant_id","project_id","agent_id","sub_agent_id","skill_id")
+);--> statement-breakpoint
+INSERT INTO "sub_agent_skills_new" SELECT * FROM "sub_agent_skills";--> statement-breakpoint
+DROP TABLE "sub_agent_skills";--> statement-breakpoint
+ALTER TABLE "sub_agent_skills_new" RENAME TO "sub_agent_skills";--> statement-breakpoint
+ALTER TABLE "sub_agent_skills" ADD CONSTRAINT "sub_agent_skills_sub_agent_fk" FOREIGN KEY ("tenant_id","project_id","agent_id","sub_agent_id") REFERENCES "public"."sub_agents"("tenant_id","project_id","agent_id","id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "sub_agent_skills" ADD CONSTRAINT "sub_agent_skills_skill_fk" FOREIGN KEY ("tenant_id","project_id","skill_id") REFERENCES "public"."skills"("tenant_id","project_id","id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "sub_agent_skills_skill_idx" ON "sub_agent_skills" USING btree ("skill_id");


### PR DESCRIPTION
## Summary

- Fixes `pnpm db:migrate` failure caused by Doltgres's inability to drop inline UNIQUE constraints via standard PostgreSQL syntax
- Replaces the `DROP CONSTRAINT` / `ADD CONSTRAINT` approach in migration `0010_oval_angel.sql` with a full table recreation (create new table → copy data → drop old → rename) to work around the Doltgres limitation
- The unique constraint on `sub_agent_skills` is widened from `(sub_agent_id, skill_id)` to `(tenant_id, project_id, agent_id, sub_agent_id, skill_id)` to properly scope it to tenant/project/agent

## Context

Doltgres stores inline `UNIQUE` constraints from `CREATE TABLE` as internal keys rather than PostgreSQL-style constraints. This makes them impossible to drop through any standard syntax:

| Approach | Result |
|---|---|
| `ALTER TABLE ... DROP CONSTRAINT` | "Constraint does not exist" |
| `ALTER TABLE ... DROP CONSTRAINT IF EXISTS` | No-op, then `ADD CONSTRAINT` fails with "Duplicate key name" |
| `DROP INDEX IF EXISTS` (standalone) | "table not found" |
| `ALTER TABLE ... DROP INDEX` (MySQL syntax) | Syntax error (PG wire protocol rejects it) |

The table recreation approach sidesteps this entirely by creating a fresh table with the correct constraint.

## Test plan

- [ ] Run `pnpm db:migrate` locally and verify it completes successfully
- [ ] Verify `sub_agent_skills` table has the correct unique constraint after migration
- [ ] Run `pnpm check` to ensure no regressions

Made with [Cursor](https://cursor.com)