### PR TITLE
fix(create-agents): sync template deps to CLI version after clone

### DIFF
--- a/.changeset/meaningful-orange-kangaroo.md
+++ b/.changeset/meaningful-orange-kangaroo.md
@@ -1,0 +1,5 @@
+---
+"@inkeep/create-agents": patch
+---
+
+Sync template @inkeep/* dependency versions to match CLI version after clone

--- a/packages/create-agents/src/utils.ts
+++ b/packages/create-agents/src/utils.ts
@@ -1,6 +1,8 @@
 import { exec } from 'node:child_process';
+import { readFileSync } from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { promisify } from 'node:util';
 import * as p from '@clack/prompts';
 import { ANTHROPIC_MODELS, GOOGLE_MODELS, OPENAI_MODELS } from '@inkeep/agents-core';
@@ -41,6 +43,37 @@ const projectTemplateRepo = 'https://github.com/inkeep/agents/agents-cookbook/te
 const execAsync = promisify(exec);
 
 const agentsApiPort = '3002';
+
+function getCliVersion(): string {
+  try {
+    const __dirname = path.dirname(fileURLToPath(import.meta.url));
+    const pkgJson = JSON.parse(readFileSync(path.join(__dirname, '..', 'package.json'), 'utf-8'));
+    return pkgJson.version;
+  } catch {
+    return '';
+  }
+}
+
+export async function syncTemplateDependencies(templatePath: string): Promise<void> {
+  const pkgPath = path.join(templatePath, 'package.json');
+  if (!(await fs.pathExists(pkgPath))) return;
+
+  const pkg = await fs.readJson(pkgPath);
+  const cliVersion = getCliVersion();
+  if (!cliVersion) return;
+
+  for (const depType of ['dependencies', 'devDependencies'] as const) {
+    const deps = pkg[depType];
+    if (!deps) continue;
+    for (const name of Object.keys(deps)) {
+      if (name.startsWith('@inkeep/')) {
+        deps[name] = `^${cliVersion}`;
+      }
+    }
+  }
+
+  await fs.writeJson(pkgPath, pkg, { spaces: 2 });
+}
 
 export const defaultGoogleModelConfigurations = {
   base: {
@@ -397,6 +430,8 @@ export const createAgents = async (
     });
 
     process.chdir(directoryPath);
+
+    await syncTemplateDependencies('.');
 
     const config = {
       dirName,


### PR DESCRIPTION
## Summary

- After `create-agents` clones the template via degit, `syncTemplateDependencies()` reads the CLI's own `package.json` version and updates all `@inkeep/*` deps in the template to `^{cliVersion}`
- Prevents version mismatch when the template hasn't been updated to match the latest CLI release (e.g., CLI v0.52.0 but template deps at `^0.50.3`)
- Stacked on #2212 (`feat/unify-env-generation`) — scoped to only the dep sync logic, no overlap with env generation changes

## Changes

### `packages/create-agents/src/utils.ts`
- **`getCliVersion()`** — reads CLI's own `package.json` version via `readFileSync` + `fileURLToPath(import.meta.url)`, returns `''` on failure
- **`syncTemplateDependencies(templatePath)`** — iterates `dependencies` and `devDependencies`, updates any `@inkeep/*` entry to `^{cliVersion}`
- Call site added after `process.chdir(directoryPath)` in `createAgents()` flow

### `packages/create-agents/src/__tests__/utils.test.ts`
- Added `node:fs` and `node:url` mocks (coexist with #2212's existing mocks)
- 6 unit tests covering: happy path, missing package.json, no @inkeep deps, no devDeps, devDeps update, non-@inkeep deps preserved

### `.changeset/meaningful-orange-kangaroo.md`
- Patch changeset for `@inkeep/create-agents`

## What this does NOT touch
- `createEnvironmentFiles()` (handled by #2212)
- E2E tests (no changes)
- URL handling / localhost changes (handled by #2212)
- `createInkeepConfig()` (handled by #2212)

## Test plan

- [x] **Unit: syncTemplateDependencies happy path** — updates @inkeep/* deps to ^1.2.3
- [x] **Unit: missing package.json** — gracefully skips
- [x] **Unit: no @inkeep deps** — writes file unchanged (no crash)
- [x] **Unit: no devDependencies** — only processes dependencies
- [x] **Unit: devDependencies** — updates @inkeep/* in devDeps too
- [x] **Unit: non-@inkeep preserved** — react, next, etc. untouched
- [x] **Typecheck** — `tsc --noEmit` passes
- [x] **Lint** — `biome lint --error-on-warnings` passes
- [x] **Format** — `biome check` passes
- [ ] **CI** — waiting for checks to run

🤖 Generated with [Claude Code](https://claude.com/claude-code)