### PR TITLE
fix: give @claude write access to push commits on PRs

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -13,10 +13,10 @@ on:
 jobs:
   claude:
     if: |
-      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude') && !contains(github.event.comment.body, '--review') && !contains(github.event.comment.body, '--full-review')) ||
-      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude') && !contains(github.event.comment.body, '--review') && !contains(github.event.comment.body, '--full-review')) ||
-      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude') && !contains(github.event.review.body, '--review') && !contains(github.event.review.body, '--full-review')) ||
-      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude') && !contains(github.event.comment.body, '--review') && !contains(github.event.comment.body, '--full-review') && (github.event.comment.author_association == 'OWNER' || github.event.comment.author_association == 'MEMBER' || github.event.comment.author_association == 'COLLABORATOR')) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude') && !contains(github.event.comment.body, '--review') && !contains(github.event.comment.body, '--full-review') && (github.event.comment.author_association == 'OWNER' || github.event.comment.author_association == 'MEMBER' || github.event.comment.author_association == 'COLLABORATOR')) ||
+      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude') && !contains(github.event.review.body, '--review') && !contains(github.event.review.body, '--full-review') && (github.event.review.author_association == 'OWNER' || github.event.review.author_association == 'MEMBER' || github.event.review.author_association == 'COLLABORATOR')) ||
+      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')) && (github.event.issue.author_association == 'OWNER' || github.event.issue.author_association == 'MEMBER' || github.event.issue.author_association == 'COLLABORATOR'))
     runs-on: ubuntu-latest
     permissions:
       contents: write


### PR DESCRIPTION
## Problem

When someone tags \`@claude\` on a PR to make a code change, Claude runs, makes the changes locally, but **cannot push them back to the branch** because \`claude.yml\` only has \`contents: read\`.

Claude's own comments confirm this has been silently failing:

- [PR #2442](https://github.com/inkeep/agents/pull/2442#discussion_r2874921640) — *"The changes have been committed locally but I don't have permission to push to the remote repository. You'll need to push the changes yourself."*
- [PR #2442](https://github.com/inkeep/agents/pull/2442#discussion_r2874916994) — *"The changes have been committed locally but couldn't be pushed due to GitHub Actions permissions."*

This has been a recurring pattern across dozens of PRs — especially \`@claude add a changeset\` requests (PRs #1702, #1731, #1735, #1738, #1699, #1591, etc.) where Claude would run, report success, but the changeset file was never actually in the branch.

## Fix

Three changes to \`claude.yml\`:

1. **\`contents: write\`** (was \`read\`) — allows Claude to push files to the branch
2. **\`pull-requests: write\`** (was \`read\`) — allows Claude to update PR descriptions etc.
3. **App token for checkout + GitHub API calls** — uses \`INTERNAL_CI_APP_ID\` so commits pushed by Claude trigger CI and other workflows (same pattern as \`claude-code-review.yml\`)