### PR TITLE
fix(ci): use GitHub App token for Changesets PR to trigger CI

### DIFF
--- a/.changeset/mad-magenta-leech.md
+++ b/.changeset/mad-magenta-leech.md
@@ -1,0 +1,5 @@
+---
+"@inkeep/agents-core": patch
+---
+
+Fix CI workflows not triggering on Changesets Version Packages PR by using GitHub App token

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,6 +56,16 @@ jobs:
           TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
           TURBO_TEAM: ${{ vars.TURBO_TEAM }}
 
+      # Generate a GitHub App token so that PRs and releases created by this
+      # workflow trigger downstream CI workflows. The default GITHUB_TOKEN
+      # cannot do this (GitHub security restriction).
+      - name: Generate GitHub App Token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.INTERNAL_CI_APP_ID }}
+          private-key: ${{ secrets.INTERNAL_CI_APP_PRIVATE_KEY }}
+
       - name: Publish packages
         id: changesets
         uses: changesets/action@v1
@@ -63,7 +73,7 @@ jobs:
           publish: pnpm release
           createGithubReleases: false
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
           HUSKY: 0
 
       - name: Release to snapshot tag
@@ -80,18 +90,8 @@ jobs:
           pnpm changeset version --snapshot $TAG_NAME
           pnpm changeset publish --tag $TAG_NAME
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
           HUSKY: 0
-
-      # Generate a GitHub App token so the release event triggers downstream
-      # workflows (the default GITHUB_TOKEN cannot do this).
-      - name: Generate GitHub App Token
-        if: steps.changesets.outputs.published == 'true'
-        id: app-token
-        uses: actions/create-github-app-token@v1
-        with:
-          app-id: ${{ secrets.INTERNAL_CI_APP_ID }}
-          private-key: ${{ secrets.INTERNAL_CI_APP_PRIVATE_KEY }}
 
       - name: Create GitHub Release
         if: steps.changesets.outputs.published == 'true'


### PR DESCRIPTION
## Summary
- Use the existing `INTERNAL_CI_APP_ID` GitHub App token in the Changesets workflow instead of the default `GITHUB_TOKEN` when creating/updating the "Version Packages" PR
- This fixes the 3 required CI checks (`ci`, `Create Agents E2E Tests`, `Cypress E2E Tests`) that never trigger on Changesets PRs due to GitHub's security restriction on `GITHUB_TOKEN`-created PRs
- Includes a no-op `agents-core` changeset to trigger a new Version Packages PR for validation

## Context
- **Linear**: [PRD-6269](https://linear.app/inkeep/issue/PRD-6269)
- **Affected PR**: #2619 (Version Packages)

## Test plan
- [ ] Merge this PR to main
- [ ] Verify the Publish workflow creates a new Version Packages PR using the App token
- [ ] Confirm all 6 required checks (3 Vercel + 3 GitHub Actions) trigger and pass on the new Version Packages PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)