### PR TITLE
Claude reviewer exclusion

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -9,7 +9,10 @@ on:
 jobs:
   pr-review:
     if: |
-      (github.event_name == 'pull_request' && (github.event.sender.type != 'Bot' || github.event.sender.login == 'inkeep-internal-ci[bot]')) ||
+      (github.event_name == 'pull_request' &&
+        (github.event.sender.type != 'Bot' || github.event.sender.login == 'inkeep-internal-ci[bot]') &&
+        !startsWith(github.event.pull_request.head.ref, 'changeset-release/')
+      ) ||
       (
         github.event_name == 'issue_comment' &&
         github.event.issue.pull_request &&


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Disable Claude reviewer on automated version bump PRs to reduce noise and cost.

Automated version bump PRs, specifically those created from `changeset-release/*` branches, were unnecessarily triggering the Claude code reviewer. This change adds a condition to the `pull_request` event filter to skip these automated PRs, while still allowing manual reviews via `issue_comment` if explicitly requested. The branch name is used as a reliable identifier as it's deterministic.

---
Linear Issue: [PRD-6230](https://linear.app/inkeep/issue/PRD-6230/disable-claude-reviewer-on-automated-version-bump-prs)

<p><a href="https://cursor.com/agents/bc-9fccf9b2-f3a7-406c-a211-97caaf316254"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9fccf9b2-f3a7-406c-a211-97caaf316254"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>


<!-- CURSOR_AGENT_PR_BODY_END -->