### PR TITLE
fix(agents-api): sanitize artifact binary data before persistence

### DIFF
--- a/agents-api/src/domains/run/artifacts/ArtifactService.ts
+++ b/agents-api/src/domains/run/artifacts/ArtifactService.ts
@@ -10,6 +10,7 @@ import jmespath from 'jmespath';
 import runDbClient from '../../../data/db/runDbClient';
 import { getLogger } from '../../../logger';
 import { toolSessionManager } from '../agents/services/ToolSessionManager';
+import { sanitizeArtifactBinaryData } from '../services/blob-storage/artifact-binary-sanitizer';
 import { agentSessionManager } from '../session/AgentSession';
 import {
   type ExtendedJsonSchema,
@@ -884,10 +885,24 @@ export class ArtifactService {
     metadata?: Record<string, any>;
     toolCallId?: string;
   }): Promise<void> {
-    // Use provided summaryData if available, otherwise default to artifact.data
-    let summaryData = artifact.summaryData || artifact.data;
-    let fullData = artifact.data;
     const { tenantId, projectId } = this.context.executionContext;
+
+    const sanitizedData = (await sanitizeArtifactBinaryData(artifact.data, {
+      tenantId,
+      projectId,
+      artifactId: artifact.artifactId,
+    })) as Record<string, any>;
+    const sanitizedSummaryData = artifact.summaryData
+      ? ((await sanitizeArtifactBinaryData(artifact.summaryData, {
+          tenantId,
+          projectId,
+          artifactId: artifact.artifactId,
+        })) as Record<string, any>)
+      : undefined;
+
+    // Use provided summaryData if available, otherwise default to sanitized data
+    let summaryData = sanitizedSummaryData || sanitizedData;
+    let fullData = sanitizedData;
 
     if (this.context.artifactComponents) {
       const artifactComponent = this.context.artifactComponents.find(
@@ -899,8 +914,8 @@ export class ArtifactService {
           const previewSchema = extractPreviewFields(schema);
           const fullSchema = extractFullFields(schema);
 
-          summaryData = this.filterBySchema(artifact.data, previewSchema);
-          fullData = this.filterBySchema(artifact.data, fullSchema);
+          summaryData = this.filterBySchema(sanitizedData, previewSchema);
+          fullData = this.filterBySchema(sanitizedData, fullSchema);
         } catch (error) {
           logger.warn(
             {

--- a/agents-api/src/domains/run/artifacts/__tests__/ArtifactService.test.ts
+++ b/agents-api/src/domains/run/artifacts/__tests__/ArtifactService.test.ts
@@ -14,6 +14,7 @@ const {
   upsertLedgerArtifactMock,
   toolSessionManagerMock,
   agentSessionManagerMock,
+  sanitizeArtifactBinaryDataMock,
 } = vi.hoisted(() => ({
   listTaskIdsByContextIdMock: vi.fn(),
   getTaskMock: vi.fn(),
@@ -33,6 +34,20 @@ const {
     setArtifactCache: vi.fn(),
     getArtifactCache: vi.fn(),
   },
+  sanitizeArtifactBinaryDataMock: vi.fn(async (value: unknown) => {
+    if (value !== null && typeof value === 'object' && !Array.isArray(value)) {
+      const part = value as Record<string, unknown>;
+      if (
+        (part.type === 'image' || part.type === 'file') &&
+        typeof part.data === 'string' &&
+        part.data.length > 0 &&
+        !part.data.startsWith('blob://')
+      ) {
+        return { ...part, data: 'blob://mock-key' };
+      }
+    }
+    return value;
+  }),
 }));
 
 // Mock @inkeep/agents-core WITHOUT importOriginal to avoid loading the heavy module
@@ -76,6 +91,11 @@ vi.mock('../../../../logger', () => ({
     debug: vi.fn(),
     child: vi.fn().mockReturnThis(),
   })),
+}));
+
+vi.mock('../../services/blob-storage/artifact-binary-sanitizer', () => ({
+  sanitizeArtifactBinaryData: sanitizeArtifactBinaryDataMock,
+  stripBinaryDataForObservability: vi.fn((value: unknown) => value),
 }));
 
 // Mock schema-validation to prevent @inkeep/agents-core/utils imports
@@ -741,6 +761,42 @@ describe('ArtifactService', () => {
         title: 'Test Title',
         summary: 'Test Summary',
       });
+    });
+  });
+
+  describe('saveArtifact', () => {
+    it('sanitizes both data and summaryData before persistence', async () => {
+      const upsertInvokerMock = vi.fn().mockResolvedValue({ created: true, existing: null });
+      upsertLedgerArtifactMock.mockReturnValue(upsertInvokerMock);
+
+      await artifactService.saveArtifact({
+        artifactId: 'art-save-1',
+        name: 'Artifact Name',
+        description: 'Artifact Description',
+        type: 'UnknownType',
+        data: { type: 'image', data: 'base64rawdata', mimeType: 'image/png' } as any,
+        summaryData: { type: 'image', data: 'base64summary', mimeType: 'image/png' } as any,
+        metadata: {},
+        toolCallId: 'tool-call-1',
+      });
+
+      expect(sanitizeArtifactBinaryDataMock).toHaveBeenCalledTimes(2);
+      expect(upsertLedgerArtifactMock).toHaveBeenCalledWith('mock-run-db-client');
+      expect(upsertInvokerMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          artifact: expect.objectContaining({
+            parts: [
+              {
+                kind: 'data',
+                data: {
+                  summary: expect.objectContaining({ data: 'blob://mock-key' }),
+                  full: expect.objectContaining({ data: 'blob://mock-key' }),
+                },
+              },
+            ],
+          }),
+        })
+      );
     });
   });
 

