### PR TITLE
ci: add Docker image build & publish to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,6 +23,9 @@ jobs:
   release:
     name: Release
     runs-on: ubuntu-latest
+    outputs:
+      published: ${{ steps.changesets.outputs.published }}
+      version: ${{ steps.extract-version.outputs.version }}
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -65,6 +68,13 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           HUSKY: 0
+
+      - name: Extract version
+        id: extract-version
+        if: steps.changesets.outputs.published == 'true'
+        run: |
+          VERSION=$(echo '${{ steps.changesets.outputs.publishedPackages }}' | jq -r '.[0].version')
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
 
       - name: Release to snapshot tag
         if: steps.changesets.outputs.published != 'true'
@@ -115,3 +125,79 @@ jobs:
             --notes "$CHANGELOG"
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+
+  docker-publish:
+    name: Docker Publish (${{ matrix.image }})
+    needs: release
+    if: needs.release.outputs.published == 'true'
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        image:
+          - agents-api
+          - agents-manage-ui
+          - agents-migrate
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: create-agents-template
+          file: create-agents-template/Dockerfile.${{ matrix.image }}
+          push: true
+          platforms: linux/amd64,linux/arm64
+          tags: |
+            inkeep/${{ matrix.image }}:${{ needs.release.outputs.version }}
+            inkeep/${{ matrix.image }}:latest
+          cache-from: type=gha,scope=${{ matrix.image }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.image }}
+
+  update-docker-compose:
+    name: Update docker-compose image tags
+    needs: [release, docker-publish]
+    if: needs.release.outputs.published == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Generate GitHub App Token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.INTERNAL_CI_APP_ID }}
+          private-key: ${{ secrets.INTERNAL_CI_APP_PRIVATE_KEY }}
+
+      - name: Checkout main
+        uses: actions/checkout@v6
+        with:
+          ref: main
+          token: ${{ steps.app-token.outputs.token }}
+
+      - name: Update image tags
+        run: |
+          VERSION="${{ needs.release.outputs.version }}"
+          sed -i "s|image: inkeep/agents-api:.*|image: inkeep/agents-api:${VERSION}|g" create-agents-template/docker-compose.yml
+          sed -i "s|image: inkeep/agents-manage-ui:.*|image: inkeep/agents-manage-ui:${VERSION}|g" create-agents-template/docker-compose.yml
+          sed -i "s|image: inkeep/agents-migrate:.*|image: inkeep/agents-migrate:${VERSION}|g" create-agents-template/docker-compose.yml
+
+      - name: Commit and push
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add create-agents-template/docker-compose.yml
+          git diff --cached --quiet && exit 0
+          git commit -m "chore: update Docker image tags to v${{ needs.release.outputs.version }} [skip ci]"
+          git push

--- a/create-agents-template/.dockerignore
+++ b/create-agents-template/.dockerignore
@@ -1,0 +1,16 @@
+node_modules
+.git
+__tests__
+*.test.ts
+*.spec.ts
+.env
+.env.*
+.turbo
+.next
+dist
+coverage
+.DS_Store
+README.md
+mprocs.yaml
+docker-compose*.yml
+Dockerfile*

--- a/create-agents-template/docker-compose.yml
+++ b/create-agents-template/docker-compose.yml
@@ -1,5 +1,6 @@
 services:
   inkeep-agents-manage-ui:
+    image: inkeep/agents-manage-ui:latest
     build:
       context: .
       dockerfile: Dockerfile.agents-manage-ui
@@ -21,6 +22,7 @@ services:
       inkeep-agents-api:
         condition: service_started
   inkeep-agents-api:
+    image: inkeep/agents-api:latest
     build:
       context: .
       dockerfile: Dockerfile.agents-api
@@ -60,6 +62,7 @@ services:
       inkeep-agents-spicedb:
         condition: service_started
   inkeep-agents-migrate:
+    image: inkeep/agents-migrate:latest
     build:
       context: .
       dockerfile: Dockerfile.agents-migrate


### PR DESCRIPTION
## Summary

- Automate Docker Hub image builds (`agents-api`, `agents-manage-ui`, `agents-migrate`) as part of the changeset release workflow
- Multi-arch builds (linux/amd64 + linux/arm64) with GHA layer caching
- Auto-updates `docker-compose.yml` image tags on main after publish

## Changes

**`.github/workflows/release.yml`**
- Add `published` and `version` outputs to the `release` job
- Add `extract-version` step to parse version from changeset output
- Add `docker-publish` job: matrix build for 3 images using QEMU + Buildx, pushes `<version>` + `latest` tags to Docker Hub
- Add `update-docker-compose` job: checks out main, sed-replaces image tags, commits with `[skip ci]`

**`create-agents-template/docker-compose.yml`**
- Add `image:` directives to app services (`inkeep/agents-api:latest`, `inkeep/agents-manage-ui:latest`, `inkeep/agents-migrate:latest`) alongside existing `build:` blocks

**`create-agents-template/.dockerignore`** (new)
- Exclude `node_modules`, `.git`, test files, build outputs from Docker build context

## Required secrets (manual setup)

- `DOCKERHUB_USERNAME` — Docker Hub username
- `DOCKERHUB_TOKEN` — Docker Hub access token with Read/Write/Delete scope

## Test plan

- [x] Validate YAML syntax
- [ ] After merge: trigger via `workflow_dispatch` or next changeset release
- [ ] Confirm images appear on Docker Hub with correct version + latest tags
- [ ] Confirm `docker-compose.yml` auto-updated on main with pinned version

🤖 Generated with [Claude Code](https://claude.com/claude-code)