### PR TITLE
Fix no-default-agent warning copy in Slack modal

### DIFF
--- a/agents-manage-ui/src/features/work-apps/slack/components/agent-configuration-card/index.tsx
+++ b/agents-manage-ui/src/features/work-apps/slack/components/agent-configuration-card/index.tsx
@@ -486,10 +486,10 @@ export function AgentConfigurationCard() {
           {!defaultAgent && channels.length > 0 && (
             <Alert variant="warning">
               <AlertTriangle className="h-4 w-4" />
-              <AlertTitle>No default agent set</AlertTitle>
+              <AlertTitle>No default agent set for your workspace</AlertTitle>
               <AlertDescription>
-                Channels using the workspace default won&apos;t respond to @Inkeep mentions or
-                /inkeep commands.
+                Unless you configure a default agent for a channel, it won&apos;t respond to @Inkeep
+                mentions or /inkeep commands.
               </AlertDescription>
             </Alert>
           )}


### PR DESCRIPTION
## Summary
- Updates the alert title from "No default agent set" to "No default agent set for your workspace"
- Updates the alert description to "Unless you configure a default agent for a channel, it won't respond to @Inkeep mentions or /inkeep commands."

## Test plan
- [ ] Open the Slack workspace configuration page with no default agent set
- [ ] Verify the warning alert shows the updated title and description

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes PRD-6198