### PR TITLE
fix: Update OpenAPI snapshot after lastUsedAt removal

### DIFF
--- a/agents-api/__snapshots__/openapi.json
+++ b/agents-api/__snapshots__/openapi.json
@@ -776,10 +776,6 @@
             "nullable": true,
             "type": "string"
           },
-          "lastUsedAt": {
-            "nullable": true,
-            "type": "string"
-          },
           "name": {
             "maxLength": 256,
             "minLength": 1,


### PR DESCRIPTION
## Summary

- Updates the OpenAPI snapshot to remove the `lastUsedAt` field from the API key response schema, matching the change made in PR #2534

## Root Cause

PR #2534 ("Fix api key lastused field not updating") removed `lastUsedAt` from the API key response but didn't regenerate the OpenAPI snapshot, breaking CI.

## Test plan

- [x] `pnpm --filter @inkeep/agents-api openapi:update-snapshot` passes (12 tests)
- [ ] CI pipeline passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)