### PR TITLE
fix(manage-ui): reuse existing Nango integration for MCP OAuth login

### DIFF
--- a/.changeset/quaint-crimson-muskox.md
+++ b/.changeset/quaint-crimson-muskox.md
@@ -1,0 +1,5 @@
+---
+"@inkeep/agents-manage-ui": patch
+---
+
+Fix Nango MCP integration reuse regression causing 'integration already exists' error on OAuth login

--- a/agents-manage-ui/src/lib/mcp-tools/nango.ts
+++ b/agents-manage-ui/src/lib/mcp-tools/nango.ts
@@ -415,7 +415,7 @@ export async function createProviderConnectSession({
       console.debug(`Integration '${providerName}' not found, will create new one`);
     }
 
-    if (existingIntegration?.areCredentialsSet) {
+    if (existingIntegration) {
       integration = existingIntegration;
     } else {
       try {


### PR DESCRIPTION
## Summary

- Fix regression from #2708 where MCP OAuth login fails with "Nango integration already exists" when a credential reference and MCP server share the same name
- The `buildMaskedCredentials` refactor removed the catch-all `areCredentialsSet = true` for non-OAUTH/TBA/APP credential types — MCP-generic integrations have no client credentials, so `areCredentialsSet` became `false`, causing the code to skip reuse and attempt a duplicate create
- Fix: check `existingIntegration` instead of `existingIntegration?.areCredentialsSet` in `createProviderConnectSession`

## Test plan

- [ ] Create a credential reference named "test" linked to an MCP server
- [ ] Disconnect the credential from the MCP server
- [ ] Click "Login" on the MCP server again — should succeed without "already exists" error
- [ ] Verify fresh MCP server OAuth login still works (no existing integration)
- [ ] Verify provider OAuth (Slack, GitHub) credential creation still works


Made with [Cursor](https://cursor.com)