### PR TITLE
ci: skip duplicate merge-queue push runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,7 @@ concurrency:
 
 jobs:
   ci:
+    if: ${{ github.event_name != 'push' || github.actor != 'github-merge-queue[bot]' }}
     runs-on: ubuntu-32gb
     timeout-minutes: 30
     permissions:
@@ -192,6 +193,7 @@ jobs:
           fi
 
   create-agents-e2e:
+    if: ${{ github.event_name != 'push' || github.actor != 'github-merge-queue[bot]' }}
     runs-on: ubuntu-32gb
     name: Create Agents E2E Tests
 

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -15,6 +15,7 @@ concurrency:
 
 jobs:
   cypress-e2e:
+    if: ${{ github.event_name != 'push' || github.actor != 'github-merge-queue[bot]' }}
     name: Cypress E2E Tests
     runs-on: ubuntu-32gb
     timeout-minutes: 30


### PR DESCRIPTION
## Summary
This PR stops duplicate heavy CI runs when a PR is merged through GitHub Merge Queue.

## Problem
After enabling merge queue with required checks (`ci`, `Cypress E2E Tests`, `Create Agents E2E Tests`), we were running the same checks multiple times for the same commit SHA:

1. On `pull_request`
2. On `merge_group` (required for merge queue)
3. Again on `push` to `main`

The third run is redundant for merge-queue commits and burns runner time.

## Investigation / Research
### Ruleset evidence
Active ruleset `main` (id `8421109`, updated `2026-03-06T16:17:04.599-05:00`) requires:
- `ci`
- `Cypress E2E Tests`
- `Create Agents E2E Tests`
- plus Vercel checks

Merge queue is enabled on the same ruleset.

### Workflow trigger evidence
Both workflows are configured with all three events (`push`, `pull_request`, `merge_group`):
- `.github/workflows/ci.yml`
- `.github/workflows/cypress.yml`

### Same-SHA duplicate run evidence
For SHA `959d5b49f6b7054dab4596c465c5f6773c827bd8`:
- CI `merge_group`: https://github.com/inkeep/agents/actions/runs/22782228643
- CI `push`: https://github.com/inkeep/agents/actions/runs/22782418539
- Cypress `merge_group`: https://github.com/inkeep/agents/actions/runs/22782228638
- Cypress `push`: https://github.com/inkeep/agents/actions/runs/22782418545

Both CI runs also executed `Create Agents E2E Tests` fully.

Push-run payload actor for these runs is `github-merge-queue[bot]`.

### Root cause
This is event-trigger duplication, not cache miss behavior:
- Workflows are configured to trigger on both `merge_group` and `push`
- Merge queue produces a `merge_group` run and then a `push` run to `main`
- Actions cache/turbo cache can speed steps, but does not suppress a separately triggered workflow run

## Fix
Add a job-level guard to skip heavy jobs when the event is `push` and actor is `github-merge-queue[bot]`:

```yaml
if: ${{ github.event_name != 'push' || github.actor != 'github-merge-queue[bot]' }}
```

Applied to:
- `ci` and `create-agents-e2e` jobs in `.github/workflows/ci.yml`
- `cypress-e2e` job in `.github/workflows/cypress.yml`

## Risk / Tradeoff
- We lose redundant post-merge heavy runs for merge-queue commits.
- Required merge-queue validation remains intact (`merge_group` checks are still required and unchanged).
- Direct/manual non-merge-queue pushes to `main` still run these jobs.

## Validation plan
- PR event: jobs should run
- Merge queue (`merge_group`): jobs should run
- Post-merge push from merge queue bot: jobs should be skipped
