### PR TITLE
test(create-agents): add content assertions to E2E config verification

### DIFF
--- a/packages/create-agents/src/__tests__/e2e/quickstart.test.ts
+++ b/packages/create-agents/src/__tests__/e2e/quickstart.test.ts
@@ -101,7 +101,14 @@ describe('create-agents quickstart e2e', () => {
 
     // Verify inkeep.config.ts was created
     console.log('Verifying inkeep.config.ts...');
-    await verifyFile(path.join(projectDir, 'src/inkeep.config.ts'));
+    await verifyFile(path.join(projectDir, 'src/inkeep.config.ts'), [
+      /defineConfig/,
+      /tenantId:/,
+      /agentsApi:/,
+      /apiKey:/,
+      /url:/,
+      /manageUiUrl:/,
+    ]);
     console.log('inkeep.config.ts verified');
 
     // Link to local monorepo packages (also runs pnpm install --no-frozen-lockfile)


### PR DESCRIPTION
## Summary
- The create-agents E2E test verified `inkeep.config.ts` existed but didn't check its contents
- Added regex patterns to `verifyFile()` call to verify critical fields (`defineConfig`, `tenantId`, `agentsApi`, `apiKey`, `url`, `manageUiUrl`) are present in the generated config
- Follows the same pattern already used for `.env` file verification on the lines above

## Test plan
- [x] `pnpm check` passes (only pre-existing `form.browser.test.tsx` flaky failure)
- [x] `pnpm --filter create-agents typecheck` passes
- [ ] Create Agents E2E CI workflow passes with the new assertions

🤖 Generated with [Claude Code](https://claude.com/claude-code)