### PR TITLE
Fix project permissions to use toSpiceDbProjectId for SpiceDB resource ID

### DIFF
--- a/agents-api/src/domains/manage/routes/projectPermissions.ts
+++ b/agents-api/src/domains/manage/routes/projectPermissions.ts
@@ -7,6 +7,7 @@ import {
   OrgRoles,
   SpiceDbProjectPermissions,
   SpiceDbResourceTypes,
+  toSpiceDbProjectId,
 } from '@inkeep/agents-core';
 import { createProtectedRoute } from '@inkeep/agents-core/middleware';
 import { requireProjectPermission } from '../../../middleware/projectAccess';
@@ -54,7 +55,7 @@ app.openapi(
     },
   }),
   async (c) => {
-    const { projectId } = c.req.valid('param');
+    const { projectId, tenantId } = c.req.valid('param');
     const userId = c.get('userId');
     const tenantRole = c.get('tenantRole') as OrgRole;
     const isTestEnvironment = process.env.ENVIRONMENT === 'test';
@@ -87,10 +88,12 @@ app.openapi(
       });
     }
 
+    const spiceProjectId = toSpiceDbProjectId(tenantId, projectId);
+
     // Use bulk permission check - single gRPC call for all permissions
     const permissions = await checkBulkPermissions({
       resourceType: SpiceDbResourceTypes.PROJECT,
-      resourceId: projectId,
+      resourceId: spiceProjectId,
       permissions: [
         SpiceDbProjectPermissions.VIEW,
         SpiceDbProjectPermissions.USE,


### PR DESCRIPTION
Uses `toSpiceDbProjectId(tenantId, projectId)` instead of passing raw `projectId` to SpiceDB bulk permission checks in the project permissions route. This ensures the resource ID is correctly formatted for SpiceDB lookups.

### Changes
- Import `toSpiceDbProjectId` from `@inkeep/agents-core`
- Destructure `tenantId` from request params
- Use `toSpiceDbProjectId(tenantId, projectId)` as the SpiceDB resource ID