### PR TITLE
fix: scope pr-review bot comment filter to claude[bot] only

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -314,7 +314,7 @@ jobs:
           CLAUDE_COMMENTS=$(echo "$THREADS" | jq -r '
             [.[]
               | select((.comments.nodes | length) > 0)
-              | select((.comments.nodes[0].author.__typename // "") == "Bot")
+              | select((.comments.nodes[0].author.login // "") == "claude[bot]")
             ] |
             sort_by(.comments.nodes[-1].createdAt) | reverse |
             if length == 0 then


### PR DESCRIPTION
## Summary
- Changes the jq filter in `claude-code-review.yml` from `__typename == "Bot"` to `login == "claude[bot]"` so only claude[bot]'s own prior threads are classified as "Automated Review Comments" (the dedup/don't-re-raise bucket)
- Other bot threads (e.g. `pullfrog[bot]`) are now excluded from both sections — the reviewer no longer sees them at all

## Context
Discovered via [PR #2412](https://github.com/inkeep/agents/pull/2412#pullrequestreview-3862702967) — Pull Frog flagged security issues (path traversal, missing auth), and while Claude's reviewer *did* reference them ("prior review already flagged..."), the classification was wrong: Pull Frog findings were in the "Automated Review Comments" section with the instruction "Do NOT re-raise, re-enumerate, or repeat any issue that appears below." This meant they could influence the reviewer's judgment or be regurgitated.

## Test plan
- [ ] Verify `claude[bot]`'s own prior review threads still appear under "Automated Review Comments" and are properly dedup'd
- [ ] Verify other bot threads (e.g. `pullfrog[bot]`) do not appear in either "Automated Review Comments" or "Human Review Comments"
- [ ] Verify PRs with no bot comments still show "_None — this is the first review run._"

🤖 Generated with [Claude Code](https://claude.com/claude-code)