### PR TITLE
fix(ci): use namespaced agent name for plugin-loaded pr-review

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -715,7 +715,7 @@ jobs:
           track_progress: true
           claude_args: |
             --plugin-dir /tmp/team-skills/ci/pr-review
-            --agent pr-review
+            --agent pr-review:pr-review
             --mcp-config '{"mcpServers":{"exa":{"command":"npx","args":["-y","exa-mcp-server"],"env":{"EXA_API_KEY":"${{ secrets.EXA_API_KEY }}"}}}}'
             --allowedTools "Task,Read,Write,Grep,Glob,mcp__exa__web_search_exa,mcp__github__create_pending_pull_request_review,mcp__github__add_comment_to_pending_review,mcp__github__submit_pending_pull_request_review,Bash(git diff:*),Bash(git log:*),Bash(git show:*),Bash(git merge-base:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh api:*),Bash(mkdir:*)"
           prompt: |


### PR DESCRIPTION
## Summary
- Changes `--agent pr-review` to `--agent pr-review:pr-review` in the Claude PR Review workflow
- When agents are loaded via `--plugin-dir`, they're registered with the plugin namespace (e.g., `pr-review:pr-review`), but `--agent pr-review` was resolving to nothing, falling back to generic Claude behavior

## Evidence
Debug artifacts from run #22273147537 confirm agents are registered as `pr-review:pr-review-*` but `--agent pr-review` doesn't match. The review completed in 7 turns / 97s (generic) instead of 100+ turns (orchestrated).

## Test plan
- [x] Verified agent namespace from debug artifacts
- [ ] Merge and trigger on next PR to validate multi-phase review

🤖 Generated with [Claude Code](https://claude.com/claude-code)