### PR TITLE
fix: treat load_skill as internal tool to suppress false-positive Sentry errors

### DIFF
--- a/agents-api/src/domains/run/agents/tools/default-tools.ts
+++ b/agents-api/src/domains/run/agents/tools/default-tools.ts
@@ -127,8 +127,7 @@ export async function getDefaultTools(
       'load_skill',
       createLoadSkillTool(ctx),
       streamRequestId,
-      'tool',
-      { relationshipIdOverride: ctx.config.relationId }
+      'tool'
     );
   }
 

--- a/agents-api/src/domains/run/agents/tools/tool-wrapper.ts
+++ b/agents-api/src/domains/run/agents/tools/tool-wrapper.ts
@@ -61,12 +61,7 @@ export function wrapToolWithStreaming(
   toolDefinition: ToolSet[string],
   streamRequestId?: string,
   toolType?: ToolType,
-  options?: {
-    needsApproval?: boolean;
-    mcpServerId?: string;
-    mcpServerName?: string;
-    relationshipIdOverride?: string;
-  }
+  options?: { needsApproval?: boolean; mcpServerId?: string; mcpServerName?: string }
 ): ToolSet[string] {
   if (
     !toolDefinition ||
@@ -75,8 +70,7 @@ export function wrapToolWithStreaming(
   ) {
     return toolDefinition;
   }
-  const relationshipId =
-    options?.relationshipIdOverride ?? getRelationshipIdForTool(ctx, toolName, toolType);
+  const relationshipId = getRelationshipIdForTool(ctx, toolName, toolType);
 
   const originalExecute = toolDefinition.execute;
   return {
@@ -110,7 +104,8 @@ export function wrapToolWithStreaming(
 
       const isInternalTool =
         toolName.includes('save_tool_result') || toolName.startsWith('transfer_to_');
-      const isInternalToolForUi = isInternalTool || toolName.startsWith('delegate_to_');
+      const isInternalToolForUi =
+        isInternalTool || toolName.startsWith('delegate_to_') || toolName === 'load_skill';
 
       const needsApproval = options?.needsApproval || false;
 


### PR DESCRIPTION
## Summary

- `load_skill` was being treated as a regular user-visible tool, so `wrapToolWithStreaming` emitted `tool_call`/`tool_result` graph events for it — but with no `relationshipId`, causing the graph animator in `use-animate-graph.ts` to fire a Sentry error on every skill load
- Fix: add `load_skill` to `isInternalToolForUi` alongside `transfer_to_*` and `delegate_to_*` — suppresses chat streaming events (input start/delta/output) and graph session events, matching other internal orchestration tools

Closes PRD-6271