### PR TITLE
fix(slack): prevent linking multiple workspaces to a single tenant

### DIFF
--- a/.changeset/wealthy-lavender-donkey.md
+++ b/.changeset/wealthy-lavender-donkey.md
@@ -1,0 +1,6 @@
+---
+"@inkeep/agents-work-apps": patch
+"@inkeep/agents-manage-ui": patch
+---
+
+Enforce single Slack workspace per tenant and improve error handling

--- a/agents-manage-ui/src/features/work-apps/slack/components/slack-dashboard.tsx
+++ b/agents-manage-ui/src/features/work-apps/slack/components/slack-dashboard.tsx
@@ -35,8 +35,10 @@ export function SlackDashboard() {
         toast.info('Slack installation was cancelled.');
       } else if (error === 'workspace_limit_reached') {
         toast.error(
-          'Only one Slack workspace can be connected per organization. Remove the existing workspace to connect a different one.'
+          'Only one Slack workspace can be connected per organization. Uninstall the existing workspace to connect a different one.'
         );
+      } else if (error === 'workspace_check_failed') {
+        toast.error('Could not verify workspace status. Please try again.');
       } else {
         console.error('Slack OAuth Error:', error);
         toast.error(`Slack installation failed: ${error}`);

--- a/packages/agents-work-apps/src/slack/routes/oauth.ts
+++ b/packages/agents-work-apps/src/slack/routes/oauth.ts
@@ -293,7 +293,15 @@ app.openapi(
       };
 
       if (tenantId && workspaceData.teamId) {
-        const existingWorkspaces = await listWorkAppSlackWorkspacesByTenant(runDbClient)(tenantId);
+        let existingWorkspaces: Awaited<
+          ReturnType<ReturnType<typeof listWorkAppSlackWorkspacesByTenant>>
+        >;
+        try {
+          existingWorkspaces = await listWorkAppSlackWorkspacesByTenant(runDbClient)(tenantId);
+        } catch (err) {
+          logger.error({ err, tenantId }, 'Failed to check existing workspaces');
+          return c.redirect(`${dashboardUrl}?error=workspace_check_failed`);
+        }
         const hasOtherWorkspace = existingWorkspaces.some(
           (w) => w.slackTeamId !== workspaceData.teamId
         );


### PR DESCRIPTION
## Summary
- Removes the "Add Workspace" button from the Slack integration dashboard in the manage UI
- Adds a guard in the OAuth callback (`/oauth_redirect`) that rejects installations when the tenant already has a *different* Slack workspace connected
- Re-installing the *same* workspace (re-auth/token refresh) continues to work
- Handles the new `workspace_limit_reached` error code in the UI with a clear toast message

## Context
The Slack work app doesn't support multiple workspaces per tenant today. The data model technically allowed it (unique constraint is on `(tenant_id, slack_team_id)`, not `tenant_id` alone), and the UI had an "Add Workspace" button. This could lead to undefined behavior since the dashboard only renders the first workspace.

## Design decisions
- **No DB migration** — enforced at the app layer only, so it's easy to lift when multi-workspace support ships
- **Guard is in `/oauth_redirect`, not `/install`** — the `/install` route is `noAuth()`, so checking there would leak whether a tenant has a workspace installed. The callback redirects errors to the authenticated manage UI.
- **Same-team re-install allowed** — the guard checks `slackTeamId !== workspaceData.teamId`, so re-authorizing the existing workspace still works

## Test plan
- [x] Verify "Add Workspace" button no longer appears when a workspace is already connected
- [x] Attempt to install a second (different) Slack workspace for the same tenant — should redirect with `workspace_limit_reached` error and display toast
- [x] Re-install the same workspace (re-auth) — should succeed as before
- [x] Verify direct navigation to `/install?tenant_id=X` still starts OAuth flow (no info leak)

🤖 Generated with [Claude Code](https://claude.com/claude-code)