### PR TITLE
Update pullfrog action to use version tag instead of commit hash

### DIFF
--- a/.github/workflows/pullfrog.yml
+++ b/.github/workflows/pullfrog.yml
@@ -28,7 +28,7 @@ jobs:
         with:
           fetch-depth: 1
       - name: Run agent
-        uses: pullfrog/pullfrog@9c99bcbbac7a7877e0390b7b3f91e28379bf2a5f # v0
+        uses: pullfrog/pullfrog@v0
         with:
           prompt: ${{ inputs.prompt }}
         env:


### PR DESCRIPTION
## Summary
Updated the pullfrog GitHub Action reference to use the semantic version tag `v0` instead of a specific commit hash for improved maintainability and clarity.

## Changes
- Changed the pullfrog action reference from a full commit hash (`9c99bcbbac7a7877e0390b7b3f91e28379bf2a5f`) to the version tag (`v0`)

## Details
This change simplifies the action reference by using the stable version tag rather than pinning to a specific commit. This approach:
- Makes the workflow configuration more readable and maintainable
- Allows for automatic updates when new commits are pushed to the `v0` tag
- Follows common GitHub Actions best practices for version management

https://claude.ai/code/session_01QZyvEs97scVf1ahTG8C1rV