### PR TITLE
fix(security): add express-rate-limit override >=8.2.2 — rate limit bypass fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -133,7 +133,8 @@
       "svgo": ">=3.3.3",
       "minimatch": ">=5.1.8",
       "lodash": ">=4.17.23",
-      "lodash-es": ">=4.17.23"
+      "lodash-es": ">=4.17.23",
+      "express-rate-limit": ">=8.2.2"
     }
   },
   "packageManager": "pnpm@10.10.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -53,6 +53,7 @@ overrides:
   minimatch: '>=5.1.8'
   lodash: '>=4.17.23'
   lodash-es: '>=4.17.23'
+  express-rate-limit: '>=8.2.2'
 
 patchedDependencies:
   '@changesets/assemble-release-plan@6.0.9':
@@ -11013,8 +11014,8 @@ packages:
     resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
     engines: {node: '>=12.0.0'}
 
-  express-rate-limit@8.2.1:
-    resolution: {integrity: sha512-PCZEIEIxqwhzw4KF0n7QF4QqruVTcF73O5kFKUnGOyjbCCgizBBiFaYpd/fnBLUMPw/BWw9OsiN7GgrNYr7j6g==}
+  express-rate-limit@8.3.1:
+    resolution: {integrity: sha512-D1dKN+cmyPWuvB+G2SREQDzPY1agpBIcTa9sJxOPMCNeH3gwzhqJRDWCXW3gg0y//+LQ/8j52JbMROWyrKdMdw==}
     engines: {node: '>= 16'}
     peerDependencies:
       express: '>= 4.11'
@@ -11860,8 +11861,8 @@ packages:
     resolution: {integrity: sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==}
     engines: {node: '>=12'}
 
-  ip-address@10.0.1:
-    resolution: {integrity: sha512-NWv9YLW4PoW2B7xtzaS3NCot75m6nK7Icdv0o3lfMceJVRfSoQwqD4wEH5rLwoKJwUiZ/rfpiVBhnaF0FK4HoA==}
+  ip-address@10.1.0:
+    resolution: {integrity: sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==}
     engines: {node: '>= 12'}
 
   ipaddr.js@1.9.1:
@@ -19301,7 +19302,7 @@ snapshots:
       eventsource: 3.0.7
       eventsource-parser: 3.0.6
       express: 5.2.1
-      express-rate-limit: 8.2.1(express@5.2.1)
+      express-rate-limit: 8.3.1(express@5.2.1)
       hono: 4.12.7
       jose: 6.1.3
       json-schema-typed: 8.0.2
@@ -29824,10 +29825,10 @@ snapshots:
 
   expect-type@1.3.0: {}
 
-  express-rate-limit@8.2.1(express@5.2.1):
+  express-rate-limit@8.3.1(express@5.2.1):
     dependencies:
       express: 5.2.1
-      ip-address: 10.0.1
+      ip-address: 10.1.0
 
   express@4.22.1:
     dependencies:
@@ -30947,7 +30948,7 @@ snapshots:
 
   internmap@2.0.3: {}
 
-  ip-address@10.0.1: {}
+  ip-address@10.1.0: {}
 
   ipaddr.js@1.9.1: {}
 


### PR DESCRIPTION
## Summary
- Adds `pnpm.overrides` for `express-rate-limit` to `>=8.2.2`
- Fixes IPv4-mapped IPv6 rate limit bypass (CVE-2026-30827)

## Security
- **Dependabot alerts:** #213
- **Severity:** High (CVE), Low (actual impact — not used in codebase)

## Test plan
- [x] `pnpm typecheck` passes
- [x] `pnpm test` passes (full suite on final branch)
- [ ] CI checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)