### PR TITLE
feat: add edit link to MCP server dropdown menu

### DIFF
--- a/agents-manage-ui/src/components/mcp-servers/mcp-tool-item.tsx
+++ b/agents-manage-ui/src/components/mcp-servers/mcp-tool-item.tsx
@@ -143,7 +143,9 @@ export function MCPToolItem({
             <span className="font-medium break-all">{tool.name}</span>
           </ItemCardTitle>
         </ItemCardLink>
-        {canEdit && <MCPToolDialogMenu toolId={tool.id} toolName={tool.name} editPath={linkPath} />}
+        {canEdit && (
+          <MCPToolDialogMenu toolId={tool.id} toolName={tool.name} editPath={`${linkPath}/edit`} />
+        )}
       </ItemCardHeader>
       <ItemCardContent>
         <div className="space-y-3 min-w-0">


### PR DESCRIPTION
## Summary
- Adds an **Edit** link to the MCP server card dropdown menu, matching the existing pattern on agent cards
- Navigates to the existing MCP server detail/edit page (`/{tenantId}/projects/{projectId}/mcp-servers/{toolId}`)
