### PR TITLE
perf: skip unnecessary doltStatus() on GET/HEAD requests

### DIFF
--- a/agents-api/src/middleware/branchScopedDb.ts
+++ b/agents-api/src/middleware/branchScopedDb.ts
@@ -93,12 +93,13 @@ export const branchScopedDbMiddleware = async (c: Context, next: Next) => {
     // Execute the route handler
     await next();
 
-    // Auto-commit for successful writes on branches
+    // Auto-commit for successful writes on branches (skip for read-only methods)
+    const isReadMethod = method === 'GET' || method === 'HEAD';
     const status = c.res.status;
     const projectDeleteOperation = isProjectDeleteOperation(c.req.path, method);
     const operationSuccess = status >= 200 && status < 300;
     const shouldCommit =
-      resolvedRef.type === 'branch' && operationSuccess && !projectDeleteOperation;
+      resolvedRef.type === 'branch' && operationSuccess && !projectDeleteOperation && !isReadMethod;
 
     if (shouldCommit) {
       try {


### PR DESCRIPTION
## Summary

- Skip the `doltStatus()` Doltgres round-trip on GET/HEAD requests in `branchScopedDbMiddleware`
- Add an `isReadMethod` check to the `shouldCommit` condition so read-only requests bypass the entire auto-commit block
- This is a pure performance optimization with no behavior change for any endpoint

## Problem

The `branchScopedDbMiddleware` was calling `doltStatus()` after every successful request, including all GET and HEAD requests. Since GET handlers never write data, this always returned an empty changeset -- a wasted Doltgres round-trip on every read.

## Why this is safe

- All ~95 manage GET endpoints are pure reads with no side effects
- No middleware between the branch checkout and the status check creates writes
- The `doltStatus()` call on reads always returned an empty changeset, so no commit was ever triggered
- Unit tests are unaffected (`ENVIRONMENT=test` short-circuits the middleware before this code path)

## Impact

- **Production:** Eliminates 1 unnecessary Doltgres round-trip per GET/HEAD request (~95 endpoints)
- **Integration tests:** Removes ~37 unnecessary round-trips per suite run (~34% of all requests)

## Test plan

- [x] `pnpm check` passes (lint, typecheck, tests, format, knip)
- [ ] Verify in staging that GET endpoints return identical responses
- [ ] Verify POST/PUT/PATCH/DELETE endpoints still auto-commit as before