### PR TITLE
fix(security): bump file-type to 21.3.1 — ASF parser DoS fix

### DIFF
--- a/.changeset/international-white-coral.md
+++ b/.changeset/international-white-coral.md
@@ -1,0 +1,5 @@
+---
+"@inkeep/agents-api": patch
+---
+
+Security and bug fixes

--- a/agents-api/package.json
+++ b/agents-api/package.json
@@ -84,7 +84,7 @@
     "cron-parser": "^5.5.0",
     "drizzle-orm": "^0.44.4",
     "fetch-to-node": "^2.1.0",
-    "file-type": "^21.3.0",
+    "file-type": "^21.3.1",
     "hono": "^4.12.7",
     "ipaddr.js": "^2.3.0",
     "hono-pino": "^0.10.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -207,8 +207,8 @@ importers:
         specifier: ^2.1.0
         version: 2.1.0
       file-type:
-        specifier: ^21.3.0
-        version: 21.3.0
+        specifier: ^21.3.1
+        version: 21.3.1
       hono:
         specifier: ^4.12.7
         version: 4.12.7
@@ -11030,6 +11030,10 @@ packages:
 
   file-type@21.3.0:
     resolution: {integrity: sha512-8kPJMIGz1Yt/aPEwOsrR97ZyZaD1Iqm8PClb1nYFclUCkBi0Ma5IsYNQzvSFS9ib51lWyIw5mIT9rWzI/xjpzA==}
+    engines: {node: '>=20'}
+
+  file-type@21.3.1:
+    resolution: {integrity: sha512-SrzXX46I/zsRDjTb82eucsGg0ODq2NpGDp4HcsFKApPy8P8vACjpJRDoGGMfEzhFC0ry61ajd7f72J3603anBA==}
     engines: {node: '>=20'}
 
   filelist@1.0.4:
@@ -29720,6 +29724,15 @@ snapshots:
       - supports-color
 
   file-type@21.3.0:
+    dependencies:
+      '@tokenizer/inflate': 0.4.1
+      strtok3: 10.3.4
+      token-types: 6.1.2
+      uint8array-extras: 1.5.0
+    transitivePeerDependencies:
+      - supports-color
+
+  file-type@21.3.1:
     dependencies:
       '@tokenizer/inflate': 0.4.1
       strtok3: 10.3.4


### PR DESCRIPTION
## Summary
- Bumps `file-type` from `^21.3.0` to `^21.3.1` in agents-api
- Fixes infinite loop in ASF parser on malformed input (CVE-2026-31808)
- Supersedes Dependabot PR #2624

## Security
- **Dependabot alerts:** #218, #220
- **Severity:** Medium
- **Mitigating factor:** Only used for image MIME type detection with an allowlist — ASF files never reach the vulnerable parser

## Test plan
- [x] `pnpm typecheck` passes
- [x] `pnpm test` passes (1869 tests)
- [ ] CI checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)