### PR TITLE
fix(ci): add Dependabot for docker-compose, pin Doltgres, disable OTEL in Cypress

### DIFF
--- a/.github/composite-actions/cypress-e2e/action.yml
+++ b/.github/composite-actions/cypress-e2e/action.yml
@@ -115,20 +115,22 @@ runs:
 
     - name: Run Cypress E2E Tests
       shell: bash
-      run: pnpm --filter @inkeep/agents-manage-ui test:e2e:ci
+      run: timeout 600 pnpm --filter @inkeep/agents-manage-ui test:e2e:ci
 
     - name: Upload Cypress Screenshots
-      if: failure()
+      if: always()
       uses: actions/upload-artifact@v4
       with:
         name: cypress-screenshots
         path: agents-manage-ui/cypress/screenshots
+        if-no-files-found: ignore
         retention-days: 7
 
     - name: Upload Cypress Videos
-      if: failure()
+      if: always()
       uses: actions/upload-artifact@v4
       with:
         name: cypress-videos
         path: agents-manage-ui/cypress/videos
+        if-no-files-found: ignore
         retention-days: 7

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  - package-ecosystem: 'docker-compose'
+    directory: '/'
+    schedule:
+      interval: 'weekly'
+
+  - package-ecosystem: 'docker-compose'
+    directory: '/create-agents-template'
+    schedule:
+      interval: 'weekly'

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -20,7 +20,7 @@ jobs:
 
     services:
       doltgres:
-        image: dolthub/doltgresql:latest
+        image: dolthub/doltgresql:0.54.10
         env:
           DOLTGRES_USER: appuser
           DOLTGRES_PASSWORD: password
@@ -134,4 +134,5 @@ jobs:
           INKEEP_AGENTS_MANAGE_UI_PASSWORD: adminADMIN!@12
           BETTER_AUTH_SECRET: test-secret-key-for-ci
           SPICEDB_PRESHARED_KEY: dev-secret-key
+          OTEL_SDK_DISABLED: true
           CYPRESS_NO_COMMAND_LOG: 1

--- a/agents-manage-ui/src/instrumentation.ts
+++ b/agents-manage-ui/src/instrumentation.ts
@@ -3,7 +3,7 @@ import type * as SentryNs from '@sentry/nextjs';
 export let onRequestError: typeof SentryNs.captureRequestError;
 
 export async function register() {
-  if (process.env.NEXT_RUNTIME === 'nodejs') {
+  if (process.env.NEXT_RUNTIME === 'nodejs' && process.env.ENVIRONMENT !== 'test') {
     await import('./otel');
   }
 


### PR DESCRIPTION
## Summary

- **Add Dependabot for docker-compose**: Track Docker image versions in `docker-compose.yml` (root) and `create-agents-template/docker-compose.yml` for automated dependency updates
- **Pin Doltgres in Cypress CI**: Pin `dolthub/doltgresql:0.54.10` in `cypress.yml` to match `docker-compose.yml`
- **Disable OTEL in test environments**:
  - Skip OTEL import in `instrumentation.ts` when `ENVIRONMENT=test` — prevents `getNodeAutoInstrumentations()` from monkeypatching HTTP modules during Next.js SSR
  - Add `OTEL_SDK_DISABLED=true` env var in Cypress workflow (belt-and-suspenders)
- **Cypress CI reliability**:
  - Add 10-min timeout to the Cypress test step so it fails before the 30-min job timeout
  - Change artifact upload to `if: always()` with `if-no-files-found: ignore` so screenshots/videos are uploaded on failure, cancellation, or timeout

### Root cause analysis (Cypress failures since Feb 19)

The OTEL commit (#2168, `0aea45a3`) was the first commit after the last passing main run. It:
1. Loads unconditionally during SSR via `instrumentation.ts` → `otel.ts`
2. Calls `getNodeAutoInstrumentations()` which patches `http`/`undici` modules globally
3. Creates a `BatchSpanProcessor` that retries exporting to a non-existent `localhost:4318` every 500ms
4. The HTTP patching interferes with Next.js internal request handling, causing all pages to fail to render

Evidence: All 10 Cypress specs fail with "element not found" errors (`#id`, `#description`, `.react-flow__node`, `[data-uri=...] textarea`) — consistent with a global rendering failure, not individual test issues.

## Test plan

- [ ] Verify Cypress CI passes on this PR (or at least progresses past the rendering failures)
- [ ] Verify screenshots/videos are uploaded as artifacts on failure
- [ ] Verify Dependabot creates PRs for docker-compose image updates

🤖 Generated with [Claude Code](https://claude.com/claude-code)
