### PR TITLE
Fix changeset version bump from minor to patch

### DIFF
--- a/.changeset/mid-pink-python.md
+++ b/.changeset/mid-pink-python.md
@@ -1,6 +1,6 @@
 ---
-"@inkeep/agents-work-apps": minor
-"@inkeep/agents-core": minor
+"@inkeep/agents-work-apps": patch
+"@inkeep/agents-core": patch
 ---
 
 Add public messaging for all Slack surfaces, DM support, and per-trigger conversation model


### PR DESCRIPTION
## Summary
- Changes `@inkeep/agents-work-apps` and `@inkeep/agents-core` changeset version bump from `minor` to `patch` in `mid-pink-python.md`

## Test plan
- [x] Verified changeset file has correct `patch` version

🤖 Generated with [Claude Code](https://claude.com/claude-code)