### PR TITLE
fix(slack): ignore edited messages to prevent duplicate agent invocations

### DIFF
--- a/packages/agents-work-apps/src/__tests__/slack/dispatcher.test.ts
+++ b/packages/agents-work-apps/src/__tests__/slack/dispatcher.test.ts
@@ -99,6 +99,31 @@ describe('dispatchSlackEvent', () => {
       expect(options.registerBackgroundWork).not.toHaveBeenCalled();
     });
 
+    it('should ignore edited messages', async () => {
+      const span = createMockSpan();
+      const options = createMockOptions();
+
+      const result = await dispatchSlackEvent(
+        'event_callback',
+        {
+          team_id: 'T123',
+          event: {
+            type: 'app_mention',
+            user: 'U123',
+            channel: 'C123',
+            text: '<@U456> hello',
+            ts: '123.456',
+            edited: { user: 'U123', ts: '123.789' },
+          },
+        },
+        options,
+        span
+      );
+
+      expect(result.outcome).toBe('ignored_edited_message');
+      expect(options.registerBackgroundWork).not.toHaveBeenCalled();
+    });
+
     it('should handle app_mention events', async () => {
       const span = createMockSpan();
       const options = createMockOptions();

--- a/packages/agents-work-apps/src/slack/dispatcher.ts
+++ b/packages/agents-work-apps/src/slack/dispatcher.ts
@@ -48,6 +48,7 @@ export async function dispatchSlackEvent(
           thread_ts?: string;
           bot_id?: string;
           subtype?: string;
+          edited?: unknown;
         }
       | undefined;
 
@@ -65,6 +66,13 @@ export async function dispatchSlackEvent(
         { botId: event.bot_id, subtype: event?.subtype, teamId, innerEventType },
         'Ignoring bot message'
       );
+      return { outcome };
+    }
+
+    if (event?.edited) {
+      outcome = 'ignored_edited_message';
+      span.setAttribute(SLACK_SPAN_KEYS.OUTCOME, outcome);
+      logger.info({ teamId, innerEventType }, 'Ignoring edited message');
       return { outcome };
     }
 

--- a/packages/agents-work-apps/src/slack/tracer.ts
+++ b/packages/agents-work-apps/src/slack/tracer.ts
@@ -46,6 +46,7 @@ export const SLACK_SPAN_KEYS = {
 export type SlackOutcome =
   | 'handled'
   | 'ignored_bot_message'
+  | 'ignored_edited_message'
   | 'ignored_unknown_event'
   | 'ignored_no_action_match'
   | 'ignored_slack_retry'


### PR DESCRIPTION
## Summary
- When a user edits a Slack message containing an @mention, Slack re-sends an `app_mention` event with an `edited` field, causing the agent to respond a second time
- Adds an early-return filter in the dispatcher (right after the existing bot-message filter) that drops any event carrying `edited`
- Adds the `ignored_edited_message` outcome to telemetry so these are observable

## Test plan
- [x] New unit test: `should ignore edited messages` — verifies outcome is `ignored_edited_message` and no background work is registered
- [x] All 16 existing dispatcher tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)