### PR TITLE
refactor(slack): reuse fetchAgentsForProject in lookupAgentName

### DIFF
--- a/.changeset/cognitive-aquamarine-parakeet.md
+++ b/.changeset/cognitive-aquamarine-parakeet.md
@@ -1,0 +1,5 @@
+---
+"@inkeep/agents-work-apps": patch
+---
+
+Refactor lookupAgentName to reuse fetchAgentsForProject instead of duplicating API call logic

--- a/packages/agents-work-apps/src/__tests__/slack/agent-resolution.test.ts
+++ b/packages/agents-work-apps/src/__tests__/slack/agent-resolution.test.ts
@@ -30,6 +30,10 @@ vi.mock('../../slack/services/nango', () => ({
   getWorkspaceDefaultAgentFromNango: vi.fn(),
 }));
 
+vi.mock('../../slack/services/events/utils', () => ({
+  fetchAgentsForProject: vi.fn().mockResolvedValue([]),
+}));
+
 describe('Agent Resolution', () => {
   beforeEach(() => {
     vi.clearAllMocks();


### PR DESCRIPTION
## Summary
- Refactors `lookupAgentName` in `agent-resolution.ts` to delegate to the existing `fetchAgentsForProject` utility from `events/utils.ts` instead of duplicating the internal API call logic (token generation, fetch, error handling)
- Removes unused imports (`generateInternalServiceToken`, `getInProcessFetch`, `InternalServices`, `env`)
- Adds mock for `fetchAgentsForProject` in `agent-resolution.test.ts` to fix tests after the import change

## Test plan
- [x] All 10 existing `agent-resolution.test.ts` tests pass
- [x] Typecheck passes
- [x] Pre-commit hooks pass (lint, format)

🤖 Generated with [Claude Code](https://claude.com/claude-code)