### PR TITLE
Upgrade actions/stale from v9 to v10

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -3,7 +3,7 @@ name: Mark stale pull requests
 on:
   schedule:
     # Run daily at midnight UTC
-    - cron: '0 0 * * *'
+    - cron: "0 0 * * *"
   workflow_dispatch:
     # Allow manual triggering for testing
 
@@ -15,78 +15,40 @@ permissions:
 jobs:
   stale:
     runs-on: ubuntu-latest
-    
+
     steps:
       - name: Mark stale pull requests
-        uses: actions/stale@v9
+        uses: actions/stale@v10
         with:
-          # Configuration for pull requests
           stale-pr-message: |
             This pull request has been automatically marked as stale because it has not had recent activity. 
             It will be closed in 7 days if no further activity occurs.
-            
+
             If this PR is still relevant:
             - Rebase it on the latest main branch
             - Add a comment explaining its current status
             - Request a review if it's ready
-            
+
             Thank you for your contributions!
-          
+
           close-pr-message: |
             This pull request has been automatically closed due to inactivity.
-            
+
             If you'd like to continue working on this, please:
             1. Create a new branch from the latest main
             2. Cherry-pick your commits or rebase your changes
             3. Open a new pull request
-            
+
             Thank you for your understanding!
-          
-          # Number of days of inactivity before marking PR as stale
-          days-before-pr-stale: 30
-          
-          # Number of days after stale label before closing PR
+
+          days-before-pr-stale: 7
           days-before-pr-close: 7
-          
-          # Label to use when marking PR as stale
-          stale-pr-label: 'stale'
-          
-          # Labels that prevent marking as stale
-          exempt-pr-labels: 'pinned,security,work-in-progress'
-          
-          # Exempt draft PRs from being marked as stale
+          stale-pr-label: "stale"
+          exempt-pr-labels: "pinned,security,work-in-progress"
           exempt-draft-pr: true
-          
-          # Remove stale label when PR is updated
-          remove-stale-when-updated: true
-          
-          # Delete branch after closing stale PR
+          exempt-all-pr-assignees: true
           delete-branch: true
-          
-          # Limit the number of operations per run to prevent hitting API rate limits
-          operations-per-run: 30
-          
-          # Enable debug logs to see what the action is doing
-          debug-only: false
-          
-          # Don't process issues, only pull requests
+          sort-by: "updated"
+
           days-before-issue-stale: -1
           days-before-issue-close: -1
-          
-          # Order to process PRs (false = oldest first, true = newest first)
-          ascending: false
-          
-          # Labels to add when PR becomes stale
-          labels-to-add-when-unstale: ''
-          
-          # Labels to remove when PR becomes stale
-          labels-to-remove-when-stale: ''
-          
-          # Enable statistics at the end of the run
-          enable-statistics: true
-          
-          # Ignore PRs with assignees (false = process all PRs)
-          ignore-pr-updates: false
-          
-          # Exempt all PRs with milestones from being marked as stale
-          exempt-all-pr-milestones: false


### PR DESCRIPTION
## Summary
- Upgrade `actions/stale` from v9 to v10 (Node 24 runtime, security/dependency updates)
- **Tighten staleness policy:** reduce `days-before-pr-stale` from 30 → 7 days. Combined with the existing 7-day close window (`days-before-pr-close`), PRs will now auto-close after **14 days** of inactivity instead of 37. This is intentional — the previous window was too generous.
- Add `exempt-all-pr-assignees: true` so PRs with an assignee aren't marked stale
- Add `sort-by: updated` to prioritize the longest-idle PRs first
- Remove 9 parameters that were restating their default values, cutting the file from 92 to 55 lines

## Test plan
- [ ] Verify workflow syntax is valid (GitHub will flag on push if not)
- [ ] Trigger manually via `workflow_dispatch` and confirm the run succeeds
- [ ] Confirm assigned PRs are skipped and unassigned stale PRs are still processed

Made with [Cursor](https://cursor.com)
<!-- PULLFROG_DIVIDER_DO_NOT_REMOVE_PLZ -->
<sup><a href="https://pullfrog.com"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pullfrog.com/logos/frog-white-full-18px.png"><img src="https://pullfrog.com/logos/frog-green-full-18px.png" width="9px" height="9px" style="vertical-align: middle; " alt="Pullfrog"></picture></a>&nbsp;&nbsp;｜ [View workflow run](https://github.com/inkeep/agents/actions/runs/22431077331/job/64949916734) ｜ Using [Claude Code](https://claude.com/claude-code) ｜ Triggered by [Pullfrog](https://pullfrog.com) ｜ [pullfrog.com](https://pullfrog.com) ｜ [𝕏](https://x.com/pullfrogai)</sup>