### PR TITLE
Show agent name and ID in Slack modal dropdowns

### DIFF
--- a/.changeset/steep-amber-rodent.md
+++ b/.changeset/steep-amber-rodent.md
@@ -1,0 +1,5 @@
+---
+"@inkeep/agents-work-apps": patch
+---
+
+Show agent name and ID in Slack modal dropdowns for disambiguation

--- a/packages/agents-work-apps/src/slack/services/modals.ts
+++ b/packages/agents-work-apps/src/slack/services/modals.ts
@@ -79,7 +79,7 @@ export function buildAgentSelectorModal(params: BuildAgentSelectorModalParams): 
       ? agents.map((agent) => ({
           text: {
             type: 'plain_text' as const,
-            text: agent.name || agent.id,
+            text: agent.name ? `${agent.name} (${agent.id})` : agent.id,
             emoji: true,
           },
           value: JSON.stringify({ agentId: agent.id, projectId: agent.projectId }),
@@ -325,7 +325,7 @@ export function buildMessageShortcutModal(params: BuildMessageShortcutModalParam
       ? agents.map((agent) => ({
           text: {
             type: 'plain_text' as const,
-            text: agent.name || agent.id,
+            text: agent.name ? `${agent.name} (${agent.id})` : agent.id,
             emoji: true,
           },
           value: JSON.stringify({ agentId: agent.id, projectId: agent.projectId }),


### PR DESCRIPTION
## Summary
- Show both agent name and ID (e.g. "Inkeep QA Graph (facts-agent)") in Slack modal dropdown options instead of just the name or ID alone
- Agent names are not guaranteed unique across a project, so including the ID makes selection unambiguous
- Applied consistently in both `buildAgentSelectorModal` and `buildMessageShortcutModal`

## Test plan
- [x] `pnpm typecheck` passes (14/14 tasks)
- [x] `pnpm test` in agents-work-apps passes (434/434 tests, including 14 modal tests)
- [ ] Manually verify in Slack that agent dropdown shows "Name (id)" format
- [ ] Verify agents without a name still show just the ID as fallback

🤖 Generated with [Claude Code](https://claude.com/claude-code)