### PR TITLE
feat(tool-chain): ref-aware schema validation and invalid tool call observability

### DIFF
--- a/agents-api/src/__tests__/run/agents/AgentMcpManager.test.ts
+++ b/agents-api/src/__tests__/run/agents/AgentMcpManager.test.ts
@@ -8,7 +8,9 @@ vi.mock('@inkeep/agents-core', async (importOriginal) => {
     ...actual,
     McpClient: vi.fn(),
     configureComposioMCPServer: vi.fn(),
+    isBuiltInMcp: vi.fn(() => false),
     isGithubWorkAppTool: vi.fn(() => false),
+    getMcpServerUrl: vi.fn((server: { url?: string }) => server?.url),
   };
 });
 
@@ -254,6 +256,39 @@ describe('AgentMcpManager', () => {
 
       expect(result.tools.search).toBeDefined();
       expect(result.tools.search.description).toBe('Override description');
+    });
+
+    test('builds refAwareInputSchema and baseInputSchema for overridden tools', async () => {
+      mockMcpClient.tools.mockResolvedValue({
+        search: {
+          description: 'Original description',
+          inputSchema: {
+            type: 'object',
+            properties: { query: { type: 'string' } },
+            required: ['query'],
+          },
+          execute: vi.fn().mockResolvedValue('result'),
+        },
+      });
+
+      const mcpTool = createMcpTool({
+        config: {
+          type: 'mcp',
+          mcp: {
+            server: { url: 'https://test.example.com/mcp' },
+            toolOverrides: {
+              search: { description: 'Override description' },
+            },
+          },
+        },
+      });
+
+      const result = await createManager().getToolSet(mcpTool);
+
+      expect(result.tools.search.inputSchema).toBeDefined();
+      expect(result.tools.search.baseInputSchema).toBeDefined();
+      const baseValidation = result.tools.search.baseInputSchema.safeParse({ query: 'hello' });
+      expect(baseValidation.success).toBe(true);
     });
 
     test('falls back to original tool when override processing fails', async () => {

--- a/agents-api/src/__tests__/run/agents/functionToolApprovals.test.ts
+++ b/agents-api/src/__tests__/run/agents/functionToolApprovals.test.ts
@@ -65,7 +65,13 @@ describe('Function tool approvals (toolPolicies)', () => {
       tools: {},
       functions: {
         fn_1: {
-          inputSchema: { type: 'object', properties: {} },
+          inputSchema: {
+            type: 'object',
+            properties: {
+              city: { type: 'string' },
+            },
+            required: ['city'],
+          },
           executeCode: 'return { ok: true };',
           dependencies: {},
         },
@@ -142,5 +148,19 @@ describe('Function tool approvals (toolPolicies)', () => {
       'req_2',
       expect.objectContaining({ type: 'approval-resolved', toolCallId: 'call_2', approved: true })
     );
+  });
+
+  it('accepts sentinel refs in function tool inputSchema', async () => {
+    const agent = new Agent(baseConfig, executionContext);
+    agent.setConversationId('conv_1');
+    agent.setDelegationStatus(true);
+    (agent as any).streamRequestId = 'req_3';
+
+    const tools = await agent.getFunctionTools('sess_3', 'req_3');
+    const schemaValidation = (tools.getWeather as any).inputSchema.safeParse({
+      city: { $tool: 'tool_call_123', $path: 'location.city' },
+    });
+
+    expect(schemaValidation.success).toBe(true);
   });
 });

--- a/agents-api/src/__tests__/run/agents/refAwareSchema.test.ts
+++ b/agents-api/src/__tests__/run/agents/refAwareSchema.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from 'vitest';
+import { z } from 'zod';
+import { buildRefAwareInputSchema } from '../../../domains/run/agents/tools/mcp-tools';
+import { makeRefAwareJsonSchema } from '../../../domains/run/agents/tools/ref-aware-schema';
+
+// Shared assertions for any ref-aware schema (Zod).
+function assertRefAwareSchema(schema: z.ZodType) {
+  // Accepts $tool-only ref
+  expect(schema.safeParse({ image: { $tool: 'toolu_123' } }).success).toBe(true);
+  // Accepts $artifact + $tool ref
+  expect(schema.safeParse({ image: { $artifact: 'art-1', $tool: 'toolu_123' } }).success).toBe(
+    true
+  );
+  // Accepts $tool + $path ref
+  expect(schema.safeParse({ image: { $tool: 'toolu_123', $path: 'content[0]' } }).success).toBe(
+    true
+  );
+  // Accepts the original concrete structure
+  expect(schema.safeParse({ image: { data: 'abc', mimeType: 'image/png' } }).success).toBe(true);
+  // Rejects unrecognised object (no $tool, no required concrete fields)
+  expect(schema.safeParse({ image: { unrelated: 'field' } }).success).toBe(false);
+  // Rejects missing required top-level arg
+  expect(schema.safeParse({}).success).toBe(false);
+}
+
+describe('makeRefAwareJsonSchema (function-tool path)', () => {
+  it('produces a Zod schema that accepts sentinel refs and the original structure', () => {
+    const rawJson = {
+      type: 'object',
+      properties: {
+        image: {
+          type: 'object',
+          properties: {
+            data: { type: 'string' },
+            mimeType: { type: 'string' },
+          },
+          required: ['data', 'mimeType'],
+        },
+      },
+      required: ['image'],
+    } as Record<string, unknown>;
+
+    const schema = z.fromJSONSchema(makeRefAwareJsonSchema(rawJson));
+    assertRefAwareSchema(schema);
+  });
+});
+
+describe('buildRefAwareInputSchema (MCP-tool path)', () => {
+  it('produces a ref-aware inputSchema and a baseInputSchema from a Zod schema', () => {
+    const zodInput = z.object({
+      image: z.object({
+        data: z.string(),
+        mimeType: z.string(),
+      }),
+    });
+
+    const { refAwareInputSchema, baseInputSchema } = buildRefAwareInputSchema(zodInput);
+
+    assertRefAwareSchema(refAwareInputSchema);
+
+    // baseInputSchema should enforce the concrete structure (rejects refs)
+    expect(baseInputSchema).toBeDefined();
+    expect(
+      baseInputSchema!.safeParse({ image: { data: 'abc', mimeType: 'image/png' } }).success
+    ).toBe(true);
+    expect(baseInputSchema!.safeParse({ image: { $tool: 'toolu_123' } }).success).toBe(false);
+  });
+
+  it('falls back gracefully when the input is not a valid Zod schema', () => {
+    const { refAwareInputSchema, baseInputSchema } = buildRefAwareInputSchema({} as any);
+    expect(refAwareInputSchema).toBeDefined();
+    expect(baseInputSchema).toBeUndefined();
+  });
+});

--- a/agents-api/src/__tests__/run/agents/toolWrapperRefAwareValidation.test.ts
+++ b/agents-api/src/__tests__/run/agents/toolWrapperRefAwareValidation.test.ts
@@ -1,0 +1,97 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { wrapToolWithStreaming } from '../../../domains/run/agents/tools/tool-wrapper';
+
+vi.mock('../../../domains/run/session/AgentSession', () => ({
+  agentSessionManager: {
+    recordEvent: vi.fn().mockResolvedValue(undefined),
+    getArtifactParser: vi.fn(),
+  },
+}));
+
+vi.mock('@inkeep/agents-core', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@inkeep/agents-core')>();
+  return {
+    ...actual,
+    createMessage: vi.fn(() => vi.fn().mockResolvedValue(undefined)),
+  };
+});
+
+describe('wrapToolWithStreaming baseInputSchema validation', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  function createContext() {
+    return {
+      conversationId: undefined,
+      isDelegatedAgent: false,
+      streamHelper: undefined,
+      config: {
+        id: 'sub-agent-1',
+        name: 'SubAgent',
+        agentId: 'agent-1',
+        tenantId: 'tenant-1',
+        projectId: 'project-1',
+      },
+      delegationId: undefined,
+      functionToolRelationshipIdByName: new Map(),
+    } as any;
+  }
+
+  it('rejects resolved args that fail baseInputSchema validation', async () => {
+    const { agentSessionManager } = await import('../../../domains/run/session/AgentSession');
+    vi.mocked(agentSessionManager.getArtifactParser).mockReturnValue({
+      resolveArgs: vi.fn().mockResolvedValue({ city: 123 }),
+    } as any);
+
+    const executeSpy = vi.fn().mockResolvedValue({ ok: true });
+    const wrapped = wrapToolWithStreaming(
+      createContext(),
+      'weather_tool',
+      {
+        description: 'Weather tool',
+        execute: executeSpy,
+        baseInputSchema: {
+          safeParse: vi.fn().mockReturnValue({
+            success: false,
+            error: { message: 'city must be a string' },
+          }),
+        },
+      } as any,
+      'stream-1',
+      'tool'
+    );
+
+    await expect(
+      (wrapped as any).execute({ city: { $tool: 'call_1', $path: 'location.city' } }, {})
+    ).rejects.toThrow(
+      "Resolved tool args failed schema validation for 'weather_tool': city must be a string"
+    );
+    expect(executeSpy).not.toHaveBeenCalled();
+  });
+
+  it('executes with resolved args when baseInputSchema validation passes', async () => {
+    const { agentSessionManager } = await import('../../../domains/run/session/AgentSession');
+    vi.mocked(agentSessionManager.getArtifactParser).mockReturnValue({
+      resolveArgs: vi.fn().mockResolvedValue({ city: 'San Francisco' }),
+    } as any);
+
+    const executeSpy = vi.fn().mockResolvedValue({ ok: true });
+    const wrapped = wrapToolWithStreaming(
+      createContext(),
+      'weather_tool',
+      {
+        description: 'Weather tool',
+        execute: executeSpy,
+        baseInputSchema: {
+          safeParse: vi.fn().mockReturnValue({ success: true }),
+        },
+      } as any,
+      'stream-1',
+      'tool'
+    );
+
+    await (wrapped as any).execute({ city: { $tool: 'call_1', $path: 'location.city' } }, {});
+    expect(executeSpy).toHaveBeenCalledWith({ city: 'San Francisco' }, {});
+  });
+});

