### PR TITLE
Resolve sentinel refs before tool execution

### DIFF
--- a/agents-api/src/domains/run/agents/generation/__tests__/ai-sdk-callbacks.test.ts
+++ b/agents-api/src/domains/run/agents/generation/__tests__/ai-sdk-callbacks.test.ts
@@ -1,8 +1,9 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { handlePrepareStepCompression } from '../ai-sdk-callbacks';
+import { agentSessionManager } from '../../../session/AgentSession';
+import { createRepairToolCallHandler, handlePrepareStepCompression } from '../ai-sdk-callbacks';
 
 vi.mock('../../../session/AgentSession', () => ({
-  agentSessionManager: { getSession: vi.fn() },
+  agentSessionManager: { getSession: vi.fn(), getArtifactParser: vi.fn() },
 }));
 
 vi.mock('@inkeep/agents-core', async (importOriginal) => {
@@ -227,5 +228,125 @@ describe('handlePrepareStepCompression', () => {
 
     const result = await handlePrepareStepCompression(makeMessages(6), compressor, 2);
     expect(result).toEqual({});
+  });
+});
+
+describe('createRepairToolCallHandler', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  function makeCtx(streamRequestId?: string): any {
+    return {
+      streamRequestId,
+      config: {
+        id: 'sub-agent-1',
+        agentId: 'agent-1',
+      },
+    };
+  }
+
+  it('repairs tool call input by resolving sentinel references', async () => {
+    const resolveArgs = vi.fn().mockResolvedValue({
+      image: { data: 'abc123', mimeType: 'image/png' },
+    });
+    vi.mocked(agentSessionManager.getArtifactParser).mockReturnValue({ resolveArgs } as any);
+
+    const handler = createRepairToolCallHandler(makeCtx('stream-1'));
+    const repaired = await handler({
+      toolCall: {
+        type: 'tool-call',
+        toolCallId: 'call-1',
+        toolName: 'image_info',
+        input: '{"image":{"$tool":"call-read-ticket","$path":"[?type==\'image\'] | [0]"}}',
+      },
+      error: new Error('Invalid tool input'),
+    });
+
+    expect(resolveArgs).toHaveBeenCalledWith({
+      image: { $tool: 'call-read-ticket', $path: "[?type=='image'] | [0]" },
+    });
+    expect(repaired).toEqual({
+      type: 'tool-call',
+      toolCallId: 'call-1',
+      toolName: 'image_info',
+      input: '{"image":{"data":"abc123","mimeType":"image/png"}}',
+    });
+  });
+
+  it('repairs nested JSON-string sentinel refs in scalar fields', async () => {
+    const resolveArgs = vi.fn().mockResolvedValue({
+      image: { data: 'abc123', mimeType: 'image/png' },
+      width: 168,
+      height: 300,
+    });
+    vi.mocked(agentSessionManager.getArtifactParser).mockReturnValue({ resolveArgs } as any);
+
+    const handler = createRepairToolCallHandler(makeCtx('stream-1'));
+    const repaired = await handler({
+      toolCall: {
+        type: 'tool-call',
+        toolCallId: 'call-2',
+        toolName: 'image_resize',
+        input: JSON.stringify({
+          image: { $artifact: 'art-1', $tool: 'call-ticket' },
+          width: '{"$tool":"call-info","$path":"width"}',
+          height: '{"$tool":"call-info","$path":"height"}',
+        }),
+      },
+      error: new Error('Invalid tool input'),
+    });
+
+    expect(resolveArgs).toHaveBeenCalledWith({
+      image: { $artifact: 'art-1', $tool: 'call-ticket' },
+      width: { $tool: 'call-info', $path: 'width' },
+      height: { $tool: 'call-info', $path: 'height' },
+    });
+    expect(repaired).toEqual({
+      type: 'tool-call',
+      toolCallId: 'call-2',
+      toolName: 'image_resize',
+      input: '{"image":{"data":"abc123","mimeType":"image/png"},"width":168,"height":300}',
+    });
+  });
+
+  it('returns null when no sentinel references are present', async () => {
+    const resolveArgs = vi
+      .fn()
+      .mockResolvedValue({ image: { data: 'abc123', mimeType: 'image/png' } });
+    vi.mocked(agentSessionManager.getArtifactParser).mockReturnValue({ resolveArgs } as any);
+
+    const handler = createRepairToolCallHandler(makeCtx('stream-1'));
+    const repaired = await handler({
+      toolCall: {
+        type: 'tool-call',
+        toolCallId: 'call-1',
+        toolName: 'image_info',
+        input: { image: { data: 'abc123', mimeType: 'image/png' } },
+      },
+      error: new Error('Invalid tool input'),
+    });
+
+    expect(resolveArgs).not.toHaveBeenCalled();
+    expect(repaired).toBeNull();
+  });
+
+  it('returns null when resolution fails', async () => {
+    const resolveArgs = vi.fn().mockRejectedValue(new Error('tool result missing'));
+    vi.mocked(agentSessionManager.getArtifactParser).mockReturnValue({ resolveArgs } as any);
+
+    const handler = createRepairToolCallHandler(makeCtx('stream-1'));
+    const repaired = await handler({
+      toolCall: {
+        type: 'tool-call',
+        toolCallId: 'call-1',
+        toolName: 'image_info',
+        input: { image: { $tool: 'call-read-ticket' } },
+      },
+      error: new Error('Invalid tool input'),
+    });
+
+    expect(resolveArgs).toHaveBeenCalledWith({ image: { $tool: 'call-read-ticket' } });
+    expect(repaired).toBeNull();
   });
 });

