### PR TITLE
Add audience-impact skill for blast-radius analysis by persona

### DIFF
--- a/.agents/skills/audience-impact/SKILL.md
+++ b/.agents/skills/audience-impact/SKILL.md
@@ -1,0 +1,115 @@
+---
+name: audience-impact
+description: |
+  Who does this change affect and how does it reach them? Maps audiences (roles × deployment modes) to impact propagation — immediate, next-publish, next-deploy, or silent.
+  Use when planning, implementing, or reviewing a change to understand blast radius by audience.
+  Complements product-surface-areas and internal-surface-areas (which catalog what exists; this skill tells you who cares).
+  Triggers: who is affected, blast radius, breaking change, audience, persona, impact analysis, changeset needed, docs needed.
+---
+
+# Audience Impact
+
+When assessing a change, ask: **who is on the other end, and how fast does this reach them?**
+
+This skill provides a mental model — not an exhaustive ledger. Use it to reason about which audiences a change affects, then load the catalog skills for detailed surface tracing when needed.
+
+## How to use this skill
+
+1. Identify which **roles** and **deployment modes** the change touches (see definitions below)
+2. Look up the change type in the **impact propagation table** to see how fast and how visibly it reaches each audience
+3. Flag any **silent** impacts explicitly — these slip through review most often
+4. If deeper surface tracing is needed, **Load:** `product-surface-areas` (customer-facing) or `internal-surface-areas` (internal subsystems)
+5. Use the **deliverables table** to determine what artifacts the change needs (changeset, docs, migration guide, etc.)
+
+When multiple audiences are affected, address them in pipeline order: immediate impacts first (Contributor), then versioned impacts (Builder — changeset + migration guide), then deployed impacts (Platform User — QA), then infrastructure (Self-hosted — docs). This matches the natural merge → publish → deploy sequence.
+
+## Two-axis model
+
+Audiences decompose into two independent axes:
+
+**Role** — who is the person?
+**Deployment mode** — where does the system run?
+
+These are orthogonal. A Builder can be cloud or self-hosted. A Platform User can be cloud or self-hosted. Assess each axis independently.
+
+## Roles
+
+### Contributor
+Develops the framework source code. Clones the repo, runs `pnpm setup-dev`, writes and tests code, submits PRs. They interact with build tooling, CI/CD, test infrastructure, database migrations, git hooks, changesets, and dev scripts. Changes to internal tooling, schemas, or dev workflows reach them **immediately** — they're working in the repo.
+
+Representative surfaces: turbo/biome config, vitest setup, drizzle migration workflow, GitHub Actions, pre-commit hooks, `.agents/skills/`, AGENTS.md.
+
+### Builder
+Builds agents using published packages. Runs `npx create-agents`, installs `@inkeep/agents-sdk` and related packages, codes against the SDK builder API, uses the CLI (`inkeep push/pull/dev`), reads docs, and references cookbook templates. They interact with published npm contracts, TypeScript types, config file schemas (`inkeep.config.ts`), API endpoints, and documentation. Changes reach them **at the next npm publish or docs deploy** — there's a version boundary between their code and ours.
+
+Representative surfaces: SDK builder functions (`agent()`, `project()`, `functionTool()`), CLI commands and flags, `defineConfig()` schema, published type exports, AI SDK provider, MCP package, OpenAI-compatible chat API, cookbook templates, agents-docs content.
+
+### Platform User
+Configures agents through the visual builder (manage-ui) without writing code. Creates projects, configures agents and tools via forms, manages API keys, sets up integrations (Slack, GitHub), views traces, runs evaluations, and manages team members and roles. Changes reach them **at the next UI deploy** — they see whatever the dashboard ships.
+
+Representative surfaces: agent builder canvas, project/agent/tool/credential forms, API key management, traces dashboard, evaluation UI, work-app integration setup, member/role management, login and onboarding flows.
+
+## Deployment modes
+
+### Cloud
+Uses Inkeep's hosted platform. Auth via SSO/Auth0, credentials managed through Nango-hosted OAuth, services deployed on Vercel. No infrastructure to manage. The `PUBLIC_IS_INKEEP_CLOUD_DEPLOYMENT` flag gates cloud-specific behavior.
+
+Representative surfaces: Auth0/SSO config, Nango-hosted OAuth flows, Vercel deployment pipeline, cloud onboarding/invitation flows, hosted API URLs.
+
+### Self-hosted
+Deploys via Docker on own infrastructure. Manages databases (Doltgres, Postgres, SpiceDB), env vars (60+), auth setup (Better Auth, JWT keys), observability (OTEL/SigNoz), and applies migrations. Changes to infrastructure config, Docker setup, or env var schemas affect self-hosters directly — they must act on them.
+
+Representative surfaces: `docker-compose.yml`, `.env.example`, database migration scripts, SpiceDB schema, OTEL exporter config, deployment docs (AWS/Azure/GCP/Hetzner guides).
+
+Self-hosted is a **modifier** — it adds infrastructure surfaces on top of whatever role the person has. A self-hosted Builder manages both SDK integration *and* Docker deployment. A self-hosted Platform User manages both the dashboard *and* the underlying infrastructure.
+
+## Impact propagation
+
+This is the primary decision aid. Given a change, how fast and how visibly does it reach each audience?
+
+| Change type | Contributor | Builder | Platform User | Self-hosted modifier |
+|---|---|---|---|---|
+| Internal tooling (biome, turbo, CI, test infra) | Immediate | None | None | None |
+| Database schema (`manage-schema.ts`, `runtime-schema.ts`) | Immediate (run `db:migrate`) | Next publish (if types change) | Next deploy (if UI affected) | Must run migrations |
+| SDK/core API (exports, types, builder signatures) | Immediate (tests break) | **Next publish — potentially breaking** | Transitive (if UI consumes affected API) | Transitive (if UI consumes affected API) |
+| CLI commands or config schema | None | **Next publish — potentially breaking** | None | None |
+| Manage UI (pages, forms, components) | None | None | **Next deploy — visible immediately** | Next deploy |
+| API routes or response shapes | Immediate (snapshot tests) | **Next publish — potentially breaking** | Next deploy (if UI consumes it) | Next deploy |
+| Validation schemas (Zod rules, allowed values, defaults) | Immediate (tests) | **Silent — previously valid input rejected** | **Silent — forms may fail unexpectedly** | **Silent — API calls may fail** |
+| Docker/env config | Immediate (local dev) | None | None | **Immediate — must reconfigure** |
+| Env var semantics (same name, changed meaning/format) | Immediate (local dev) | None | None | **Silent — system may behave incorrectly** |
+| Documentation content | None | **Next docs deploy — may mislead** | Next docs deploy | Next docs deploy |
+| Auth/permissions (RBAC, cookies, tokens) | Immediate (tests) | Next publish (if SDK auth changes) | **Next deploy — login/access may break** | Must update auth config |
+| Telemetry contracts (span names, OTEL attributes) | Immediate (if tests assert spans) | None | None | **Silent — dashboards/alerts may break** |
+| Trigger/webhook contracts (schemas, signatures, payloads) | Immediate (tests) | **Next publish — potentially breaking** | **Next deploy — trigger config may break** | Next deploy |
+
+**Impact latency key:**
+- **Immediate**: affects them in their current working session
+- **Next publish**: affects them when they `npm update` — version boundary provides a buffer
+- **Next deploy**: affects them when the UI/API redeploys — no version boundary, but there's a deploy gate
+- **Transitive**: not directly affected, but may be affected if a downstream surface they use consumes the changed surface
+- **Silent**: affects them without obvious signal — **most dangerous**. The system appears to work but behaves incorrectly (e.g., a validation change that silently rejects previously valid input, a telemetry contract change that breaks downstream dashboards)
+
+## What counts as "breaking" per role
+
+- **Contributor**: CI fails, tests break, dev setup stops working. Loud and immediate — usually caught before merge.
+- **Builder**: Published API changes (removed exports, changed type shapes, new required config fields, altered CLI flags). Versioned via semver + changesets, but breaking changes in patch versions are especially harmful.
+- **Platform User**: UI behavior changes (forms that worked differently, removed features, changed navigation). No version boundary — they experience it the moment it deploys.
+- **Self-hosted**: Infrastructure contract changes (new required env vars, changed Docker config, new database migration steps). Silent if not documented — the system may appear to work but behave incorrectly.
+
+## Deeper surface tracing
+
+This skill tells you **who cares**. For detailed surface enumeration, load the catalog skills:
+
+- **Load:** `product-surface-areas` — customer-facing surfaces (APIs, SDKs, CLI, UI, docs, templates). Maps primarily to Builder and Platform User roles.
+- **Load:** `internal-surface-areas` — internal subsystems (build, CI, test, DB, auth, runtime). Maps primarily to Contributor role and the self-hosted modifier.
+
+## Deciding what deliverables a change needs
+
+| Affected audience | Likely deliverables |
+|---|---|
+| Contributor | Update/add tests. Update AGENTS.md if workflow changes. Update skills if conventions change. |
+| Builder | Changeset (semver). Docs update. Migration guide if breaking. |
+| Platform User | QA the UI change. Update visual-builder docs if behavior changes. |
+| Self-hosted | Update `.env.example`. Update deployment docs. Migration guide if infra changes. |
+| Cloud-only | Verify feature flag gating. Update cloud-specific onboarding if affected. |

