### PR TITLE
ci: upgrade Claude model to Opus for both workflows

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -729,6 +729,7 @@ jobs:
           allowed_bots: "claude[bot]"
           track_progress: true
           claude_args: |
+            --model opus
             --plugin-dir /tmp/team-skills/ci/pr-review
             --agent pr-review:pr-review
             --mcp-config '{"mcpServers":{"exa":{"command":"npx","args":["-y","exa-mcp-server"],"env":{"EXA_API_KEY":"${{ secrets.EXA_API_KEY }}"}}}}'

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -35,7 +35,7 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-          claude_args: '--model claude-opus-4-1-20250805'
+          claude_args: '--model opus'
 
           # This is an optional setting that allows Claude to read CI results on PRs
           # additional_permissions: |


### PR DESCRIPTION
## Summary

- `claude-code-review.yml` (auto PR review on every commit) - was using the Claude Code CLI default, which is **Sonnet**. Bumping to **Opus**.
- `claude.yml` (@claude mention handler) - was pinned to `claude-opus-4-1-20250805`, a legacy Opus that is 2+ generations behind and costs $15/MTok vs $5/MTok for the current version. Bumping to latest **Opus**.

**Why the `opus` alias instead of a pinned version ID:**

Using `--model opus` means the workflow always runs on the latest Opus without manual maintenance - Anthropic's `opus` alias automatically points to the newest version when one ships.

If you ever want to pin to a specific version (for cost control or reproducibility), you can either hard-set a full model ID (e.g. `--model claude-opus-4-6`) or set the `ANTHROPIC_MODEL` environment variable in the workflow.

Discovered while working on #2483.