### PR TITLE
fix(ci): tolerate already-promoted Vercel deployments

### DIFF
--- a/.github/workflows/vercel-production.yml
+++ b/.github/workflows/vercel-production.yml
@@ -2,9 +2,9 @@ name: Deploy to Vercel Production
 
 # This workflow deploys to Vercel production when a GitHub release is published,
 # or manually via workflow_dispatch (deploys latest main).
-# 1. Deploy both projects to production (builds with production env vars, creates staged deployments)
+# 1. Deploy both projects with --prod (builds with production env vars, may auto-promote)
 # 2. Wait for Vercel deployment checks to pass (configured in Vercel dashboard)
-# 3. Once BOTH projects pass checks, promote both to current production
+# 3. Explicitly promote both to current production (tolerates already-promoted deployments)
 #
 # Required secrets (configure in GitHub Repository Settings > Secrets):
 # - VERCEL_TOKEN: API token from Vercel Dashboard > Settings > Tokens
@@ -107,9 +107,23 @@ jobs:
       - name: Promote agents-api
         run: |
           echo "Promoting agents-api to production..."
-          vercel promote ${{ needs.deploy-agents-api.outputs.url }} --token=${{ secrets.VERCEL_TOKEN }} --scope=${{ secrets.VERCEL_ORG_ID }}
+          if ! OUTPUT=$(vercel promote ${{ needs.deploy-agents-api.outputs.url }} --token=${{ secrets.VERCEL_TOKEN }} --scope=${{ secrets.VERCEL_ORG_ID }} 2>&1); then
+            if echo "$OUTPUT" | grep -q "already the current production deployment"; then
+              echo "::warning::agents-api deployment is already the current production deployment, skipping promote"
+            else
+              echo "$OUTPUT"
+              exit 1
+            fi
+          fi
 
       - name: Promote agents-manage-ui
         run: |
           echo "Promoting agents-manage-ui to production..."
-          vercel promote ${{ needs.deploy-agents-manage-ui.outputs.url }} --token=${{ secrets.VERCEL_TOKEN }} --scope=${{ secrets.VERCEL_ORG_ID }}
+          if ! OUTPUT=$(vercel promote ${{ needs.deploy-agents-manage-ui.outputs.url }} --token=${{ secrets.VERCEL_TOKEN }} --scope=${{ secrets.VERCEL_ORG_ID }} 2>&1); then
+            if echo "$OUTPUT" | grep -q "already the current production deployment"; then
+              echo "::warning::agents-manage-ui deployment is already the current production deployment, skipping promote"
+            else
+              echo "$OUTPUT"
+              exit 1
+            fi
+          fi


### PR DESCRIPTION
## Summary
- The `vercel deploy --prod` command auto-promotes deployments, so the explicit `vercel promote` step in the "Promote all to production" job can fail with a 409 "already the current production deployment" error
- This caused [this run](https://github.com/inkeep/agents/actions/runs/22403360433) to fail, also blocking `agents-manage-ui` from being promoted
- The promote steps now emit a GitHub Actions warning annotation instead of failing when the deployment is already live, while still failing on real errors

## Test plan
- [ ] Verify next Vercel production deploy workflow completes without failure
- [ ] Check that the warning annotation appears in the job logs when auto-promotion occurs

🤖 Generated with [Claude Code](https://claude.com/claude-code)