### PR TITLE
fix: Mark agents-ui-demo as private to prevent publish attempts

### DIFF
--- a/agents-ui-demo/package.json
+++ b/agents-ui-demo/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@inkeep/agents-ui-demo",
   "version": "0.1.0",
+  "private": true,
   "type": "module",
   "license": "SEE LICENSE IN LICENSE.md",
   "scripts": {
@@ -27,16 +28,6 @@
     "typescript": "~5.9.2",
     "vite": "^7.1.11"
   },
-  "publishConfig": {
-    "access": "public",
-    "registry": "https://registry.npmjs.org/"
-  },
-  "files": [
-    "dist",
-    "README.md",
-    "LICENSE.md",
-    "SUPPLEMENTAL_TERMS.md"
-  ],
   "repository": {
     "type": "git",
     "url": "git+https://github.com/inkeep/agents.git",


### PR DESCRIPTION
## Summary

- Adds `"private": true` to `agents-ui-demo/package.json` and removes the now-unnecessary `publishConfig` and `files` fields
- Fixes the release workflow failure ([run #1431](https://github.com/inkeep/agents/actions/runs/22699442616/job/65813032189)) where `changeset publish` attempted to publish `@inkeep/agents-ui-demo` to npm, got a 404, and caused the entire job to exit non-zero

## Root cause

The changeset `ignore` config only controls **version bumping** — it does not prevent `changeset publish` from attempting to publish a package. Since `@inkeep/agents-ui-demo` was not marked `"private": true`, `changeset publish` saw its local version (`0.1.0`) wasn't on npm and tried to publish it. The publish failed with E404 (package not provisioned on the registry), which made the whole release workflow fail despite all other packages publishing successfully.

## Test plan

- [ ] Verify `pnpm install` still resolves correctly (no lockfile changes)
- [ ] Confirm the release workflow passes on next run

Made with [Cursor](https://cursor.com)