--- a/agents-api/src/domains/run/agents/agent-types.ts
+++ b/agents-api/src/domains/run/agents/agent-types.ts
@@ -215,6 +215,11 @@ export type AiSdkToolDefinition = {
       args: unknown
     ) => { success: true; error?: never } | { success: false; error: { message: string } };
   };
+  baseInputSchema?: {
+    safeParse?: (
+      args: unknown
+    ) => { success: true; error?: never } | { success: false; error: { message: string } };
+  };
   execute?: (args: unknown, context?: unknown) => Promise<unknown>;
 };
 

--- a/agents-api/src/domains/run/agents/generation/generate.ts
+++ b/agents-api/src/domains/run/agents/generation/generate.ts
@@ -1,9 +1,18 @@
 import { z } from '@hono/zod-openapi';
-import { type DataPart, type FilePart, type Part, SPAN_KEYS } from '@inkeep/agents-core';
+import {
+  createMessage,
+  type DataPart,
+  type FilePart,
+  generateId,
+  type Part,
+  SPAN_KEYS,
+  SPAN_NAMES,
+} from '@inkeep/agents-core';
 import type { Span } from '@opentelemetry/api';
 import { SpanStatusCode } from '@opentelemetry/api';
-import type { ToolSet } from 'ai';
+import type { StepResult, ToolSet } from 'ai';
 import { generateText, Output, streamText } from 'ai';
+import runDbClient from '../../../../data/db/runDbClient';
 import { getLogger } from '../../../../logger';
 import type { MidGenerationCompressor } from '../../compression/MidGenerationCompressor';
 import { agentSessionManager } from '../../session/AgentSession';
@@ -22,6 +31,7 @@ import { configureModelSettings } from './model-config';
 import { formatFinalResponse } from './response-formatting';
 import { buildDataComponentsSchema } from './schema-builder';
 import { loadToolsAndPrompts } from './tool-loading';
+import { formatInvalidToolCallForHistory } from './tool-result-for-conversation-history';
 
 const logger = getLogger('Agent');
 
@@ -58,6 +68,125 @@ export function setupGenerationContext(
   return { contextId, taskId, streamRequestId: streamRequestId ?? '', sessionId };
 }
 