--- a/agents-api/src/domains/run/agents/generation/ai-sdk-callbacks.ts
+++ b/agents-api/src/domains/run/agents/generation/ai-sdk-callbacks.ts
@@ -1,11 +1,144 @@
+import { parseEmbeddedJson } from '@inkeep/agents-core';
 import { getLogger } from '../../../../logger';
 import type { MidGenerationCompressor } from '../../compression/MidGenerationCompressor';
+import { SENTINEL_KEY } from '../../constants/artifact-syntax';
 import { agentSessionManager } from '../../session/AgentSession';
 import { tracer } from '../../utils/tracer';
 import type { AgentRunContext } from '../agent-types';
 import { getMaxGenerationSteps } from './model-config';
 
 const logger = getLogger('Agent');
+
+function hasSentinelReference(value: unknown): boolean {
+  if (!value || typeof value !== 'object') {
+    return false;
+  }
+
+  if (Array.isArray(value)) {
+    return value.some((item) => hasSentinelReference(item));
+  }
+
+  const record = value as Record<string, unknown>;
+  if (
+    typeof record[SENTINEL_KEY.TOOL] === 'string' ||
+    (typeof record[SENTINEL_KEY.ARTIFACT] === 'string' &&
+      typeof record[SENTINEL_KEY.TOOL] === 'string')
+  ) {
+    return true;
+  }
+
+  return Object.values(record).some((item) => hasSentinelReference(item));
+}
+
+type RepairableToolCall = {
+  type?: string;
+  toolCallId: string;
+  toolName: string;
+  input: unknown;
+};
+
+function parseJsonContainerString(value: string): unknown {
+  const trimmed = value.trim();
+  if (!(trimmed.startsWith('{') || trimmed.startsWith('['))) {
+    return value;
+  }
+
+  try {
+    return JSON.parse(trimmed);
+  } catch {
+    return value;
+  }
+}
+
+function normalizeEmbeddedJsonStrings(value: unknown): unknown {
+  if (typeof value === 'string') {
+    const parsed = parseJsonContainerString(value);
+    if (parsed === value) {
+      return value;
+    }
+    return normalizeEmbeddedJsonStrings(parsed);
+  }
+
+  if (Array.isArray(value)) {
+    return value.map((item) => normalizeEmbeddedJsonStrings(item));
+  }
+
+  if (!value || typeof value !== 'object') {
+    return value;
+  }
+
+  return Object.fromEntries(
+    Object.entries(value).map(([key, nested]) => [key, normalizeEmbeddedJsonStrings(nested)])
+  );
+}
+
+function normalizeToolInput(input: unknown): unknown {
+  if (typeof input === 'string') {
+    try {
+      return normalizeEmbeddedJsonStrings(JSON.parse(input));
+    } catch {
+      try {
+        const parsed = parseEmbeddedJson(input);
+        if (typeof parsed === 'string') {
+          return undefined;
+        }
+        return normalizeEmbeddedJsonStrings(parsed);
+      } catch {
+        return undefined;
+      }
+    }
+  }
+
+  return normalizeEmbeddedJsonStrings(parseEmbeddedJson(input));
+}
+
+export function createRepairToolCallHandler(ctx: AgentRunContext) {
+  return async ({ toolCall, error }: { toolCall: RepairableToolCall; error: unknown }) => {
+    const streamRequestId = ctx.streamRequestId;
+    if (!streamRequestId || !toolCall?.toolCallId) {
+      return null;
+    }
+
+    const parser = agentSessionManager.getArtifactParser(streamRequestId);
+    if (!parser) {
+      return null;
+    }
+
+    const parsedInput = normalizeToolInput(toolCall.input);
+    if (parsedInput === undefined || !hasSentinelReference(parsedInput)) {
+      return null;
+    }
+
+    try {
+      const resolved = await parser.resolveArgs(parsedInput);
+      if (JSON.stringify(resolved) === JSON.stringify(parsedInput)) {
+        return null;
+      }
+
+      const repairedInput = JSON.stringify(resolved);
+      if (typeof repairedInput !== 'string') {
+        return null;
+      }
+
+      return {
+        ...toolCall,
+        input: repairedInput,
+      };
+    } catch (resolveError) {
+      logger.debug(
+        {
+          streamRequestId,
+          toolCallId: toolCall.toolCallId,
+          toolName: toolCall.toolName,
+          error: error instanceof Error ? error.message : String(error),
+          resolveError: resolveError instanceof Error ? resolveError.message : String(resolveError),
+        },
+        'Tool repair failed while resolving sentinel references'
+      );
+      return null;
+    }
+  };
+}
 
 export async function handlePrepareStepCompression(
   stepMessages: any[],

--- a/agents-api/src/domains/run/agents/generation/generate.ts
+++ b/agents-api/src/domains/run/agents/generation/generate.ts
@@ -15,7 +15,11 @@ import type { AgentRunContext, ResolvedGenerationResponse } from '../agent-types
 import { hasToolCallWithPrefix, resolveGenerationResponse } from '../agent-types';
 import { handleStreamGeneration } from '../streaming/stream-handler';
 import { V1_BREAKDOWN_SCHEMA } from '../versions/v1/PromptConfig';
-import { handlePrepareStepCompression, handleStopWhenConditions } from './ai-sdk-callbacks';
+import {
+  createRepairToolCallHandler,
+  handlePrepareStepCompression,
+  handleStopWhenConditions,
+} from './ai-sdk-callbacks';
 import { setupCompression } from './compression';
 import { buildConversationHistory, buildInitialMessages } from './conversation-history';
 import { configureModelSettings } from './model-config';
@@ -80,6 +84,7 @@ export function buildBaseGenerationConfig(
     stopWhen: async ({ steps }: { steps: unknown[] }) => {
       return await handleStopWhenConditions(ctx, steps);
     },
+    experimental_repairToolCall: createRepairToolCallHandler(ctx),
     experimental_telemetry: buildTelemetryConfig(ctx, phase),
     abortSignal: AbortSignal.timeout(timeoutMs),
   };

--- a/agents-api/src/domains/run/artifacts/__tests__/ArtifactParser.typeSchema.test.ts
+++ b/agents-api/src/domains/run/artifacts/__tests__/ArtifactParser.typeSchema.test.ts
@@ -350,7 +350,6 @@ describe('ArtifactParser — typeSchema in data parts', () => {
         const imageResult = {
           result: {
             data: 'base64data==',
-            encoding: 'base64',
             mimeType: 'image/png',
           },
         };

--- a/agents-api/src/domains/run/artifacts/__tests__/ArtifactService.test.ts
+++ b/agents-api/src/domains/run/artifacts/__tests__/ArtifactService.test.ts
@@ -551,7 +551,6 @@ describe('ArtifactService', () => {
       });
       expect(artifactService.getToolResultRaw('call-img')).toEqual({
         data: 'base64data==',
-        encoding: 'base64',
         mimeType: 'image/png',
       });
     });

--- a/agents-api/src/domains/run/artifacts/artifact-utils.ts
+++ b/agents-api/src/domains/run/artifacts/artifact-utils.ts
@@ -27,12 +27,11 @@ export function queryJMESPath(data: unknown, selector: string): unknown {
 
 export type NormalizedContentItem =
   | { type: 'text'; text: unknown }
-  | { type: 'image'; data: string; encoding: 'base64'; mimeType: string };
+  | { type: 'image'; data: string; mimeType: string };
 
 function normalizeContentItem(item: any): NormalizedContentItem | null {
   if (item?.type === 'text') return { type: 'text', text: item.text };
-  if (item?.type === 'image')
-    return { type: 'image', data: item.data, encoding: 'base64', mimeType: item.mimeType };
+  if (item?.type === 'image') return { type: 'image', data: item.data, mimeType: item.mimeType };
   return null;
 }
 
@@ -52,8 +51,7 @@ export function unwrapToolResult(result: any): unknown {
     if (items.length === 1) {
       const first = items[0];
       if (first?.type === 'text') return first.text;
-      if (first?.type === 'image')
-        return { data: first.data, encoding: 'base64', mimeType: first.mimeType };
+      if (first?.type === 'image') return { data: first.data, mimeType: first.mimeType };
       return first;
     }
 

--- a/agents-api/src/mcp-media/server.ts
+++ b/agents-api/src/mcp-media/server.ts
@@ -10,11 +10,11 @@ Use these tools to inspect and manipulate images.
 - **image_resize** — scale an image to target dimensions. Provide width, height, or both. Aspect ratio is preserved by default.
 
 ## Input format
-All tools accept an image object with fields: data (base64-encoded bytes), encoding ("base64"), and mimeType (e.g. "image/png"). If you have a URL, fetch it and base64-encode the response body.
+All tools accept an image object with fields: data (base64-encoded bytes) and mimeType (e.g. "image/png"). If you have a URL, fetch it and base64-encode the response body.
 
 ## Chaining example
 Tools return the same image object format they accept, so you can chain them directly:
-1. image_info({ "image": { "data": "<base64>", "encoding": "base64", "mimeType": "image/png" } }) — inspect dimensions
+1. image_info({ "image": { "data": "<base64>", "mimeType": "image/png" } }) — inspect dimensions
 2. image_crop({ "image": <ref to step 1 result>, "x": 0, "y": 0, "width": 200, "height": 200 })
 3. image_resize({ "image": <ref to step 2 result>, "width": 100 })
 

--- a/agents-api/src/mcp-media/tools/image.ts
+++ b/agents-api/src/mcp-media/tools/image.ts
@@ -5,11 +5,10 @@ import { z } from 'zod';
 
 const MAX_IMAGE_BASE64_BYTES = 25 * 1024 * 1024;
 
-type ImageInput = { data: string; encoding: 'base64'; mimeType: string };
+type ImageInput = { data: string; mimeType: string };
 
 export const imageInputSchema = z.object({
   data: z.string().describe('Base64-encoded image bytes'),
-  encoding: z.literal('base64').describe('Encoding of the data field — must be "base64"'),
   mimeType: z.string().describe('MIME type of the image (e.g. "image/png", "image/jpeg")'),
 });
 
@@ -26,7 +25,7 @@ export function registerImageTools(server: McpServer): void {
     {
       description: 'Get metadata about an image: dimensions, format, channels, and file size.',
       inputSchema: z.object({
-        image: imageInputSchema.describe('Image object with base64 data, encoding, and mimeType'),
+        image: imageInputSchema.describe('Image object with base64 data and mimeType'),
       }),
     },
     async ({ image }): Promise<CallToolResult> => {


### PR DESCRIPTION
The AI SDK validates tool args against the tool schema **before** `execute()` is called, so the `$tool`/`$artifact`/`$path` sentinel keys are rejected before `resolveArgs` can replace them with real data.

1. Model outputs `image_info({ image: { $tool: "...", $path: "..." } })`
2. AI SDK validates this against the MCP-derived Zod schema (`z.object({ data: z.string(), mimeType: z.string() })`) — **fails** because `data` and `mimeType` are missing
3. AI SDK throws `InvalidToolInputError`, catches it internally, and marks the tool call as `invalid: true`

The tool chaining sentinel keys (`$tool`, `$path`, `$artifact`) are **never resolved** because the AI SDK validates tool args **before** calling `execute()`. The model's raw JSON `{ $tool: "..." }` fails schema validation and `execute()` (where `resolveArgs` lives) is never reached. The reference resolution system works correctly — it's just never invoked.

**What was changed:**
1. Use the AI SDK's `repairToolCall` callback to resolve references during the repair phase
2. **`imageInputSchema`**: Removed unnecessary `encoding` field — still a good cleanup but not the root cause
