### PR TITLE
Scope GitHub installation access tokens to repository_id in OIDC exchange

### DIFF
--- a/.changeset/green-badgers-prove.md
+++ b/.changeset/green-badgers-prove.md
@@ -1,0 +1,5 @@
+---
+'@inkeep/agents-work-apps': patch
+---
+
+Fix GitHub OIDC token exchange to scope installation tokens to the repository from the OIDC claims.

--- a/packages/agents-work-apps/src/__tests__/github/routes/token-exchange.test.ts
+++ b/packages/agents-work-apps/src/__tests__/github/routes/token-exchange.test.ts
@@ -130,7 +130,7 @@ describe('GitHub Token Exchange Route', () => {
         expect(validateOidcTokenMock).toHaveBeenCalledWith(validToken);
         expect(lookupInstallationForRepoMock).toHaveBeenCalledWith('test-org', 'test-repo');
         expect(getInstallationByGitHubIdMock).toHaveBeenCalledWith('12345678');
-        expect(generateInstallationAccessTokenMock).toHaveBeenCalledWith(12345678);
+        expect(generateInstallationAccessTokenMock).toHaveBeenCalledWith(12345678, 123456789);
       });
 
       it('should return installation token with project_id when project has access', async () => {
@@ -206,6 +206,57 @@ describe('GitHub Token Exchange Route', () => {
     });
 
     describe('400 Bad Request cases', () => {
+      it('should return 400 when repository_id claim is invalid', async () => {
+        const validToken = await createTestOidcToken();
+
+        validateOidcTokenMock.mockResolvedValue({
+          success: true,
+          claims: {
+            repository: 'test-org/test-repo',
+            repository_owner: 'test-org',
+            repository_id: 'not-a-number',
+            workflow: 'CI',
+            actor: 'test-user',
+            ref: 'refs/heads/main',
+          },
+        });
+
+        lookupInstallationForRepoMock.mockResolvedValue({
+          success: true,
+          installation: {
+            installationId: 12345678,
+            appId: 98765,
+          },
+        });
+
+        getInstallationByGitHubIdMock.mockResolvedValue({
+          id: 'inst_123',
+          tenantId: 'tenant_abc123',
+          installationId: '12345678',
+          accountLogin: 'test-org',
+          accountId: '99999',
+          accountType: 'Organization',
+          status: 'active',
+          createdAt: '2026-01-01T00:00:00Z',
+          updatedAt: '2026-01-01T00:00:00Z',
+        });
+
+        const response = await app.request('/', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ oidc_token: validToken }),
+        });
+
+        expect(response.status).toBe(400);
+        const body = await response.json();
+        expect(body).toMatchObject({
+          title: 'Bad Request',
+          status: 400,
+          error: 'OIDC token contains an invalid repository_id claim',
+        });
+        expect(generateInstallationAccessTokenMock).not.toHaveBeenCalled();
+      });
+
       it('should return 400 when oidc_token is missing', async () => {
         const response = await app.request('/', {
           method: 'POST',

--- a/packages/agents-work-apps/src/github/installation.ts
+++ b/packages/agents-work-apps/src/github/installation.ts
@@ -184,7 +184,8 @@ export async function lookupInstallationForRepo(
 }
 
 export async function generateInstallationAccessToken(
-  installationId: number
+  installationId: number,
+  repositoryId: number
 ): Promise<GenerateInstallationAccessTokenResult> {
   let appJwt: string;
   try {
@@ -207,9 +208,13 @@ export async function generateInstallationAccessToken(
       headers: {
         Authorization: `Bearer ${appJwt}`,
         Accept: 'application/vnd.github+json',
+        'Content-Type': 'application/json',
         'X-GitHub-Api-Version': '2022-11-28',
         'User-Agent': 'inkeep-agents-api',
       },
+      body: JSON.stringify({
+        repository_ids: [repositoryId],
+      }),
     });
 
     if (!response.ok) {
@@ -249,7 +254,7 @@ export async function generateInstallationAccessToken(
   } catch (error) {
     const message = error instanceof Error ? error.message : 'Unknown error';
     logger.error(
-      { error: message, installationId },
+      { error: message, installationId, repositoryId },
       'Error calling GitHub API to generate installation access token'
     );
     return {

--- a/packages/agents-work-apps/src/github/routes/tokenExchange.ts
+++ b/packages/agents-work-apps/src/github/routes/tokenExchange.ts
@@ -287,7 +287,29 @@ app.post('/', async (c) => {
     );
   }
 
-  const tokenResult = await generateInstallationAccessToken(installation.installationId);
+  const repositoryId = Number.parseInt(claims.repository_id, 10);
+  if (!Number.isSafeInteger(repositoryId) || repositoryId <= 0) {
+    const errorMessage = 'OIDC token contains an invalid repository_id claim';
+    logger.warn(
+      { repository: claims.repository, repositoryId: claims.repository_id },
+      errorMessage
+    );
+    c.header('Content-Type', 'application/problem+json');
+    return c.json(
+      {
+        title: 'Bad Request',
+        status: 400,
+        detail: errorMessage,
+        error: errorMessage,
+      },
+      400
+    );
+  }
+
+  const tokenResult = await generateInstallationAccessToken(
+    installation.installationId,
+    repositoryId
+  );
 
   if (!tokenResult.success) {
     const { errorType, message } = tokenResult;


### PR DESCRIPTION
### Motivation
- The OIDC token exchange previously minted GitHub App installation tokens without scoping them to the originating repository, allowing cross-repository access within the same installation. 
- The change ensures installation tokens are limited to the `repository_id` from the validated OIDC claims to prevent unauthorized access to other repositories in the installation.

### Description
- Parse and validate `repository_id` from the OIDC claims in `packages/agents-work-apps/src/github/routes/tokenExchange.ts` and return `400` if the claim is missing or invalid via a problem+json response. 
- Update `generateInstallationAccessToken` in `packages/agents-work-apps/src/github/installation.ts` to accept `repositoryId` and include `repository_ids: [repositoryId]` in the POST body to GitHub's `/app/installations/{id}/access_tokens` endpoint so the token is scoped to a single repository. 
- Update unit test expectations in `packages/agents-work-apps/src/__tests__/github/routes/token-exchange.test.ts` to assert the repository-id is passed to token generation and add a regression test that rejects invalid `repository_id` claims. 
- Add a patch changeset for `@inkeep/agents-work-apps` describing the security fix.

### Testing
- Ran `pnpm exec biome check --write packages/agents-work-apps/src/github/routes/tokenExchange.ts packages/agents-work-apps/src/github/installation.ts packages/agents-work-apps/src/__tests__/github/routes/token-exchange.test.ts .changeset/green-badgers-prove.md` which completed and auto-fixed formatting issues. 
- Attempted `pnpm --filter @inkeep/agents-work-apps test -- --run src/__tests__/github/routes/token-exchange.test.ts`, but Vitest failed to start in this environment because the workspace package `@inkeep/agents-core` could not be resolved, so the new test could not be executed end-to-end here. 
- Attempted `pnpm --filter @inkeep/agents-work-apps typecheck`, which also failed in this environment due to unresolved workspace imports and unrelated pre-existing type resolution issues outside the scope of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69b9fee0957c833383c5d548eec9fb7f)