+type ToolErrorPart = Extract<
+  NonNullable<StepResult<ToolSet>['content']>[number],
+  { type: 'tool-error' }
+>;
+
+function isToolErrorPart(part: unknown): part is ToolErrorPart {
+  return (
+    typeof part === 'object' &&
+    part !== null &&
+    (part as Record<string, unknown>).type === 'tool-error'
+  );
+}
+
+async function handleInvalidToolResultsFromStep(
+  ctx: AgentRunContext,
+  step: StepResult<ToolSet>
+): Promise<void> {
+  const streamRequestId = ctx.streamRequestId;
+
+  for (const part of step.content ?? []) {
+    if (!isToolErrorPart(part)) continue;
+
+    const toolError = part;
+
+    // AI SDK v6 converts schema-validation errors to strings via getErrorMessage()
+    // before storing them in step.content. execute() errors remain Error objects and
+    // are already handled (OTEL span + session events) by executeToolCall / tool-wrapper.
+    if (typeof toolError.error !== 'string') continue;
+
+    const input = toolError.input;
+    const errorMessage = toolError.error;
+
+    // 1. Emit an OTEL span so SigNoz shows this as a tool_call activity.
+    await tracer.startActiveSpan(SPAN_NAMES.AI_TOOL_CALL, async (span) => {
+      span.setAttributes({
+        [SPAN_KEYS.AI_TOOL_CALL_NAME]: toolError.toolName,
+        [SPAN_KEYS.AI_TOOL_CALL_ARGS]: input !== undefined ? JSON.stringify(input) : '',
+        [SPAN_KEYS.AI_TOOL_CALL_RESULT]: JSON.stringify({
+          type: 'error-text',
+          value: errorMessage,
+        }),
+        [SPAN_KEYS.AI_TOOL_CALL_ID]: toolError.toolCallId,
+        [SPAN_KEYS.AI_TELEMETRY_FUNCTION_ID]: ctx.config.id,
+        [SPAN_KEYS.AI_TELEMETRY_SUB_AGENT_ID]: ctx.config.id,
+        [SPAN_KEYS.AI_TELEMETRY_SUB_AGENT_NAME]: ctx.config.name ?? '',
+        [SPAN_KEYS.SUB_AGENT_ID]: ctx.config.id,
+        [SPAN_KEYS.SUB_AGENT_NAME]: ctx.config.name ?? '',
+        'conversation.id': ctx.conversationId ?? '',
+      });
+      span.setStatus({ code: SpanStatusCode.ERROR, message: errorMessage });
+      span.end();
+    });
+
+    // 2. Record session events for the SSE streaming feed.
+    if (streamRequestId) {
+      agentSessionManager.recordEvent(streamRequestId, 'tool_call', ctx.config.id, {
+        toolName: toolError.toolName,
+        input,
+        toolCallId: toolError.toolCallId,
+        inDelegatedAgent: ctx.isDelegatedAgent,
+      });
+      agentSessionManager.recordEvent(streamRequestId, 'tool_result', ctx.config.id, {
+        toolName: toolError.toolName,
+        toolCallId: toolError.toolCallId,
+        output: null,
+        error: errorMessage,
+        inDelegatedAgent: ctx.isDelegatedAgent,
+      });
+    }
+
+    // 3. Persist to conversation history so the failure is visible in the DB.
+    if (ctx.conversationId) {
+      try {
+        const messageId = generateId();
+        await createMessage(runDbClient)({
+          id: messageId,
+          tenantId: ctx.config.tenantId,
+          projectId: ctx.config.projectId,
+          conversationId: ctx.conversationId,
+          role: 'assistant',
+          content: {
+            text: formatInvalidToolCallForHistory(
+              toolError.toolName,
+              toolError.toolCallId,
+              input,
+              new Error(errorMessage)
+            ),
+          },
+          visibility: 'internal',
+          messageType: 'tool-result',
+          fromSubAgentId: ctx.config.id,
+          metadata: {
+            a2a_metadata: {
+              toolName: toolError.toolName,
+              toolCallId: toolError.toolCallId,
+              toolArgs: input,
+              toolOutput: null,
+              error: errorMessage,
+              timestamp: Date.now(),
+              delegationId: ctx.delegationId,
+              isDelegated: ctx.isDelegatedAgent,
+            },
+          },
+        });
+      } catch (err) {
+        logger.warn(
+          {
+            err,
+            toolName: toolError.toolName,
+            toolCallId: toolError.toolCallId,
+            conversationId: ctx.conversationId,
+          },
+          'Failed to persist invalid tool call to conversation history'
+        );
+      }
+    }
+  }
+}
+
 export function buildBaseGenerationConfig(
   ctx: AgentRunContext,
   modelSettings: Record<string, unknown>,
@@ -79,6 +208,9 @@ export function buildBaseGenerationConfig(
     },
     stopWhen: async ({ steps }: { steps: unknown[] }) => {
       return await handleStopWhenConditions(ctx, steps);
+    },
+    onStepFinish: async (step: StepResult<ToolSet>) => {
+      await handleInvalidToolResultsFromStep(ctx, step);
     },
     experimental_telemetry: buildTelemetryConfig(ctx, phase),
     abortSignal: AbortSignal.timeout(timeoutMs),

--- a/agents-api/src/domains/run/agents/generation/tool-result-for-conversation-history.ts
+++ b/agents-api/src/domains/run/agents/generation/tool-result-for-conversation-history.ts
@@ -148,6 +148,28 @@ function getIndexedPartsForConversationHistory(
   return indexedParts;
 }
 
+export function formatInvalidToolCallForHistory(
+  toolName: string,
+  toolCallId: string,
+  input: unknown,
+  error: unknown
+): string {
+  const inputStr =
+    input !== undefined
+      ? JSON.stringify(input, null, 2)
+      : 'No input (validation failed before parsing)';
+  const errorMessage = error instanceof Error ? error.message : String(error);
+  return `## Tool: ${toolName}
+
+### 🔧 TOOL_CALL_ID: ${toolCallId}
+
+### Input
+${inputStr}
+
+### Error
+${errorMessage}`;
+}
+
 export async function buildToolResultForConversationHistory(
   ctx: AgentRunContext,
   toolName: string,

--- a/agents-api/src/domains/run/agents/services/AgentMcpManager.ts
+++ b/agents-api/src/domains/run/agents/services/AgentMcpManager.ts
@@ -26,6 +26,7 @@ import { agentSessionManager } from '../../session/AgentSession';
 import { setSpanWithError, tracer } from '../../utils/tracer';
 import type { AgentConfig } from '../Agent';
 import type { AiSdkToolDefinition } from '../agent-types';
+import { makeBaseInputSchema, makeRefAwareJsonSchema } from '../tools/ref-aware-schema';
 
 const logger = getLogger('AgentMcpManager');
 
@@ -379,16 +380,33 @@ export class AgentMcpManager {
     mcpToolName: string
   ) {
     const rawSchema = toolDef.inputSchema as Record<string, unknown>;
+    const baseSchema = (override.schema || rawSchema) as Record<string, unknown>;
+    const refAwareSchema = makeRefAwareJsonSchema(baseSchema);
+    let baseInputSchema: ReturnType<typeof z.fromJSONSchema> | undefined;
     let inputSchema: ReturnType<typeof z.fromJSONSchema> | ReturnType<typeof jsonSchema>;
+
     try {
-      inputSchema = override.schema ? z.fromJSONSchema(override.schema) : jsonSchema(rawSchema);
+      baseInputSchema = makeBaseInputSchema(baseSchema);
+    } catch (schemaError) {
+      logger.warn(
+        {
+          mcpToolName,
+          toolName,
+          schemaError: AgentMcpManager.errMsg(schemaError),
+        },
+        'Failed to build baseInputSchema; skipping resolved-args validation for this tool'
+      );
+    }
+
+    try {
+      inputSchema = override.schema ? z.fromJSONSchema(refAwareSchema) : jsonSchema(refAwareSchema);
     } catch (schemaError) {
       logger.error(
         {
           mcpToolName,
           toolName,
           schemaError: AgentMcpManager.errMsg(schemaError),
-          overrideSchema: override.schema,
+          overrideSchema: baseSchema,
         },
         'Failed to convert override schema, using original'
       );
@@ -398,62 +416,65 @@ export class AgentMcpManager {
     const finalName = override.displayName || toolName;
     const description = override.description || toolDef.description || `Tool ${finalName}`;
 
-    const definition = tool({
-      description,
-      inputSchema,
-      execute: async (simpleArgs: any) => {
-        let complexArgs = simpleArgs;
-        if (override.transformation) {
-          try {
-            if (typeof override.transformation === 'string') {
-              complexArgs = await JsonTransformer.transform(simpleArgs, override.transformation, {
-                timeout: 10000,
-              });
-            } else if (
-              typeof override.transformation === 'object' &&
-              override.transformation !== null
-            ) {
-              complexArgs = await JsonTransformer.transformWithConfig(
-                simpleArgs,
-                { objectTransformation: override.transformation },
-                { timeout: 10000 }
+    const definition = {
+      ...tool({
+        description,
+        inputSchema,
+        execute: async (simpleArgs: any) => {
+          let complexArgs = simpleArgs;
+          if (override.transformation) {
+            try {
+              if (typeof override.transformation === 'string') {
+                complexArgs = await JsonTransformer.transform(simpleArgs, override.transformation, {
+                  timeout: 10000,
+                });
+              } else if (
+                typeof override.transformation === 'object' &&
+                override.transformation !== null
+              ) {
+                complexArgs = await JsonTransformer.transformWithConfig(
+                  simpleArgs,
+                  { objectTransformation: override.transformation },
+                  { timeout: 10000 }
+                );
+              } else {
+                logger.warn(
+                  { mcpToolName, toolName, transformationType: typeof override.transformation },
+                  'Invalid transformation type, skipping transformation'
+                );
+              }
+            } catch (transformError) {
+              logger.error(
+                {
+                  mcpToolName,
+                  toolName,
+                  transformError: AgentMcpManager.errMsg(transformError),
+                  transformation: override.transformation,
+                },
+                'Failed to transform tool arguments, using original arguments'
               );
-            } else {
-              logger.warn(
-                { mcpToolName, toolName, transformationType: typeof override.transformation },
-                'Invalid transformation type, skipping transformation'
-              );
+              complexArgs = simpleArgs;
             }
-          } catch (transformError) {
-            logger.error(
-              {
-                mcpToolName,
-                toolName,
-                transformError: AgentMcpManager.errMsg(transformError),
-                transformation: override.transformation,
-              },
-              'Failed to transform tool arguments, using original arguments'
-            );
-            complexArgs = simpleArgs;
           }
-        }
 
-        if (typeof toolDef.execute !== 'function') {
-          throw new Error(`Original tool ${toolName} does not have a valid execute function`);
-        }
+          if (typeof toolDef.execute !== 'function') {
+            throw new Error(`Original tool ${toolName} does not have a valid execute function`);
+          }
 
-        try {
-          return await toolDef.execute(complexArgs);
-        } catch (executeError) {
-          const msg = AgentMcpManager.errMsg(executeError);
-          logger.error(
-            { mcpToolName, toolName, executeError: msg, complexArgs },
-            'Failed to execute original tool'
-          );
-          throw new Error(`Tool execution failed for ${toolName}: ${msg}`);
-        }
-      },
-    });
+          try {
+            return await toolDef.execute(complexArgs);
+          } catch (executeError) {
+            const msg = AgentMcpManager.errMsg(executeError);
+            logger.error(
+              { mcpToolName, toolName, executeError: msg, complexArgs },
+              'Failed to execute original tool'
+            );
+            throw new Error(`Tool execution failed for ${toolName}: ${msg}`);
+          }
+        },
+      }),
+      baseInputSchema,
+    };
 
     return { finalName, definition };
   }

--- a/agents-api/src/domains/run/agents/tools/function-tools.ts
+++ b/agents-api/src/domains/run/agents/tools/function-tools.ts
@@ -11,6 +11,7 @@ import type { SandboxConfig } from '../../types/executionContext';
 import type { AgentRunContext } from '../agent-types';
 import { enhanceToolResultWithStructureHints } from '../generation/tool-result';
 import { toolSessionManager } from '../services/ToolSessionManager';
+import { makeBaseInputSchema, makeRefAwareJsonSchema } from './ref-aware-schema';
 import { parseAndCheckApproval } from './tool-approval';
 import { wrapToolWithStreaming } from './tool-wrapper';
 
@@ -75,9 +76,27 @@ export async function getFunctionTools(
         continue;
       }
 
-      const zodSchema = functionData.inputSchema
-        ? z.fromJSONSchema(functionData.inputSchema)
-        : z.string();
+      let baseInputSchema: ReturnType<typeof z.fromJSONSchema> | undefined;
+      let refAwareInputSchema: ReturnType<typeof z.fromJSONSchema> = z.string();
+      if (functionData.inputSchema) {
+        try {
+          baseInputSchema = makeBaseInputSchema(functionData.inputSchema);
+        } catch {
+          // baseInputSchema stays undefined
+        }
+        try {
+          refAwareInputSchema = z.fromJSONSchema(makeRefAwareJsonSchema(functionData.inputSchema));
+        } catch (schemaError) {
+          logger.warn(
+            {
+              functionToolName: functionToolDef.name,
+              schemaError: schemaError instanceof Error ? schemaError.message : String(schemaError),
+            },
+            'Failed to build refAwareInputSchema; falling back to base schema'
+          );
+          refAwareInputSchema = z.fromJSONSchema(functionData.inputSchema);
+        }
+      }
       const toolPolicies = functionToolDef.toolPolicies;
       const needsApproval =
         !!toolPolicies?.['*']?.needsApproval ||
@@ -85,7 +104,7 @@ export async function getFunctionTools(
 
       const aiTool = tool({
         description: functionToolDef.description || functionToolDef.name,
-        inputSchema: zodSchema,
+        inputSchema: refAwareInputSchema,
         execute: async (args, { toolCallId, providerMetadata }: any) => {
           const parsed = await parseAndCheckApproval(
             ctx,
@@ -158,11 +177,15 @@ export async function getFunctionTools(
           }
         },
       });
+      const functionToolWithBaseInputSchema = {
+        ...aiTool,
+        baseInputSchema,
+      };
 
       functionTools[functionToolDef.name] = wrapToolWithStreaming(
         ctx,
         functionToolDef.name,
-        aiTool,
+        functionToolWithBaseInputSchema,
         streamRequestId || '',
         'tool',
         { needsApproval }

--- a/agents-api/src/domains/run/agents/tools/mcp-tools.ts
+++ b/agents-api/src/domains/run/agents/tools/mcp-tools.ts
@@ -1,6 +1,7 @@
 import { parseEmbeddedJson, unwrapError } from '@inkeep/agents-core';
 import { SpanStatusCode, trace } from '@opentelemetry/api';
 import { type ToolSet, tool } from 'ai';
+import { z } from 'zod';
 import { getLogger } from '../../../../logger';
 import { agentSessionManager } from '../../session/AgentSession';
 import type { AgentRunContext } from '../agent-types';
@@ -10,9 +11,27 @@ import {
   enhanceToolResultWithStructureHints,
 } from '../generation/tool-result';
 import { toolSessionManager } from '../services/ToolSessionManager';
+import { makeBaseInputSchema, makeRefAwareJsonSchema } from './ref-aware-schema';
 import { parseAndCheckApproval } from './tool-approval';
 import { getRelationshipIdForTool } from './tool-utils';
 import { wrapToolWithStreaming } from './tool-wrapper';
+
+export function buildRefAwareInputSchema(inputSchema: unknown): {
+  refAwareInputSchema: ReturnType<typeof z.fromJSONSchema>;
+  baseInputSchema: ReturnType<typeof z.fromJSONSchema> | undefined;
+} {
+  try {
+    const rawJson = z.toJSONSchema(inputSchema as z.ZodType) as Record<string, unknown>;
+    const baseInputSchema = makeBaseInputSchema(rawJson);
+    const refAwareInputSchema = z.fromJSONSchema(makeRefAwareJsonSchema(rawJson));
+    return { refAwareInputSchema, baseInputSchema };
+  } catch {
+    return {
+      refAwareInputSchema: inputSchema as ReturnType<typeof z.fromJSONSchema>,
+      baseInputSchema: undefined,
+    };
+  }
+}
 
 const logger = getLogger('Agent');
 
@@ -78,129 +97,136 @@ export async function getMcpTools(
         'Tool approval check'
       );
 
-      const sessionWrappedTool = tool({
-        description: originalTool.description,
-        inputSchema: originalTool.inputSchema,
-        execute: async (args, { toolCallId, providerMetadata }: any) => {
-          const parsed = await parseAndCheckApproval(
-            ctx,
-            toolName,
-            toolCallId,
-            args,
-            providerMetadata,
-            needsApproval
-          );
-          if (parsed.denied) {
-            return parsed.result;
-          }
-          const finalArgs = parsed.args;
+      const { refAwareInputSchema, baseInputSchema } = buildRefAwareInputSchema(
+        originalTool.inputSchema
+      );
 
-          logger.debug({ toolName, toolCallId }, 'MCP Tool Called');
+      const sessionWrappedTool = {
+        ...tool({
+          description: originalTool.description,
+          inputSchema: refAwareInputSchema,
+          execute: async (args, { toolCallId, providerMetadata }: any) => {
+            const parsed = await parseAndCheckApproval(
+              ctx,
+              toolName,
+              toolCallId,
+              args,
+              providerMetadata,
+              needsApproval
+            );
+            if (parsed.denied) {
+              return parsed.result;
+            }
+            const finalArgs = parsed.args;
 
-          try {
-            const rawResult = await originalTool.execute(finalArgs, { toolCallId });
+            logger.debug({ toolName, toolCallId }, 'MCP Tool Called');
 
-            const result = rawResult as Record<string, unknown>;
-            if (result.isError) {
-              const errorMessage =
-                (result.content as Array<{ text?: string }>)?.[0]?.text ||
-                'MCP tool returned an error';
-              logger.error(
-                { toolName, toolCallId, errorMessage, rawResult },
-                'MCP tool returned error status'
+            try {
+              const rawResult = await originalTool.execute(finalArgs, { toolCallId });
+
+              const result = rawResult as Record<string, unknown>;
+              if (result.isError) {
+                const errorMessage =
+                  (result.content as Array<{ text?: string }>)?.[0]?.text ||
+                  'MCP tool returned an error';
+                logger.error(
+                  { toolName, toolCallId, errorMessage, rawResult },
+                  'MCP tool returned error status'
+                );
+
+                toolSessionManager.recordToolResult(sessionId, {
+                  toolCallId,
+                  toolName,
+                  args: finalArgs,
+                  result: { error: errorMessage, failed: true },
+                  timestamp: Date.now(),
+                });
+
+                if (streamRequestId) {
+                  const relationshipId = getRelationshipIdForTool(ctx, toolName, 'mcp');
+                  agentSessionManager.recordEvent(streamRequestId, 'error', ctx.config.id, {
+                    message: `MCP tool "${toolName}" failed: ${errorMessage}`,
+                    code: 'mcp_tool_error',
+                    severity: 'error',
+                    context: {
+                      toolName,
+                      toolCallId,
+                      errorMessage,
+                      relationshipId,
+                    },
+                    relationshipId,
+                  });
+                }
+
+                const activeSpan = trace.getActiveSpan();
+                if (activeSpan) {
+                  const error = new Error(
+                    `Tool "${toolName}" failed: ${errorMessage}. This tool is currently unavailable. Please try a different approach or inform the user of the issue.`
+                  );
+                  activeSpan.recordException(error);
+                  activeSpan.setStatus({
+                    code: SpanStatusCode.ERROR,
+                    message: `MCP tool returned error: ${errorMessage}`,
+                  });
+                }
+
+                throw new Error(
+                  `Tool "${toolName}" failed: ${errorMessage}. This tool is currently unavailable. Please try a different approach or inform the user of the issue.`
+                );
+              }
+
+              const parsedResult = parseEmbeddedJson(rawResult);
+
+              const contentPartArtifacts = buildContentPartArtifacts(parsedResult, toolCallId);
+              const enhancedResult = enhanceToolResultWithStructureHints(
+                ctx,
+                parsedResult,
+                toolCallId,
+                contentPartArtifacts
               );
+
+              if (streamRequestId) {
+                for (const cpa of contentPartArtifacts) {
+                  const cacheEntry = {
+                    data: cpa.contentItem,
+                    name: `Content part from ${toolName}`,
+                    description: `Content part ${cpa.index} (type: ${cpa.contentItem.type ?? 'unknown'}) from tool call ${cpa.toolCallId}`,
+                  };
+                  await agentSessionManager.setArtifactCache(
+                    streamRequestId,
+                    `${cpa.artifactId}:${cpa.toolCallId}`,
+                    cacheEntry
+                  );
+                  await agentSessionManager.setArtifactCache(
+                    streamRequestId,
+                    `${cpa.toolCallId}:${cpa.index}`,
+                    { ...cacheEntry, artifactId: cpa.artifactId }
+                  );
+                }
+              }
 
               toolSessionManager.recordToolResult(sessionId, {
                 toolCallId,
                 toolName,
                 args: finalArgs,
-                result: { error: errorMessage, failed: true },
+                result: parsedResult,
+                structureHints: enhancedResult._structureHints,
                 timestamp: Date.now(),
               });
 
-              if (streamRequestId) {
-                const relationshipId = getRelationshipIdForTool(ctx, toolName, 'mcp');
-                agentSessionManager.recordEvent(streamRequestId, 'error', ctx.config.id, {
-                  message: `MCP tool "${toolName}" failed: ${errorMessage}`,
-                  code: 'mcp_tool_error',
-                  severity: 'error',
-                  context: {
-                    toolName,
-                    toolCallId,
-                    errorMessage,
-                    relationshipId,
-                  },
-                  relationshipId,
-                });
-              }
-
-              const activeSpan = trace.getActiveSpan();
-              if (activeSpan) {
-                const error = new Error(
-                  `Tool "${toolName}" failed: ${errorMessage}. This tool is currently unavailable. Please try a different approach or inform the user of the issue.`
-                );
-                activeSpan.recordException(error);
-                activeSpan.setStatus({
-                  code: SpanStatusCode.ERROR,
-                  message: `MCP tool returned error: ${errorMessage}`,
-                });
-              }
-
-              throw new Error(
-                `Tool "${toolName}" failed: ${errorMessage}. This tool is currently unavailable. Please try a different approach or inform the user of the issue.`
+              return enhancedResult;
+            } catch (error) {
+              const rootCause = unwrapError(error);
+              logger.error(
+                { toolName, toolCallId, error: rootCause.message },
+                'MCP tool execution failed'
               );
+              throw rootCause;
             }
-
-            const parsedResult = parseEmbeddedJson(rawResult);
-
-            const contentPartArtifacts = buildContentPartArtifacts(parsedResult, toolCallId);
-            const enhancedResult = enhanceToolResultWithStructureHints(
-              ctx,
-              parsedResult,
-              toolCallId,
-              contentPartArtifacts
-            );
-
-            if (streamRequestId) {
-              for (const cpa of contentPartArtifacts) {
-                const cacheEntry = {
-                  data: cpa.contentItem,
-                  name: `Content part from ${toolName}`,
-                  description: `Content part ${cpa.index} (type: ${cpa.contentItem.type ?? 'unknown'}) from tool call ${cpa.toolCallId}`,
-                };
-                await agentSessionManager.setArtifactCache(
-                  streamRequestId,
-                  `${cpa.artifactId}:${cpa.toolCallId}`,
-                  cacheEntry
-                );
-                await agentSessionManager.setArtifactCache(
-                  streamRequestId,
-                  `${cpa.toolCallId}:${cpa.index}`,
-                  { ...cacheEntry, artifactId: cpa.artifactId }
-                );
-              }
-            }
-
-            toolSessionManager.recordToolResult(sessionId, {
-              toolCallId,
-              toolName,
-              args: finalArgs,
-              result: parsedResult,
-              structureHints: enhancedResult._structureHints,
-              timestamp: Date.now(),
-            });
-
-            return enhancedResult;
-          } catch (error) {
-            const rootCause = unwrapError(error);
-            logger.error(
-              { toolName, toolCallId, error: rootCause.message },
-              'MCP tool execution failed'
-            );
-            throw rootCause;
-          }
-        },
-      });
+          },
+        }),
+        baseInputSchema,
+      };
 
       wrappedTools[toolName] = wrapToolWithStreaming(
         ctx,

--- a/agents-api/src/domains/run/agents/tools/ref-aware-schema.ts
+++ b/agents-api/src/domains/run/agents/tools/ref-aware-schema.ts
@@ -1,0 +1,107 @@
+import { z } from '@hono/zod-openapi';
+import { SENTINEL_KEY } from '../../constants/artifact-syntax';
+
+const TOOL_CALL_ARG_REF_SCHEMA: Record<string, unknown> = {
+  anyOf: [
+    {
+      type: 'object',
+      required: [SENTINEL_KEY.ARTIFACT, SENTINEL_KEY.TOOL],
+      properties: {
+        [SENTINEL_KEY.ARTIFACT]: { type: 'string' },
+        [SENTINEL_KEY.TOOL]: { type: 'string' },
+        [SENTINEL_KEY.PATH]: { type: 'string' },
+      },
+      additionalProperties: true,
+    },
+    {
+      type: 'object',
+      required: [SENTINEL_KEY.TOOL],
+      properties: {
+        [SENTINEL_KEY.TOOL]: { type: 'string' },
+        [SENTINEL_KEY.PATH]: { type: 'string' },
+      },
+      additionalProperties: true,
+    },
+  ],
+};
+
+function withToolCallArgRef(schemaNode: unknown): Record<string, unknown> {
+  return {
+    anyOf: [schemaNode, TOOL_CALL_ARG_REF_SCHEMA],
+  };
+}
+
+function isObjectRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+function transformSchemaNode(schemaNode: unknown, isValuePosition: boolean): unknown {
+  if (!isObjectRecord(schemaNode)) {
+    return schemaNode;
+  }
+
+  const transformed: Record<string, unknown> = { ...schemaNode };
+
+  if (isObjectRecord(schemaNode.properties)) {
+    transformed.properties = Object.fromEntries(
+      Object.entries(schemaNode.properties).map(([key, valueSchema]) => [
+        key,
+        transformSchemaNode(valueSchema, true),
+      ])
+    );
+  }
+
+  if (isObjectRecord(schemaNode.patternProperties)) {
+    transformed.patternProperties = Object.fromEntries(
+      Object.entries(schemaNode.patternProperties).map(([key, valueSchema]) => [
+        key,
+        transformSchemaNode(valueSchema, true),
+      ])
+    );
+  }
+
+  if (schemaNode.items !== undefined) {
+    if (Array.isArray(schemaNode.items)) {
+      transformed.items = schemaNode.items.map((item) => transformSchemaNode(item, true));
+    } else {
+      transformed.items = transformSchemaNode(schemaNode.items, true);
+    }
+  }
+
+  if (isObjectRecord(schemaNode.additionalProperties)) {
+    transformed.additionalProperties = transformSchemaNode(schemaNode.additionalProperties, true);
+  }
+
+  for (const key of ['anyOf', 'oneOf', 'allOf'] as const) {
+    const variant = schemaNode[key];
+    if (Array.isArray(variant)) {
+      transformed[key] = variant.map((item) => transformSchemaNode(item, false));
+    }
+  }
+
+  if (isObjectRecord(schemaNode.not)) {
+    transformed.not = transformSchemaNode(schemaNode.not, false);
+  }
+
+  if (isObjectRecord(schemaNode.if)) {
+    transformed.if = transformSchemaNode(schemaNode.if, false);
+  }
+  if (isObjectRecord(schemaNode.then)) {
+    transformed['then'] = transformSchemaNode(schemaNode.then, false);
+  }
+  if (isObjectRecord(schemaNode.else)) {
+    transformed.else = transformSchemaNode(schemaNode.else, false);
+  }
+
+  return isValuePosition ? withToolCallArgRef(transformed) : transformed;
+}
+
+export function makeRefAwareJsonSchema(schema: Record<string, unknown>): Record<string, unknown> {
+  return transformSchemaNode(schema, false) as Record<string, unknown>;
+}
+
+export function makeBaseInputSchema(
+  schema: Record<string, unknown>
+): ReturnType<typeof z.fromJSONSchema> {
+  return z.fromJSONSchema(schema);
+}

--- a/agents-api/src/domains/run/agents/tools/tool-wrapper.ts
+++ b/agents-api/src/domains/run/agents/tools/tool-wrapper.ts
@@ -156,17 +156,17 @@ export function wrapToolWithStreaming(
           ? await artifactParser.resolveArgs(parsedArgsForResolution)
           : args;
 
-        const parameters = (toolDefinition as AiSdkToolDefinition).parameters;
-        if (artifactParser && parameters?.safeParse) {
-          const resolvedChanged =
-            JSON.stringify(parsedArgsForResolution) !== JSON.stringify(resolvedArgs);
-          if (resolvedChanged) {
-            const validation = parameters.safeParse(resolvedArgs);
-            if (!validation.success) {
-              throw new Error(
-                `Resolved tool args failed schema validation for '${toolName}': ${validation.error.message}`
-              );
-            }
+        const aiToolDefinition = toolDefinition as AiSdkToolDefinition;
+        const validationSchema = aiToolDefinition.baseInputSchema ?? aiToolDefinition.parameters;
+        const resolvedChanged =
+          JSON.stringify(parsedArgsForResolution) !== JSON.stringify(resolvedArgs);
+
+        if (artifactParser && validationSchema?.safeParse && resolvedChanged) {
+          const validation = validationSchema.safeParse(resolvedArgs);
+          if (!validation.success) {
+            throw new Error(
+              `Resolved tool args failed schema validation for '${toolName}': ${validation.error.message}`
+            );
           }
         }
 

--- a/agents-api/src/domains/run/artifacts/__tests__/ArtifactParser.typeSchema.test.ts
+++ b/agents-api/src/domains/run/artifacts/__tests__/ArtifactParser.typeSchema.test.ts
@@ -350,7 +350,6 @@ describe('ArtifactParser — typeSchema in data parts', () => {
         const imageResult = {
           result: {
             data: 'base64data==',
-            encoding: 'base64',
             mimeType: 'image/png',
           },
         };

--- a/agents-api/src/domains/run/artifacts/__tests__/ArtifactService.test.ts
+++ b/agents-api/src/domains/run/artifacts/__tests__/ArtifactService.test.ts
@@ -551,7 +551,6 @@ describe('ArtifactService', () => {
       });
       expect(artifactService.getToolResultRaw('call-img')).toEqual({
         data: 'base64data==',
-        encoding: 'base64',
         mimeType: 'image/png',
       });
     });

--- a/agents-api/src/domains/run/artifacts/artifact-utils.ts
+++ b/agents-api/src/domains/run/artifacts/artifact-utils.ts
@@ -27,12 +27,11 @@ export function queryJMESPath(data: unknown, selector: string): unknown {
 
 export type NormalizedContentItem =
   | { type: 'text'; text: unknown }
-  | { type: 'image'; data: string; encoding: 'base64'; mimeType: string };
+  | { type: 'image'; data: string; mimeType: string };
 
 function normalizeContentItem(item: any): NormalizedContentItem | null {
   if (item?.type === 'text') return { type: 'text', text: item.text };
-  if (item?.type === 'image')
-    return { type: 'image', data: item.data, encoding: 'base64', mimeType: item.mimeType };
+  if (item?.type === 'image') return { type: 'image', data: item.data, mimeType: item.mimeType };
   return null;
 }
 
@@ -52,8 +51,7 @@ export function unwrapToolResult(result: any): unknown {
     if (items.length === 1) {
       const first = items[0];
       if (first?.type === 'text') return first.text;
-      if (first?.type === 'image')
-        return { data: first.data, encoding: 'base64', mimeType: first.mimeType };
+      if (first?.type === 'image') return { data: first.data, mimeType: first.mimeType };
       return first;
     }
 

--- a/agents-api/src/mcp-media/server.ts
+++ b/agents-api/src/mcp-media/server.ts
@@ -10,11 +10,11 @@ Use these tools to inspect and manipulate images.
 - **image_resize** — scale an image to target dimensions. Provide width, height, or both. Aspect ratio is preserved by default.
 
 ## Input format
-All tools accept an image object with fields: data (base64-encoded bytes), encoding ("base64"), and mimeType (e.g. "image/png"). If you have a URL, fetch it and base64-encode the response body.
+All tools accept an image object with fields: data (base64-encoded bytes) and mimeType (e.g. "image/png"). If you have a URL, fetch it and base64-encode the response body.
 
 ## Chaining example
 Tools return the same image object format they accept, so you can chain them directly:
-1. image_info({ "image": { "data": "<base64>", "encoding": "base64", "mimeType": "image/png" } }) — inspect dimensions
+1. image_info({ "image": { "data": "<base64>", "mimeType": "image/png" } }) — inspect dimensions
 2. image_crop({ "image": <ref to step 1 result>, "x": 0, "y": 0, "width": 200, "height": 200 })
 3. image_resize({ "image": <ref to step 2 result>, "width": 100 })
 

--- a/agents-api/src/mcp-media/tools/image.ts
+++ b/agents-api/src/mcp-media/tools/image.ts
@@ -5,11 +5,10 @@ import { z } from 'zod';
 
 const MAX_IMAGE_BASE64_BYTES = 25 * 1024 * 1024;
 
-type ImageInput = { data: string; encoding: 'base64'; mimeType: string };
+type ImageInput = { data: string; mimeType: string };
 
 export const imageInputSchema = z.object({
   data: z.string().describe('Base64-encoded image bytes'),
-  encoding: z.literal('base64').describe('Encoding of the data field — must be "base64"'),
   mimeType: z.string().describe('MIME type of the image (e.g. "image/png", "image/jpeg")'),
 });
 
@@ -26,7 +25,7 @@ export function registerImageTools(server: McpServer): void {
     {
       description: 'Get metadata about an image: dimensions, format, channels, and file size.',
       inputSchema: z.object({
-        image: imageInputSchema.describe('Image object with base64 data, encoding, and mimeType'),
+        image: imageInputSchema.describe('Image object with base64 data and mimeType'),
       }),
     },
     async ({ image }): Promise<CallToolResult> => {

--- a/specs/2026-03-20-tool-chain-ref-aware-validation/SPEC.md
+++ b/specs/2026-03-20-tool-chain-ref-aware-validation/SPEC.md
@@ -1,0 +1,60 @@
+# Tool-Chain Ref-Aware Schema Validation — Retrospective Speclet
+
+**Date:** 2026-03-20
+**Type:** Retrospective (code already written)
+**Status:** Implemented, tests passing
+
+---
+
+## Executive Summary
+
+Agents support multi-step tool chaining where a tool call's arguments can reference the output of a prior tool call via sentinel objects (`{ $tool: "call_id", $path: "result.field" }`). Before this change, two failure modes existed:
+
+1. **Schema rejection at call time.** The AI SDK validates tool arguments against each tool's input schema. Sentinel refs are not valid values for most schema types (e.g., `{ $tool: "..." }` is not a `string`), so the SDK would reject chained tool calls before they ever reached the executor — silently, with no visibility in OTEL, session events, or conversation history.
+
+2. **Invalid resolved args after resolution.** When sentinel refs were resolved to their actual values, the resolved args were validated against the widened (ref-accepting) schema, not the original strict schema — meaning invalid resolved values could pass through to execution.
+
+### What Was Built
+
+**Ref-aware schema widening (`ref-aware-schema.ts`):** A recursive JSON Schema transformer that wraps every value-position node with `anyOf: [<original schema>, <sentinel ref schema>]`. The AI SDK sees a schema that accepts both real values and sentinel refs, so it never rejects a tool call at parse time for containing a ref.
+
+**Base schema preservation:** The original (pre-widened) schema is retained as `baseInputSchema` on each tool definition. After sentinel refs are resolved by `ArtifactParser`, the resolved args are validated against `baseInputSchema` — catching cases where resolution produced an invalid value.
+
+**Invalid tool call observability (`handleInvalidToolResultsFromStep`):** A new `onStepFinish` callback catches `tool-error` content parts emitted by the AI SDK for schema-validation failures. For each one it emits an OTEL span, records session events for the SSE feed, and persists a message to conversation history — giving the same visibility as a normal tool call that errors during execution.
+
+**Image schema simplification:** Removed the redundant `encoding: 'base64'` field from the `ImageInput` type and schema; encoding is now implicit.
+
+### Architecture
+
+```
+AI SDK call time:
+  args (may contain $tool refs)
+    → validated against refAwareInputSchema  ← always passes for valid refs
+    → execute() called
+
+tool-wrapper execute():
+  args
+    → parseEmbeddedJson()           ← unescape embedded JSON
+    → ArtifactParser.resolveArgs()  ← swap $tool refs for real values
+    → validate against baseInputSchema  ← catches bad resolved values
+    → originalExecute(resolvedArgs)
+
+onStepFinish callback:
+  step.content[].type === 'tool-error'
+    → OTEL span + session event + DB message  ← visibility for SDK-level rejections
+```
+
+### Key Design Decisions
+
+| Decision | Choice | Rationale |
+|---|---|---|
+| Where to widen the schema | Value-position nodes only (properties, items, additionalProperties) — not structural nodes (anyOf/oneOf/allOf) | Prevents double-wrapping of combinators; sentinel refs are only valid as leaf values |
+| Validation timing | After resolution, using `baseInputSchema` | Widened schema can't catch bad resolved values; original schema is the correct constraint |
+| Error surface for SDK-level rejections | `onStepFinish` hook | `execute()` is never called for these errors; the only observation point is the step result |
+| `encoding` field on image objects | Removed | Field was always `'base64'`; carrying it added schema surface with zero information |
+
+### What's Not Covered
+
+- **Partial resolution failures** (a ref resolves but the resolved value fails validation for only some fields) — surfaced as a thrown error, bubbles up as a normal tool execution failure.
+- **Circular or missing refs** — handled upstream by `ArtifactParser`, not in scope here.
+- **Ref-aware schema for A2A tool proxies** — not touched; those tools go through a different path.


### PR DESCRIPTION
## Summary

Tool chaining — where one tool call's arguments reference the output of a prior tool via sentinel objects like `{ $tool: "call_id", $path: "result.field" }` — had two silent failure modes:

1. **Schema rejection at call time.** The AI SDK validates tool arguments before calling `execute()`. Sentinel refs are not valid values for most schema types, so chained tool calls were silently rejected before reaching the executor — with no OTEL span, no session event, nothing in conversation history.
2. **No post-resolution validation.** After sentinel refs were resolved to real values, there was no check that the resolved values actually satisfied the original schema.

This PR fixes both, and adds full observability for SDK-level schema failures.

## Key decisions

**Schema widening strategy:** `ref-aware-schema.ts` recursively transforms each tool's JSON Schema so every value-position node (properties, items, additionalProperties) becomes `anyOf: [<original>, <sentinel-ref-schema>]`. Structural combinator nodes (anyOf/oneOf/allOf) are traversed but not widened — this prevents double-wrapping. The widened schema is what the AI SDK sees.

**Two-schema model:** The original (pre-widened) schema is preserved as `baseInputSchema` on the tool definition alongside the widened `inputSchema`. After `ArtifactParser` resolves sentinel refs, `tool-wrapper` validates resolved args against `baseInputSchema` — the strict constraint that refs bypassed at call time.

**Observability via `onStepFinish`:** SDK-level schema validation failures never reach `execute()`, so `tool-wrapper` can't catch them. The only hook is `onStepFinish` in `generate.ts`, where `tool-error` content parts surface these failures. Each one now gets an OTEL span, session events (for the SSE feed), and a conversation history message — same visibility as a normal execution-time failure.

**Image `encoding` field removed:** The `encoding: 'base64'` field on `ImageInput` was always the literal string `'base64'` — it carried no information. Removed from the type, schema, and server docs.

## Manual QA

Manually tested with the zendesk MCP + image agent.