### PR TITLE
ci: require CI, Create Agents E2E, and Cypress checks to merge to main

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -14,7 +14,8 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
-  ci:
+  cypress-e2e:
+    name: Cypress E2E Tests
     runs-on: ubuntu-32gb
     timeout-minutes: 30
 


### PR DESCRIPTION
## Summary
- Rename Cypress workflow job from `ci` to `cypress-e2e` (display name "Cypress E2E Tests") to avoid collision with CI workflow's `ci` job
- Enable branch protection on `main` with three required status checks: `ci`, `Create Agents E2E Tests`, and `Cypress E2E Tests`
- PRs can no longer merge to main without all three CI checks passing

## Test plan
- [ ] Verify this PR shows the renamed "Cypress E2E Tests" check (not "ci" from Cypress workflow)
- [ ] Verify CI / ci check still runs as expected
- [ ] Verify CI / Create Agents E2E Tests check still runs as expected
- [ ] After merge, confirm branch protection rules are active on main

🤖 Generated with [Claude Code](https://claude.com/claude-code)