### PR TITLE
test: regression tests for initiatedBy propagation through service tokens

### DIFF
--- a/.changeset/keen-orange-chinchilla.md
+++ b/.changeset/keen-orange-chinchilla.md
@@ -1,6 +1,0 @@
----
-"@inkeep/agents-core": patch
-"@inkeep/agents-api": patch
----
-
-Add regression tests for initiatedBy propagation through service tokens during agent delegation

--- a/agents-api/src/__tests__/middleware/runAuth-initiatedBy.test.ts
+++ b/agents-api/src/__tests__/middleware/runAuth-initiatedBy.test.ts
@@ -150,6 +150,27 @@ describe('runAuth middleware - initiatedBy propagation via service token', () =>
     expect(capturedContext?.metadata).not.toHaveProperty('initiatedBy');
   });
 
+  it('should reject with 403 when x-inkeep-sub-agent-id does not match token targetAgentId', async () => {
+    const token = await generateServiceToken({
+      tenantId: 'test-tenant',
+      projectId: 'test-project',
+      originAgentId: 'origin-agent',
+      targetAgentId: 'target-agent',
+      initiatedBy: { type: 'user', id: 'user_abc123' },
+    });
+
+    const app = createTestApp();
+    const res = await app.request('/test', {
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'x-inkeep-agent-id': 'origin-agent',
+        'x-inkeep-sub-agent-id': 'wrong-agent',
+      },
+    });
+
+    expect(res.status).toBe(403);
+  });
+
   it('should preserve user identity through full generate → verify → auth chain', async () => {
     const userId = 'user_playground_session_12345';
     const token = await generateServiceToken({

--- a/agents-api/src/__tests__/run/agents/relationTools.test.ts
+++ b/agents-api/src/__tests__/run/agents/relationTools.test.ts
@@ -887,7 +887,7 @@ describe('Relationship Tools', () => {
       });
     });
 
-    it('should pass initiatedBy in team delegation context to generateServiceToken', async () => {
+    it('should pass initiatedBy when metadata includes teamDelegation flag', async () => {
       mockExecutionContext = createMockExecutionContext();
       mockExecutionContext.metadata = {
         teamDelegation: true,
@@ -904,11 +904,13 @@ describe('Relationship Tools', () => {
 
       await tool.execute({ message: 'Team delegation with user test' }, mockToolCallOptions);
 
-      expect(vi.mocked(generateServiceToken)).toHaveBeenCalledWith(
-        expect.objectContaining({
-          initiatedBy: { type: 'user', id: 'user_xyz789' },
-        })
-      );
+      expect(vi.mocked(generateServiceToken)).toHaveBeenCalledWith({
+        tenantId: 'test-tenant',
+        projectId: 'test-project',
+        originAgentId: 'test-agent',
+        targetAgentId: 'target-agent',
+        initiatedBy: { type: 'user', id: 'user_xyz789' },
+      });
     });
 
     it('should not include initiatedBy when metadata has no initiatedBy', async () => {

--- a/agents-api/src/__tests__/run/handlers/executionHandler-team-delegation.test.ts
+++ b/agents-api/src/__tests__/run/handlers/executionHandler-team-delegation.test.ts
@@ -163,8 +163,8 @@ describe('ExecutionHandler - Team Delegation JWT Regeneration', () => {
     baseUrl: 'http://localhost:3000',
     resolvedRef: { type: 'branch', name: 'main', hash: 'test-hash' },
     metadata: teamDelegation
-      ? { teamDelegation: true, originAgentId: 'remote-origin-agent' }
-      : undefined,
+      ? ({ teamDelegation: true, originAgentId: 'remote-origin-agent' } as Record<string, unknown>)
+      : (undefined as Record<string, unknown> | undefined),
     project: {
       id: 'test-project',
       tenantId: 'test-tenant',

--- a/packages/agents-core/src/utils/__tests__/service-token-auth.test.ts
+++ b/packages/agents-core/src/utils/__tests__/service-token-auth.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest';
+import { signJwt } from '../jwt-helpers';
 import {
   generateServiceToken,
   validateTargetAgent,
@@ -15,7 +16,7 @@ describe('Service Token Auth', () => {
   };
 
   describe('generateServiceToken + verifyServiceToken round-trip', () => {
-    it('should round-trip basic claims', async () => {
+    it('should round-trip basic claims without initiatedBy', async () => {
       const token = await generateServiceToken(baseParams);
       const result = await verifyServiceToken(token);
 
@@ -26,6 +27,7 @@ describe('Service Token Auth', () => {
       expect(result.payload?.tenantId).toBe('tenant-1');
       expect(result.payload?.projectId).toBe('project-1');
       expect(result.payload?.iss).toBe('inkeep-agents');
+      expect(result.payload?.initiatedBy).toBeUndefined();
     });
 
     it('should round-trip initiatedBy with type "user"', async () => {
@@ -50,25 +52,6 @@ describe('Service Token Auth', () => {
 
       expect(result.valid).toBe(true);
       expect(result.payload?.initiatedBy).toEqual({ type: 'api_key', id: 'key_xyz789' });
-    });
-
-    it('should not include initiatedBy when not provided', async () => {
-      const token = await generateServiceToken(baseParams);
-      const result = await verifyServiceToken(token);
-
-      expect(result.valid).toBe(true);
-      expect(result.payload?.initiatedBy).toBeUndefined();
-    });
-
-    it('should not include initiatedBy when explicitly undefined', async () => {
-      const token = await generateServiceToken({
-        ...baseParams,
-        initiatedBy: undefined,
-      });
-      const result = await verifyServiceToken(token);
-
-      expect(result.valid).toBe(true);
-      expect(result.payload?.initiatedBy).toBeUndefined();
     });
   });
 
@@ -129,8 +112,21 @@ describe('Service Token Auth', () => {
   });
 
   describe('verifyServiceToken validation', () => {
-    it('should reject tokens with invalid issuer', async () => {
+    it('should reject malformed tokens', async () => {
       const result = await verifyServiceToken('not-a-valid-token');
+      expect(result.valid).toBe(false);
+    });
+
+    it('should reject tokens with wrong issuer', async () => {
+      const token = await signJwt({
+        issuer: 'wrong-issuer',
+        subject: 'agent-origin',
+        audience: 'agent-target',
+        expiresIn: '1h',
+        claims: { tenantId: 'tenant-1', projectId: 'project-1' },
+      });
+
+      const result = await verifyServiceToken(token);
       expect(result.valid).toBe(false);
     });
   });


### PR DESCRIPTION
## Summary

- Adds regression tests covering the full `initiatedBy` propagation chain that was broken by `6144fc9a` and fixed in #2651
- Tests every layer of the delegation chain to prevent future regressions where user identity is dropped during internal A2A calls

## What's covered

| Layer | Test file | What it verifies |
|---|---|---|
| **Service token round-trip** | `packages/agents-core/src/utils/__tests__/service-token-auth.test.ts` (10 tests) | `initiatedBy` survives `generateServiceToken` → `verifyServiceToken` for `user` and `api_key` types |
| **ExecutionHandler** | `agents-api/src/__tests__/run/handlers/executionHandler-team-delegation.test.ts` (+3 tests) | `initiatedBy` from execution context metadata is passed to `generateServiceToken` |
| **RelationTools** | `agents-api/src/__tests__/run/agents/relationTools.test.ts` (+4 tests) | `initiatedBy` is passed to `generateServiceToken` in both internal and team delegation contexts |
| **runAuth middleware** | `agents-api/src/__tests__/middleware/runAuth-initiatedBy.test.ts` (4 tests, new) | `tryTeamAgentAuth` extracts `initiatedBy` from verified service token into execution context metadata |

## Context

The bug from `6144fc9a` changed service token generation from conditional (team delegation only) to always-generate, which was correct for fixing app credential auth. However, it dropped the `initiatedBy` field from the token, causing user-scoped MCP connections to fail because downstream agents couldn't identify the requesting user.

These tests ensure that if any layer of the propagation chain regresses, CI will catch it immediately.

## Test plan

- [x] All 49 tests pass locally (`service-token-auth`: 10, `executionHandler`: 6, `relationTools`: 29, `runAuth`: 4)
- [x] Pre-commit hooks pass
- [ ] CI passes

Made with [Cursor](https://cursor.com)