### PR TITLE
ci: prevent OpenAPI snapshot update from re-triggering checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,15 +22,11 @@ jobs:
     if: ${{ (github.event_name != 'push' || github.actor != 'github-merge-queue[bot]') && github.head_ref != 'changeset-release/main' }}
     runs-on: ubuntu-32gb
     timeout-minutes: 30
-    permissions:
-      contents: write
     env:
       TURBO_TELEMETRY_DISABLED: 1
       TURBO_CACHE_DIR: .turbo
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
       TURBO_TEAM: ${{ vars.TURBO_TEAM }}
-      GIT_AUTHOR_NAME: github-actions[bot]
-      GIT_AUTHOR_EMAIL: 41898282+github-actions[bot]@users.noreply.github.com
 
     steps:
       - name: Checkout code
@@ -86,14 +82,12 @@ jobs:
         env:
           HUSKY: 0
 
-      # Auto-update OpenAPI snapshot on PRs (skip fork PRs since GITHUB_TOKEN is read-only)
+      # Verify OpenAPI snapshot is up to date on PRs.
       # Gate: only run when files that affect the OpenAPI spec changed.
       # These paths mirror the pre-commit hook in package.json lint-staged config.
       - name: Check for OpenAPI-affecting changes
         id: openapi-changes
-        if: |
-          github.event_name == 'pull_request' &&
-          github.event.pull_request.head.repo.full_name == github.repository
+        if: github.event_name == 'pull_request'
         run: |
           if git diff --name-only origin/${{ github.base_ref }}...HEAD | \
              grep -qE '^agents-api/src/(domains/.*/routes/|openapi\.|createApp\.)'; then
@@ -118,10 +112,16 @@ jobs:
           INKEEP_AGENTS_MANAGE_DATABASE_URL: postgresql://appuser:password@localhost:5432/inkeep_agents
           INKEEP_AGENTS_RUN_DATABASE_URL: postgresql://appuser:password@localhost:5433/inkeep_agents
 
-      - name: Commit OpenAPI snapshot if changed
+      - name: Verify OpenAPI snapshot is up to date
         if: steps.openapi-changes.outputs.changed == 'true'
         run: |
-          scripts/ci-commit-and-push.sh agents-api/__snapshots__/openapi.json "chore: update OpenAPI snapshot" "${{ github.head_ref }}"
+          if git diff --exit-code agents-api/__snapshots__/openapi.json; then
+            echo "✅ OpenAPI snapshot is up to date."
+          else
+            echo "::error::OpenAPI snapshot is out of date. Run the following locally and commit the result:"
+            echo "::error::  pnpm exec turbo build --filter=@inkeep/agents-api... && pnpm --filter @inkeep/agents-api openapi:update-snapshot"
+            exit 1
+          fi
 
       - name: Install Playwright
         run: pnpx playwright install chromium --with-deps # install browsers + dependencies for Chromium only


### PR DESCRIPTION
## Summary
- Replaces the auto-commit-and-push behavior for OpenAPI snapshot updates with a verification step that fails CI if the snapshot is out of date
- Removes `contents: write` permission and git author env vars from the CI job since it no longer pushes commits
- Removes fork PR restriction so snapshot verification runs on all PRs

## Why
The previous behavior pushed a snapshot commit back to the PR branch, which re-triggered all required checks (~9 min wasted). Now CI simply fails with a clear error message telling the developer to update the snapshot locally.

## Test plan
- [ ] Open a PR that changes route files without updating the snapshot — CI should fail with the instructional error message
- [ ] Open a PR that changes route files with the snapshot already up to date — CI should pass with "OpenAPI snapshot is up to date"
- [ ] Open a PR with no route changes — snapshot check is skipped entirely

🤖 Generated with [Claude Code](https://claude.com/claude-code)