### PR TITLE
fix(agents-core): bump JWT TTL from 5m to 1h for delegation tokens

### DIFF
--- a/.changeset/sheer-salmon-sheep.md
+++ b/.changeset/sheer-salmon-sheep.md
@@ -1,0 +1,5 @@
+---
+"@inkeep/agents-core": patch
+---
+
+Bump Slack user token and A2A service token TTL from 5 minutes to 1 hour to prevent 401 failures during long-running agent delegations

--- a/packages/agents-core/src/__tests__/utils/team-agent-auth.test.ts
+++ b/packages/agents-core/src/__tests__/utils/team-agent-auth.test.ts
@@ -45,7 +45,7 @@ describe('Team Agent Authentication', () => {
       expect(token1).not.toBe(token2);
     });
 
-    it('should generate tokens that expire in 5 minutes', async () => {
+    it('should generate tokens that expire in 1 hour', async () => {
       const beforeGeneration = Math.floor(Date.now() / 1000);
       const token = await generateServiceToken(mockParams);
       const result = await verifyServiceToken(token);
@@ -55,9 +55,9 @@ describe('Team Agent Authentication', () => {
 
       if (result.payload) {
         const expiryTime = result.payload.exp - result.payload.iat;
-        expect(expiryTime).toBe(300); // 5 minutes = 300 seconds
+        expect(expiryTime).toBe(3600); // 1 hour = 3600 seconds
         expect(result.payload.exp).toBeGreaterThan(beforeGeneration);
-        expect(result.payload.exp).toBeLessThanOrEqual(beforeGeneration + 301); // Allow 1 second tolerance
+        expect(result.payload.exp).toBeLessThanOrEqual(beforeGeneration + 3601); // Allow 1 second tolerance
       }
     });
   });

--- a/packages/agents-core/src/utils/service-token-auth.ts
+++ b/packages/agents-core/src/utils/service-token-auth.ts
@@ -42,7 +42,7 @@ export type VerifyServiceTokenResult = JwtVerifyResult<ServiceTokenPayload>;
 
 /**
  * Generate a JWT token for agent-to-agent authentication.
- * Token expires in 5 minutes.
+ * Token expires in 1 hour.
  */
 export async function generateServiceToken(params: GenerateServiceTokenParams): Promise<string> {
   try {
@@ -50,7 +50,7 @@ export async function generateServiceToken(params: GenerateServiceTokenParams): 
       issuer: ISSUER,
       subject: params.originAgentId,
       audience: params.targetAgentId,
-      expiresIn: '5m',
+      expiresIn: '1h',
       claims: {
         tenantId: params.tenantId,
         projectId: params.projectId,

--- a/packages/agents-core/src/utils/slack-user-token.ts
+++ b/packages/agents-core/src/utils/slack-user-token.ts
@@ -8,7 +8,7 @@ const ISSUER = 'inkeep-auth';
 const AUDIENCE = 'inkeep-api';
 const TOKEN_USE = 'slackUser';
 const ACTOR_SUB = 'inkeep-work-app-slack';
-const TOKEN_TTL = '5m';
+const TOKEN_TTL = '1h';
 
 /**
  * Zod schema for validating Slack user access token JWT payload.


### PR DESCRIPTION
## Summary

- Bump Slack user JWT TTL from 5 minutes to 1 hour (`slack-user-token.ts`)
- Bump A2A service token TTL from 5 minutes to 1 hour (`service-token-auth.ts`)
- Update test assertion in `team-agent-auth.test.ts` to match new 1h expiry

**Linear:** [PRD-6133](https://linear.app/inkeep/issue/PRD-6133/hotfix-bump-jwt-ttl-from-5m-to-1h-to-prevent-delegation-auth-failures) (hotfix) — mitigates [PRD-6132](https://linear.app/inkeep/issue/PRD-6132/fix-internal-delegation-uses-expired-jwt-after-long-running) (root cause)

## Context

Internal sub-agent delegation fails with `401` when the original JWT expires during long-running agent generations. Observed in production: a Slack-triggered Docs Writer agent completed two delegations within 5 minutes, but the third delegation (after context compression) failed because the Slack user JWT had expired. The token was issued at 20:50:29 and expired at 20:55:29 — the first failed delegation attempt was at 20:55:35, just 6 seconds late.

This is a **band-aid fix**. The proper solution (PRD-6132) is to generate fresh service tokens at delegation time rather than reusing the original JWT from request start. Bumping the TTL to 1 hour is safe because:

- Both tokens are scoped (tenant, project, agent) and travel only via `getInProcessFetch()` — they never leave the process boundary
- The dashboard temp JWT already uses a 1-hour TTL, so this aligns with existing precedent

## Test plan

- [x] `team-agent-auth.test.ts` — 25 tests pass (updated expiry assertion from 300s to 3600s)
- [x] `slack-user-token.test.ts` — 26 tests pass (no assertion changes needed)
- [ ] Verify Slack-triggered agent with 3+ delegations completes without 401

🤖 Generated with [Claude Code](https://claude.com/claude-code)