### PR TITLE
fix(ci): correct Playwright cache restore-key prefix mismatch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,7 +99,7 @@ jobs:
         with:
           path: ~/.cache/ms-playwright
           key: playwright-${{ runner.os }}-${{ hashFiles('**/pnpm-lock.yaml') }}
-          restore-keys: ${{ runner.os }}-playwright-
+          restore-keys: playwright-${{ runner.os }}-
 
       - name: Install dependencies
         if: steps.changeset-check.outputs.is_changeset != 'true'
@@ -328,7 +328,7 @@ jobs:
         with:
           path: ~/.cache/ms-playwright
           key: playwright-${{ runner.os }}-${{ hashFiles('**/pnpm-lock.yaml') }}
-          restore-keys: ${{ runner.os }}-playwright-
+          restore-keys: playwright-${{ runner.os }}-
 
       - name: Install Playwright
         if: steps.changeset-check.outputs.is_changeset != 'true'


### PR DESCRIPTION
## Summary

- Fix Playwright browser cache restore-key prefix mismatch in CI workflow that causes ~8.5 minute cache misses
- The primary key format is `playwright-<os>-<hash>` but restore-keys used `<os>-playwright-`, so the prefix never matched on cache miss
- Fixed in both the `ci` job and `create-agents-e2e` job

## Impact

Merge queue CI median increased from **7.3 min to 9.7 min**, with **45% of runs exceeding 10 minutes** (up from 16%). Each cache miss forces a full Playwright browser download (~8.5 min) instead of a cache restore (~13 sec).

## Test plan

- [ ] Verify next CI run gets a cache hit on Playwright browsers (look for `Cache restored from key: playwright-Linux-...` in logs)
- [ ] Confirm merge queue CI times return to ~7.3 min median

🤖 Generated with [Claude Code](https://claude.com/claude-code)