### PR TITLE
feat: inject x-api-key header for Composio MCP servers

### DIFF
--- a/.changeset/hot-clocks-invite.md
+++ b/.changeset/hot-clocks-invite.md
@@ -1,0 +1,6 @@
+---
+"@inkeep/agents-core": patch
+"@inkeep/agents-api": patch
+---
+
+update composio mcp servers with api key header

--- a/agents-api/src/domains/run/agents/Agent.ts
+++ b/agents-api/src/domains/run/agents/Agent.ts
@@ -3,9 +3,9 @@ import {
   type AgentConversationHistoryConfig,
   type Artifact,
   type ArtifactComponentApiInsert,
-  buildComposioMCPUrl,
   type CredentialStoreRegistry,
   CredentialStuffer,
+  configureComposioMCPServer,
   createMessage,
   type DataComponentApiInsert,
   type DataPart,
@@ -1283,16 +1283,14 @@ export class Agent {
       };
     }
 
-    // Inject user_id for Composio servers at runtime
-    if (serverConfig.url) {
-      serverConfig.url = buildComposioMCPUrl(
-        serverConfig.url.toString(),
-        this.config.tenantId,
-        this.config.projectId,
-        isUserScoped ? 'user' : 'project',
-        userId
-      );
-    }
+    // Inject user_id and x-api-key for Composio servers at runtime
+    configureComposioMCPServer(
+      serverConfig,
+      this.config.tenantId,
+      this.config.projectId,
+      isUserScoped ? 'user' : 'project',
+      userId
+    );
 
     // Merge forwarded headers (user session auth) into server config
     if (this.config.forwardedHeaders && Object.keys(this.config.forwardedHeaders).length > 0) {

--- a/packages/agents-core/src/data-access/manage/tools.ts
+++ b/packages/agents-core/src/data-access/manage/tools.ts
@@ -24,7 +24,7 @@ import {
   type ToolUpdate,
 } from '../../types/index';
 import {
-  buildComposioMCPUrl,
+  configureComposioMCPServer,
   detectAuthenticationRequired,
   getCredentialStoreLookupKeyFromRetrievalParams,
   isThirdPartyMCPServerAuthenticated,
@@ -209,16 +209,14 @@ const discoverToolsFromServer = async (
       }
     }
 
-    // Inject user_id for Composio servers at discovery time
-    if (serverConfig.url) {
-      serverConfig.url = buildComposioMCPUrl(
-        serverConfig.url.toString(),
-        tool.tenantId,
-        tool.projectId,
-        tool.credentialScope === 'user' ? 'user' : 'project',
-        userId
-      );
-    }
+    // Inject user_id and x-api-key for Composio servers at discovery time
+    configureComposioMCPServer(
+      serverConfig,
+      tool.tenantId,
+      tool.projectId,
+      tool.credentialScope === 'user' ? 'user' : 'project',
+      userId
+    );
 
     if (isGithubWorkAppTool(tool)) {
       serverConfig.headers = {


### PR DESCRIPTION
## Summary

Refactors `buildComposioMCPUrl` into `configureComposioMCPServer` so it configures the full `serverConfig` — both URL and headers — in one shot.

### Changes

- **Renamed** `buildComposioMCPUrl` → `configureComposioMCPServer`
- **Injects `x-api-key` header** from `COMPOSIO_API_KEY` env var into `serverConfig.headers`
- **Injects `user_id`** query param into the URL (existing behavior, unchanged)
- **No-ops** for non-Composio URLs

### Why

Composio has a setting to require `x-api-key` for MCP server authentication. Our Composio MCP servers don't have `credentialReferences` attached, so the API key needs to come directly from the env var. Previously we only injected `user_id` into the URL; now we also inject the auth header.

### Files changed

- `packages/agents-core/src/utils/third-party-mcp-servers/composio-client.ts` — core refactor
- `agents-api/src/domains/run/agents/Agent.ts` — updated call site (runtime)
- `packages/agents-core/src/data-access/manage/tools.ts` — updated call site (discovery)