### PR TITLE
fix(ci): increase timeout for heavy Doltgres integration tests

### DIFF
--- a/agents-api/src/__tests__/manage/integration/projects.test.ts
+++ b/agents-api/src/__tests__/manage/integration/projects.test.ts
@@ -169,7 +169,7 @@ describe('Project CRUD Routes - Integration Tests', () => {
         ...page3Body.data.map((p: any) => p.id),
       ];
       expect(new Set(allProjectIds).size).toBe(5); // All should be unique
-    });
+    }, 120_000);
 
     it('should return empty data for page beyond available data', async () => {
       const tenantId = await createTrackedTenant('projects-list-beyond-pages');
@@ -187,7 +187,7 @@ describe('Project CRUD Routes - Integration Tests', () => {
         total: 3,
         pages: 2,
       });
-    });
+    }, 90_000);
 
     it('should enforce max limit of 100', async () => {
       const tenantId = await createTrackedTenant('projects-list-max-limit');
@@ -555,7 +555,7 @@ describe('Project CRUD Routes - Integration Tests', () => {
       const listRes = await makeRequest(`/manage/tenants/${tenantId}/projects?limit=10`);
       const listBody = await listRes.json();
       expect(listBody.data).toHaveLength(5);
-    });
+    }, 90_000);
 
     it('should maintain data isolation between tenants', async () => {
       const tenantId1 = await createTrackedTenant('projects-isolation-1');
@@ -579,6 +579,6 @@ describe('Project CRUD Routes - Integration Tests', () => {
       const ids2 = body2.data.map((p: any) => p.id);
       const intersection = ids1.filter((id: string) => ids2.includes(id));
       expect(intersection).toHaveLength(0);
-    });
+    }, 90_000);
   });
 });


### PR DESCRIPTION
## Summary

- The test "should handle pagination with multiple pages" in `projects.test.ts` times out at 60s in CI because it performs ~50 sequential Doltgres operations (5 project creates + 3 pagination GETs + cleanup)
- CI Doltgres is slower than local because it runs on Docker's ephemeral filesystem with no persistent I/O cache
- The overall test suite takes ~1477s for 71 tests, confirming Doltgres is the bottleneck
- Adds per-test Vitest timeouts to the four heaviest tests: 120s for the pagination test and 90s for three other multi-project tests (beyond-pages, concurrent ops, tenant isolation)

## Test plan

- [x] `pnpm format` passes with no changes
- [x] `pnpm check` passes (lint + typecheck + test + format:check + knip)
- [x] CI pipeline passes with updated timeouts
- No test logic was changed; only the timeout parameter was added to four `it()` calls

🤖 Generated with [Claude Code](https://claude.com/claude-code)