### PR TITLE
fix(ci): skip CI checks for Changesets Version Packages PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ concurrency:
 
 jobs:
   ci:
-    if: ${{ github.event_name != 'push' || github.actor != 'github-merge-queue[bot]' }}
+    if: ${{ (github.event_name != 'push' || github.actor != 'github-merge-queue[bot]') && github.head_ref != 'changeset-release/main' }}
     runs-on: ubuntu-32gb
     timeout-minutes: 30
     permissions:
@@ -193,7 +193,7 @@ jobs:
           fi
 
   create-agents-e2e:
-    if: ${{ github.event_name != 'push' || github.actor != 'github-merge-queue[bot]' }}
+    if: ${{ (github.event_name != 'push' || github.actor != 'github-merge-queue[bot]') && github.head_ref != 'changeset-release/main' }}
     runs-on: ubuntu-32gb
     name: Create Agents E2E Tests
 

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -15,7 +15,7 @@ concurrency:
 
 jobs:
   cypress-e2e:
-    if: ${{ github.event_name != 'push' || github.actor != 'github-merge-queue[bot]' }}
+    if: ${{ (github.event_name != 'push' || github.actor != 'github-merge-queue[bot]') && github.head_ref != 'changeset-release/main' }}
     name: Cypress E2E Tests
     runs-on: ubuntu-32gb
     timeout-minutes: 30


### PR DESCRIPTION
## Summary
- Skip `ci`, `create-agents-e2e`, and `cypress-e2e` jobs when the PR branch is `changeset-release/main`
- Version Packages PRs only contain changelog `.md` and `package.json` version bumps — no code changes, so running full CI/E2E is unnecessary compute
- Skipped GitHub Actions jobs satisfy required check constraints, so auto-merge is unblocked

## Details

Adds `&& github.head_ref != 'changeset-release/main'` to the `if:` condition on 3 jobs:
- `ci` in `.github/workflows/ci.yml`
- `create-agents-e2e` in `.github/workflows/ci.yml`
- `cypress-e2e` in `.github/workflows/cypress.yml`

Context: https://github.com/inkeep/agents/pull/2619

## Test plan
- [ ] Verify this PR's own CI still runs (it's not from `changeset-release/main`)
- [ ] Next Version Packages PR should show all 3 checks as skipped and merge without waiting

🤖 Generated with [Claude Code](https://claude.com/claude-code)