--- a/agents-api/src/domains/run/services/__tests__/artifact-binary-sanitizer.test.ts
+++ b/agents-api/src/domains/run/services/__tests__/artifact-binary-sanitizer.test.ts
@@ -1,0 +1,189 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  sanitizeArtifactBinaryData,
+  stripBinaryDataForObservability,
+} from '../blob-storage/artifact-binary-sanitizer';
+
+vi.mock('../blob-storage/index', () => ({
+  getBlobStorageProvider: vi.fn(),
+  isBlobUri: (s: string) => s.startsWith('blob://'),
+  toBlobUri: (key: string) => `blob://${key}`,
+  fromBlobUri: (uri: string) => uri.slice('blob://'.length),
+  BLOB_URI_PREFIX: 'blob://',
+}));
+
+vi.mock('../blob-storage/storage-keys', () => ({
+  buildStorageKey: vi.fn(
+    (input: any) =>
+      `v1/t_${input.tenantId}/artifact-data/p_${input.projectId}/a_${input.artifactId}/sha256-${input.contentHash}.${input.ext}`
+  ),
+}));
+
+const SMALL_BASE64 = 'aGVsbG8='; // "hello" — only 8 chars, below threshold
+const LARGE_BASE64 = Buffer.from('x'.repeat(200)).toString('base64'); // > 100 chars
+
+const CTX = { tenantId: 'tenant-1', projectId: 'proj-1', artifactId: 'art-1' };
+
+describe('stripBinaryDataForObservability', () => {
+  it('replaces image part data with placeholder', () => {
+    const input = { type: 'image', data: LARGE_BASE64, mimeType: 'image/png' };
+    const result = stripBinaryDataForObservability(input) as any;
+    expect(result.type).toBe('image');
+    expect(result.data).toMatch(/^\[binary data ~\d+ bytes, mimeType: image\/png\]$/);
+    expect(result.mimeType).toBe('image/png');
+  });
+
+  it('replaces file part data with placeholder', () => {
+    const input = { type: 'file', data: LARGE_BASE64, mimeType: 'application/pdf' };
+    const result = stripBinaryDataForObservability(input) as any;
+    expect(result.data).toMatch(/^\[binary data ~\d+ bytes/);
+  });
+
+  it('leaves already-blob-uri data untouched', () => {
+    const input = { type: 'image', data: 'blob://some/key', mimeType: 'image/png' };
+    const result = stripBinaryDataForObservability(input) as any;
+    expect(result.data).toBe('blob://some/key');
+  });
+
+  it('leaves small strings untouched (below 100 char threshold)', () => {
+    const input = { type: 'image', data: SMALL_BASE64, mimeType: 'image/png' };
+    const result = stripBinaryDataForObservability(input) as any;
+    expect(result.data).toBe(SMALL_BASE64);
+  });
+
+  it('leaves http URLs untouched', () => {
+    const input = { type: 'image', data: 'https://example.com/img.png', mimeType: 'image/png' };
+    const result = stripBinaryDataForObservability(input) as any;
+    expect(result.data).toBe('https://example.com/img.png');
+  });
+
+  it('recursively strips nested binary parts', () => {
+    const input = {
+      toolResult: [
+        { type: 'text', text: 'Ticket info' },
+        { type: 'image', data: LARGE_BASE64, mimeType: 'image/jpeg' },
+      ],
+    };
+    const result = stripBinaryDataForObservability(input) as any;
+    expect(result.toolResult[0]).toEqual({ type: 'text', text: 'Ticket info' });
+    expect(result.toolResult[1].data).toMatch(/^\[binary data/);
+  });
+
+  it('handles arrays at top level', () => {
+    const input = [
+      { type: 'text', text: 'hi' },
+      { type: 'image', data: LARGE_BASE64, mimeType: 'image/png' },
+    ];
+    const result = stripBinaryDataForObservability(input) as any[];
+    expect(result[0]).toEqual({ type: 'text', text: 'hi' });
+    expect(result[1].data).toMatch(/^\[binary data/);
+  });
+
+  it('passes through non-object primitives unchanged', () => {
+    expect(stripBinaryDataForObservability('hello')).toBe('hello');
+    expect(stripBinaryDataForObservability(42)).toBe(42);
+    expect(stripBinaryDataForObservability(null)).toBeNull();
+  });
+
+  it('handles circular references safely', () => {
+    const input: Record<string, unknown> = { type: 'container' };
+    input.self = input;
+
+    const result = stripBinaryDataForObservability(input) as Record<string, unknown>;
+    expect(result.type).toBe('container');
+    expect(result.self).toBe('[Circular Reference]');
+  });
+});
+
+describe('sanitizeArtifactBinaryData', () => {
+  let mockUpload: ReturnType<typeof vi.fn>;
+
+  beforeEach(async () => {
+    mockUpload = vi.fn().mockResolvedValue(undefined);
+    const { getBlobStorageProvider } = await import('../blob-storage/index');
+    vi.mocked(getBlobStorageProvider).mockReturnValue({
+      upload: mockUpload,
+      download: vi.fn(),
+      delete: vi.fn(),
+    });
+  });
+
+  it('uploads an inline image part and replaces data with blob:// URI', async () => {
+    const input = { type: 'image', data: LARGE_BASE64, mimeType: 'image/png' };
+    const result = (await sanitizeArtifactBinaryData(input, CTX)) as any;
+
+    expect(mockUpload).toHaveBeenCalledOnce();
+    expect(result.type).toBe('image');
+    expect(result.data).toMatch(/^blob:\/\//);
+    expect(result.mimeType).toBe('image/png');
+  });
+
+  it('preserves non-binary fields on the image part', async () => {
+    const input = { type: 'image', data: LARGE_BASE64, mimeType: 'image/jpeg', extra: 'keep' };
+    const result = (await sanitizeArtifactBinaryData(input, CTX)) as any;
+    expect(result.extra).toBe('keep');
+  });
+
+  it('does not re-upload data that is already a blob:// URI', async () => {
+    const input = { type: 'image', data: 'blob://v1/t_x/artifact-data/p_y/a_z/sha256-abc.png' };
+    await sanitizeArtifactBinaryData(input, CTX);
+    expect(mockUpload).not.toHaveBeenCalled();
+  });
+
+  it('recursively sanitizes nested structures', async () => {
+    const input = {
+      toolResult: [
+        { type: 'text', text: 'Ticket data' },
+        { type: 'image', data: LARGE_BASE64, mimeType: 'image/png' },
+      ],
+      toolName: 'get-zendesk-ticket',
+    };
+    const result = (await sanitizeArtifactBinaryData(input, CTX)) as any;
+
+    expect(result.toolName).toBe('get-zendesk-ticket');
+    expect(result.toolResult[0]).toEqual({ type: 'text', text: 'Ticket data' });
+    expect(result.toolResult[1].data).toMatch(/^blob:\/\//);
+    expect(mockUpload).toHaveBeenCalledOnce();
+  });
+
+  it('uploads multiple image parts independently', async () => {
+    const input = {
+      images: [
+        { type: 'image', data: LARGE_BASE64, mimeType: 'image/png' },
+        { type: 'image', data: LARGE_BASE64, mimeType: 'image/jpeg' },
+      ],
+    };
+    await sanitizeArtifactBinaryData(input, CTX);
+    expect(mockUpload).toHaveBeenCalledTimes(2);
+  });
+
+  it('leaves non-binary values unchanged', async () => {
+    const input = {
+      toolName: 'search',
+      toolInput: { query: 'test' },
+      count: 5,
+      flag: true,
+    };
+    const result = await sanitizeArtifactBinaryData(input, CTX);
+    expect(result).toEqual(input);
+    expect(mockUpload).not.toHaveBeenCalled();
+  });
+
+  it('produces a deterministic blob:// URI via content hash', async () => {
+    const input = { type: 'image', data: LARGE_BASE64, mimeType: 'image/png' };
+    const r1 = (await sanitizeArtifactBinaryData(input, CTX)) as any;
+    const r2 = (await sanitizeArtifactBinaryData(input, CTX)) as any;
+    expect(r1.data).toBe(r2.data);
+  });
+
+  it('handles circular references safely', async () => {
+    const input: Record<string, unknown> = {
+      toolResult: [{ type: 'image', data: LARGE_BASE64, mimeType: 'image/png' }],
+    };
+    input.self = input;
+
+    const result = (await sanitizeArtifactBinaryData(input, CTX)) as Record<string, unknown>;
+    expect(result.self).toBe('[Circular Reference]');
+    expect(mockUpload).toHaveBeenCalledOnce();
+  });
+});

--- a/agents-api/src/domains/run/services/blob-storage/artifact-binary-sanitizer.ts
+++ b/agents-api/src/domains/run/services/blob-storage/artifact-binary-sanitizer.ts
@@ -1,0 +1,155 @@
+import { createHash } from 'node:crypto';
+import { getExtensionFromMimeType } from '@inkeep/agents-core/constants/allowed-image-formats';
+import { getBlobStorageProvider, isBlobUri, toBlobUri } from './index';
+import { buildStorageKey } from './storage-keys';
+
+export interface ArtifactBinaryContext {
+  tenantId: string;
+  projectId: string;
+  artifactId: string;
+}
+
+type InlineBinaryPart = {
+  type: 'image' | 'file';
+  data: string;
+  mimeType?: string;
+  [key: string]: unknown;
+};
+
+const CIRCULAR_REFERENCE_PLACEHOLDER = '[Circular Reference]';
+
+function isInlineBinaryPart(value: unknown): value is InlineBinaryPart {
+  if (typeof value !== 'object' || value === null) return false;
+  const v = value as Record<string, unknown>;
+  return (
+    (v.type === 'image' || v.type === 'file') &&
+    typeof v.data === 'string' &&
+    v.data.length > 100 &&
+    !isBlobUri(v.data) &&
+    !v.data.startsWith('http') &&
+    !v.data.startsWith('data:')
+  );
+}
+
+async function uploadInlinePart(
+  part: InlineBinaryPart,
+  ctx: ArtifactBinaryContext
+): Promise<InlineBinaryPart> {
+  const storage = getBlobStorageProvider();
+  const buffer = Buffer.from(part.data, 'base64');
+  const mimeType = part.mimeType ?? 'application/octet-stream';
+  const contentHash = createHash('sha256').update(buffer).digest('hex');
+  const ext = getExtensionFromMimeType(mimeType);
+
+  const key = buildStorageKey({
+    category: 'artifact-data',
+    tenantId: ctx.tenantId,
+    projectId: ctx.projectId,
+    artifactId: ctx.artifactId,
+    contentHash,
+    ext,
+  });
+
+  await storage.upload({ key, data: buffer, contentType: mimeType });
+
+  return { ...part, data: toBlobUri(key) };
+}
+
+/**
+ * Recursively walk `value` and upload any inline binary image/file parts
+ * (i.e. objects with `{ type: "image"|"file", data: "<base64>" }`) to blob
+ * storage, replacing the raw base64 with a `blob://` URI.
+ *
+ * Safe to call on already-sanitized data — parts whose `data` is already a
+ * `blob://` URI are left untouched.
+ */
+export async function sanitizeArtifactBinaryData(
+  value: unknown,
+  ctx: ArtifactBinaryContext
+): Promise<unknown> {
+  const inStack = new WeakSet<object>();
+
+  const visit = async (current: unknown): Promise<unknown> => {
+    if (isInlineBinaryPart(current)) {
+      return uploadInlinePart(current, ctx);
+    }
+    if (Array.isArray(current)) {
+      if (inStack.has(current)) {
+        return CIRCULAR_REFERENCE_PLACEHOLDER;
+      }
+      inStack.add(current);
+      try {
+        return Promise.all(current.map((item) => visit(item)));
+      } finally {
+        inStack.delete(current);
+      }
+    }
+    if (current !== null && typeof current === 'object') {
+      if (inStack.has(current)) {
+        return CIRCULAR_REFERENCE_PLACEHOLDER;
+      }
+      inStack.add(current);
+      try {
+        const result: Record<string, unknown> = {};
+        for (const [k, v] of Object.entries(current as Record<string, unknown>)) {
+          result[k] = await visit(v);
+        }
+        return result;
+      } finally {
+        inStack.delete(current);
+      }
+    }
+    return current;
+  };
+
+  return visit(value);
+}
+
+/**
+ * Synchronously walk `value` and replace any inline binary data strings with
+ * a human-readable placeholder. Use this before writing to OTEL span
+ * attributes or LLM prompts where raw base64 is useless noise.
+ */
+export function stripBinaryDataForObservability(value: unknown): unknown {
+  const inStack = new WeakSet<object>();
+
+  const visit = (current: unknown): unknown => {
+    if (isInlineBinaryPart(current)) {
+      const part = current as InlineBinaryPart;
+      const approxBytes = Math.round(part.data.length * 0.75);
+      return {
+        ...part,
+        data: `[binary data ~${approxBytes} bytes, mimeType: ${part.mimeType ?? 'unknown'}]`,
+      };
+    }
+    if (Array.isArray(current)) {
+      if (inStack.has(current)) {
+        return CIRCULAR_REFERENCE_PLACEHOLDER;
+      }
+      inStack.add(current);
+      try {
+        return current.map(visit);
+      } finally {
+        inStack.delete(current);
+      }
+    }
+    if (current !== null && typeof current === 'object') {
+      if (inStack.has(current)) {
+        return CIRCULAR_REFERENCE_PLACEHOLDER;
+      }
+      inStack.add(current);
+      try {
+        const result: Record<string, unknown> = {};
+        for (const [k, v] of Object.entries(current as Record<string, unknown>)) {
+          result[k] = visit(v);
+        }
+        return result;
+      } finally {
+        inStack.delete(current);
+      }
+    }
+    return current;
+  };
+
+  return visit(value);
+}

--- a/agents-api/src/domains/run/services/blob-storage/storage-keys.ts
+++ b/agents-api/src/domains/run/services/blob-storage/storage-keys.ts
@@ -10,7 +10,16 @@ export type ConversationMediaKeyInput = {
   ext: string;
 };
 
-export type StorageKeyInput = ConversationMediaKeyInput;
+export type ArtifactDataKeyInput = {
+  category: 'artifact-data';
+  tenantId: string;
+  projectId: string;
+  artifactId: string;
+  contentHash: string;
+  ext: string;
+};
+
+export type StorageKeyInput = ConversationMediaKeyInput | ArtifactDataKeyInput;
 
 export function buildStorageKey(input: StorageKeyInput): string {
   switch (input.category) {
@@ -23,6 +32,15 @@ export function buildStorageKey(input: StorageKeyInput): string {
         'conv',
         `c_${input.conversationId}`,
         `m_${input.messageId}`,
+        `sha256-${input.contentHash}.${input.ext}`,
+      ].join('/');
+    case 'artifact-data':
+      return [
+        STORAGE_KEY_VERSION,
+        `t_${input.tenantId}`,
+        input.category,
+        `p_${input.projectId}`,
+        `a_${input.artifactId}`,
         `sha256-${input.contentHash}.${input.ext}`,
       ].join('/');
   }

--- a/agents-api/src/domains/run/session/AgentSession.ts
+++ b/agents-api/src/domains/run/session/AgentSession.ts
@@ -32,6 +32,7 @@ import {
   STATUS_UPDATE_DEFAULT_NUM_EVENTS,
 } from '../constants/execution-limits';
 import { getFormattedConversationHistory, getScopedHistory } from '../data/conversations';
+import { stripBinaryDataForObservability } from '../services/blob-storage/artifact-binary-sanitizer';
 import { getStreamHelper } from '../stream/stream-registry';
 import { defaultStatusSchemas } from '../utils/default-status-schemas';
 import { getModelContextWindow } from '../utils/model-context-utils';
@@ -1366,7 +1367,11 @@ ${this.statusUpdateState?.config.prompt?.trim() || ''}`;
           'subAgent.id': artifactData.subAgentId || 'unknown',
           'subAgent.name': artifactData.subAgentName || 'unknown',
           'artifact.tool_call_id': artifactData.metadata?.toolCallId || 'unknown',
-          'artifact.data': JSON.stringify(artifactData.data, null, 2),
+          'artifact.data': JSON.stringify(
+            stripBinaryDataForObservability(artifactData.data),
+            null,
+            2
+          ),
           'tenant.id': artifactData.tenantId || 'unknown',
           'project.id': artifactData.projectId || 'unknown',
           'context.id': artifactData.contextId || 'unknown',
@@ -1576,8 +1581,9 @@ ${this.statusUpdateState?.config.prompt?.trim() || ''}`;
             };
           } else {
             // Truncate artifact data based on model context limits (use 20% for data preview)
+            // Strip binary blobs before serializing — base64 is useless noise for the naming LLM
             const fullDataStr = JSON.stringify(
-              artifactData.data || artifactData.summaryData || {},
+              stripBinaryDataForObservability(artifactData.data || artifactData.summaryData || {}),
               null,
               2
             );
@@ -1664,7 +1670,7 @@ Make the name extremely specific to what this tool call actually returned, not g
                   'artifact.type': artifactData.artifactType,
                   'artifact.summary': JSON.stringify(artifactData.summaryData, null, 2),
                   'artifact.full': JSON.stringify(
-                    artifactData.data || artifactData.summaryData,
+                    stripBinaryDataForObservability(artifactData.data || artifactData.summaryData),
                     null,
                     2
                   ),
@@ -1703,7 +1709,9 @@ Make the name extremely specific to what this tool call actually returned, not g
                       'artifact.description': result.output.description,
                       'artifact.summary': JSON.stringify(artifactData.summaryData, null, 2),
                       'artifact.full': JSON.stringify(
-                        artifactData.data || artifactData.summaryData,
+                        stripBinaryDataForObservability(
+                          artifactData.data || artifactData.summaryData
+                        ),
                         null,
                         2
                       ),


### PR DESCRIPTION
**Summary**
- Sanitize inline artifact binary payloads before persistence by uploading base64 image/file parts to blob storage and replacing them with blob:// URIs.
- Keep observability and naming prompts cleaner by stripping large binary payloads from artifact telemetry/prompt serialization paths.