--- a/.agents/skills/internal-surface-areas/SKILL.md
+++ b/.agents/skills/internal-surface-areas/SKILL.md
@@ -11,6 +11,8 @@ description: |
 ## Overview
 This is a consolidated inventory of internal “surface areas”: subsystems, infrastructure, tooling, and shared code that developers/operators interact with, but which are not directly customer-facing contracts. Use it during planning or PR review to understand internal dependency chains (what breaks when X changes) and to avoid accidental workflow/build/test/deploy regressions.
 
+**Companion skills:** For *who* is affected and how changes propagate per audience, load `audience-impact`. For customer-facing surfaces, load `product-surface-areas`.
+
 ## Summary
 
 | Category | Count |

--- a/.agents/skills/product-surface-areas/SKILL.md
+++ b/.agents/skills/product-surface-areas/SKILL.md
@@ -9,6 +9,8 @@ description: |
 ## Overview
 This is a consolidated inventory of customer-facing “surface areas”: anything a customer can directly use, interact with, or take a dependency on. Use it to conceptually understand the surface area of what one change may mean for the whole product (i.e. the entire feature dependency tree/propagation chain end-to-end).
 
+**Companion skills:** For *who* is affected and how changes propagate per audience, load `audience-impact`. For internal/infra surfaces, load `internal-surface-areas`.
+
 ## Summary
 
 | Category | Count |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -222,10 +222,11 @@ This product has **50+ customer-facing** and **100+ internal tooling/devops** su
 
 | Skill | Scope | Load when |
 |---|---|---|
