### PR TITLE
chore(ci): add GitHub Actions to Dependabot and batch updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,8 +4,25 @@ updates:
     directory: '/'
     schedule:
       interval: 'weekly'
+    groups:
+      docker-compose:
+        patterns:
+          - '*'
 
   - package-ecosystem: 'docker-compose'
     directory: '/create-agents-template'
     schedule:
       interval: 'weekly'
+    groups:
+      docker-compose:
+        patterns:
+          - '*'
+
+  - package-ecosystem: 'github-actions'
+    directory: '/'
+    schedule:
+      interval: 'monthly'
+    groups:
+      github-actions:
+        patterns:
+          - '*'


### PR DESCRIPTION
## Summary
- Add a `github-actions` ecosystem entry to Dependabot with a monthly schedule so action versions are kept up to date
- Group all updates by ecosystem (`docker-compose` and `github-actions`) so each produces a single batched PR instead of one per dependency

## Test plan
- [ ] Verify Dependabot picks up the new config on the next scheduled run
- [ ] Confirm grouped PRs appear as single PRs per ecosystem/directory

Made with [Cursor](https://cursor.com)