### PR TITLE
chore: point PR review workflows to team-skills

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -687,6 +687,20 @@ jobs:
             -o .agents/skills/web-design-guidelines/references/guidelines.md
           echo "Web design guidelines fetched ($(wc -l < .agents/skills/web-design-guidelines/references/guidelines.md) lines)"
 
+      - name: Generate GitHub App token for team-skills
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.INTERNAL_CI_APP_ID }}
+          private-key: ${{ secrets.INTERNAL_CI_APP_PRIVATE_KEY }}
+          owner: inkeep
+          repositories: team-skills
+
+      - name: Clone team-skills (CI-only PR review agents)
+        run: gh repo clone inkeep/team-skills /tmp/team-skills -- --depth 1
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+
       - name: Run PR Review
         id: claude
         # Pinned to SDK 0.2.25 (last working version) due to AJV validation crash in 0.2.27+
@@ -700,6 +714,7 @@ jobs:
           allowed_bots: "claude[bot]"
           track_progress: true
           claude_args: |
+            --plugin-dir /tmp/team-skills/ci/pr-review
             --agent pr-review
             --mcp-config '{"mcpServers":{"exa":{"command":"npx","args":["-y","exa-mcp-server"],"env":{"EXA_API_KEY":"${{ secrets.EXA_API_KEY }}"}}}}'
             --allowedTools "Task,Read,Write,Grep,Glob,mcp__exa__web_search_exa,mcp__github__create_pending_pull_request_review,mcp__github__add_comment_to_pending_review,mcp__github__submit_pending_pull_request_review,Bash(git diff:*),Bash(git log:*),Bash(git show:*),Bash(git merge-base:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh api:*),Bash(mkdir:*)"

--- a/.github/workflows/closed-pr-review-auto-improver.yml
+++ b/.github/workflows/closed-pr-review-auto-improver.yml
@@ -52,10 +52,10 @@ jobs:
           app-id: ${{ secrets.INTERNAL_CI_APP_ID }}
           private-key: ${{ secrets.INTERNAL_CI_APP_PRIVATE_KEY }}
           owner: inkeep
-          repositories: internal-cc-plugins
+          repositories: team-skills
 
-      - name: Clone internal plugins
-        run: gh repo clone inkeep/internal-cc-plugins /tmp/internal-cc-plugins
+      - name: Clone team-skills (CI-only PR review agents)
+        run: gh repo clone inkeep/team-skills /tmp/team-skills -- --depth 1
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
 
@@ -229,7 +229,7 @@ jobs:
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           claude_args: |
-            --plugin-dir /tmp/internal-cc-plugins/closed-pr-review-auto-improver
+            --plugin-dir /tmp/team-skills/ci/closed-pr-review-auto-improver
             --agent closed-pr-review-auto-improver
             --allowedTools "Read,Grep,Glob,Edit,Write,Bash(git checkout -b:*),Bash(git add:*),Bash(git commit:*),Bash(git push:*),Bash(gh pr create:*),Bash(gh pr edit:*),Bash(gh api:*),Bash(git diff:*),Bash(git log:*),Bash(git status:*),Bash(git rev-list:*),Bash(git show:*)"
           prompt: |
@@ -271,8 +271,8 @@ jobs:
             3. Apply the generalizability test (all 4 criteria must pass)
             4. If HIGH-generalizability patterns found:
                - Create branch: `closed-pr-review-auto-improver/pr-${{ steps.pr-meta.outputs.pr_number }}-learnings`
-               - Edit relevant `.claude/agents/pr-review-*.md` files
-               - Create draft PR with changes
+               - Edit relevant `pr-review-*.md` agent files in `/tmp/team-skills/ci/pr-review/agents/`
+               - Create draft PR targeting `inkeep/team-skills` with changes
                - Add label: `pr-review-improvement`
             5. If no generalizable patterns: Output your analysis JSON and exit
 


### PR DESCRIPTION
## Summary

- Updates both Claude CI workflows to load PR review agents and skills from `inkeep/team-skills/ci/` instead of repo-local files or `internal-cc-plugins`
- Old pr-review agent files intentionally kept in place as inert fallback until validated
- Requires [team-skills PR #5](https://github.com/inkeep/team-skills/pull/5) to be merged first

## Changes

### `claude-code-review.yml`
- Add GitHub App token generation step (`INTERNAL_CI_APP_ID`) for team-skills access
- Add shallow clone of `inkeep/team-skills` to `/tmp/team-skills`
- Add `--plugin-dir /tmp/team-skills/ci/pr-review` to `claude_args`

### `closed-pr-review-auto-improver.yml`
- Change token `repositories` from `internal-cc-plugins` → `team-skills`
- Clone `team-skills` instead of `internal-cc-plugins`
- Update `--plugin-dir` to `/tmp/team-skills/ci/closed-pr-review-auto-improver`
- Update prompt to reference team-skills paths for agent edits and PR target

## Test plan
- [ ] Merge team-skills PR #5 first
- [ ] Merge this PR
- [ ] Open a test PR to trigger `claude-code-review.yml` — verify agents load from team-skills
- [ ] Merge test PR to trigger `closed-pr-review-auto-improver.yml` — verify auto-improver targets team-skills
- [ ] After validation, submit cleanup PR (remove old agent files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)