+| `audience-impact` | Who is affected and how fast does it reach them? Maps roles (Contributor, Builder, Platform User) × deployment modes (Cloud, Self-hosted) to impact propagation. | Start here — identifies which audiences a change affects and what deliverables are needed |
 | `product-surface-areas` | APIs, SDKs, CLI, UIs, Widgets, Event Streams, docs, protocols, templates, etc. | Change affects anything a customer (developer or no-code admin) uses or depends on |
 | `internal-surface-areas` | Build, CI/CD, DB, auth, runtime engine, test infra, internal AI tooling, etc. | Change affects infrastructure, tooling, or shared internals |
 
-**Tip**: Both skills include dependency graphs, breaking change impact matrices, and transitive chain tracing for systematically identifying relevant surfaces and code paths that may be affected by changes.
+**Tip**: Start with `audience-impact` to quickly identify who cares and how changes propagate, then load the catalog skills for detailed surface tracing. Both catalog skills include dependency graphs, breaking change impact matrices, and transitive chain tracing.
 
 ## Development Guidelines
 


### PR DESCRIPTION
## Summary

Adds a new `audience-impact` skill that helps agents reason about which audiences are affected by a change and how fast the impact reaches them. This complements the existing `product-surface-areas` and `internal-surface-areas` skills — those catalog *what exists*; this skill tells you *who cares*.

## Architectural decisions

**Two-axis audience model instead of flat persona list.** Audiences are modeled as 3 roles (Contributor, Builder, Platform User) × 2 deployment modes (Cloud, Self-hosted). This captures the same information as 5+ flat personas with less redundancy — deployment mode is a modifier, not a separate persona. A self-hosted Builder manages both SDK integration *and* Docker deployment.

**Mental model, not exhaustive ledger.** The skill uses narrative role descriptions with representative surface examples rather than per-surface persona tags. This avoids staleness (categories are stable even as individual surfaces change) and keeps the skill compact (~115 lines). Agents load the catalog skills for detailed enumeration when needed.

**Impact propagation table as primary decision aid.** A 14-row × 4-column table maps change types to impact latency per audience (Immediate / Next-publish / Next-deploy / Transitive / Silent). The "Silent" category — where the system appears to work but behaves incorrectly — is explicitly called out as the most dangerous.

## Changes

- **New skill:** `.agents/skills/audience-impact/SKILL.md` — single-file skill (Pattern 1) with:
  - Two-axis model (roles × deployment modes)
  - 3 role definitions (Contributor, Builder, Platform User) with representative surfaces
  - 2 deployment mode definitions (Cloud, Self-hosted)
  - Impact propagation table (14 change types × 5 latency levels)
  - "What counts as breaking" per role
  - Deliverables table (what artifacts each audience needs)
  - Load callouts to catalog skills for deeper tracing
- **AGENTS.md:** Added `audience-impact` as first row in surface area skills table with "Start here" guidance; updated tip text
- **product-surface-areas/SKILL.md:** Added companion skills cross-reference in Overview
- **internal-surface-areas/SKILL.md:** Added companion skills cross-reference in Overview

## How to verify

1. Load the skill: ask an agent "who is affected by a change to the Zod validation schema?"
2. Verify the agent uses the impact propagation table to identify Silent impacts for Builder, Platform User, and Self-hosted audiences
3. Verify the agent suggests loading catalog skills for detailed surface enumeration
4. Check that AGENTS.md surface area table renders correctly with the new first row

---

Generated with [Claude Code](https://claude.com/claude-code)