### PR TITLE
ci: skip auto-format for Version Packages PRs

### DIFF
--- a/.github/workflows/auto-format.yml
+++ b/.github/workflows/auto-format.yml
@@ -13,10 +13,12 @@ concurrency:
 
 jobs:
   auto-format:
-    # On PRs: skip forks (can't push back). On push to main: always run.
+    # On PRs: skip forks (can't push back) and changeset release PRs (machine-generated).
+    # On push to main: always run.
     if: >-
       github.event_name == 'push' ||
-      github.event.pull_request.head.repo.full_name == github.repository
+      (github.event.pull_request.head.repo.full_name == github.repository &&
+       github.head_ref != 'changeset-release/main')
     runs-on: ubuntu-latest
     timeout-minutes: 15
     permissions:


### PR DESCRIPTION
## Summary
- Skip the auto-format workflow for `changeset-release/main` PRs since they contain machine-generated version bumps and changelogs
- Running auto-format on these PRs wastes ~1 min and risks pushing a formatting commit that re-triggers all required checks (~9 min)

## Test plan
- [ ] Verify auto-format workflow still runs on normal PRs
- [ ] Verify auto-format workflow still runs on push to main
- [ ] Verify auto-format workflow skips on `changeset-release/main` PRs

🤖 Generated with [Claude Code](https://claude.com/claude-code)