### PR TITLE
fix:removed tooltip provider at the root and used at the place wherever we are using the tooltip

### DIFF
--- a/agents-manage-ui/src/components/agent/node-library/node-item.tsx
+++ b/agents-manage-ui/src/components/agent/node-library/node-item.tsx
@@ -1,7 +1,7 @@
 import { GripVertical, type LucideIcon } from 'lucide-react';
 import type { ComponentProps, FC, ReactNode } from 'react';
 import { FlowButton } from '@/components/agent/flow-button';
-import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
 import { cn } from '@/lib/utils';
 
 export type NodeItem = {
@@ -47,12 +47,14 @@ export const NodeItem: FC<NodeItemProps> = ({ node, className }) => {
 
   if (disabled && disabledTooltip) {
     return (
-      <Tooltip>
-        <TooltipTrigger asChild>{content}</TooltipTrigger>
-        <TooltipContent side="right" sideOffset={8}>
-          {disabledTooltip}
-        </TooltipContent>
-      </Tooltip>
+      <TooltipProvider>
+        <Tooltip>
+          <TooltipTrigger asChild>{content}</TooltipTrigger>
+          <TooltipContent side="right" sideOffset={8}>
+            {disabledTooltip}
+          </TooltipContent>
+        </Tooltip>
+      </TooltipProvider>
     );
   }
 

--- a/agents-manage-ui/src/components/agent/nodes/function-tool-node.tsx
+++ b/agents-manage-ui/src/components/agent/nodes/function-tool-node.tsx
@@ -1,6 +1,6 @@
 import { type NodeProps, Position } from '@xyflow/react';
 import { Code, Shield } from 'lucide-react';
-import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
 import { useAgentErrors } from '@/hooks/use-agent-errors';
 import { cn } from '@/lib/utils';
 import { toolPoliciesNeedApproval } from '@/lib/utils/tool-policies';
@@ -44,18 +44,20 @@ export function FunctionToolNode({
               </div>
               <BaseNodeHeaderTitle className="flex-1 truncate">{name}</BaseNodeHeaderTitle>
               {needsApproval && (
-                <Tooltip>
-                  <TooltipTrigger asChild>
-                    <button
-                      type="button"
-                      className="shrink-0 text-muted-foreground"
-                      title="Requires approval"
-                    >
-                      <Shield className="h-4 w-4" />
-                    </button>
-                  </TooltipTrigger>
-                  <TooltipContent>Requires approval</TooltipContent>
-                </Tooltip>
+                <TooltipProvider>
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <button
+                        type="button"
+                        className="shrink-0 text-muted-foreground"
+                        title="Requires approval"
+                      >
+                        <Shield className="h-4 w-4" />
+                      </button>
+                    </TooltipTrigger>
+                    <TooltipContent>Requires approval</TooltipContent>
+                  </Tooltip>
+                </TooltipProvider>
               )}
             </div>
             {description && (

--- a/agents-manage-ui/src/components/agent/nodes/mcp-node.tsx
+++ b/agents-manage-ui/src/components/agent/nodes/mcp-node.tsx
@@ -4,7 +4,7 @@ import { useParams } from 'next/navigation';
 import type { FC, ReactNode } from 'react';
 import { MCPToolImage } from '@/components/mcp-servers/mcp-tool-image';
 import { Badge } from '@/components/ui/badge';
-import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
 import { useMcpToolStatusQuery, useMcpToolsQuery } from '@/lib/query/mcp-tools';
 import { cn, createLookup } from '@/lib/utils';
 import { getActiveTools } from '@/lib/utils/active-tools';
@@ -40,17 +40,19 @@ const TruncateToolBadge: FC<{
   }
 
   return (
-    <Tooltip>
-      <TooltipTrigger asChild>
-        <div className="relative max-w-full">
-          <TruncateBadge>{label}</TruncateBadge>
-          <div className="absolute -top-1 -right-2 rounded-full bg-background p-0.5">
-            <Shield className="h-3 w-3 text-muted-foreground" />
+    <TooltipProvider>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <div className="relative max-w-full">
+            <TruncateBadge>{label}</TruncateBadge>
+            <div className="absolute -top-1 -right-2 rounded-full bg-background p-0.5">
+              <Shield className="h-3 w-3 text-muted-foreground" />
+            </div>
           </div>
-        </div>
-      </TooltipTrigger>
-      <TooltipContent>Requires approval</TooltipContent>
-    </Tooltip>
+        </TooltipTrigger>
+        <TooltipContent>Requires approval</TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
   );
 };
 

--- a/agents-manage-ui/src/components/agent/ship/chat-ui-guide/chat-ui-preview-form.tsx
+++ b/agents-manage-ui/src/components/agent/ship/chat-ui-guide/chat-ui-preview-form.tsx
@@ -6,7 +6,7 @@ import { ColorPickerInput } from '@/components/ui/color-picker';
 import { Form, FormItem } from '@/components/ui/form';
 import { Label } from '@/components/ui/label';
 import { Switch } from '@/components/ui/switch';
-import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
 
 export enum ChatUIComponent {
   EMBEDDED_CHAT = 'Embedded Chat',
@@ -61,14 +61,16 @@ export const ChatUIPreviewForm = ({ form }: ChatUIPreviewFormProps) => {
         <FormItem className="relative flex flex-row gap-2 items-center w-full justify-between">
           <div className="flex flex-row gap-2 items-center">
             <Label>Show data operations</Label>
-            <Tooltip>
-              <TooltipTrigger>
-                <Info className="w-3 h-3 text-muted-foreground" />
-              </TooltipTrigger>
-              <TooltipContent>
-                Controls whether data operations are included in the response stream.
-              </TooltipContent>
-            </Tooltip>
+            <TooltipProvider>
+              <Tooltip>
+                <TooltipTrigger>
+                  <Info className="w-3 h-3 text-muted-foreground" />
+                </TooltipTrigger>
+                <TooltipContent>
+                  Controls whether data operations are included in the response stream.
+                </TooltipContent>
+              </Tooltip>
+            </TooltipProvider>
           </div>
           <Controller
             control={form.control}

--- a/agents-manage-ui/src/components/agent/sidepane/form-components/label.tsx
+++ b/agents-manage-ui/src/components/agent/sidepane/form-components/label.tsx
@@ -1,7 +1,7 @@
 import { Info } from 'lucide-react';
 import type { FC, ReactNode } from 'react';
 import { Label } from '@/components/ui/label';
-import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
 import { cn } from '@/lib/utils';
 
 interface FieldLabelProps {
@@ -26,12 +26,14 @@ export const FieldLabel: FC<FieldLabelProps> = ({
       {label}
       {isRequired && <span className="text-red-500">*</span>}
       {tooltip && (
-        <Tooltip>
-          <TooltipTrigger>
-            <Info className="w-3 h-3 text-muted-foreground ml-1" />
-          </TooltipTrigger>
-          <TooltipContent className="wrap-break-word">{tooltip}</TooltipContent>
-        </Tooltip>
+        <TooltipProvider>
+          <Tooltip>
+            <TooltipTrigger>
+              <Info className="w-3 h-3 text-muted-foreground ml-1" />
+            </TooltipTrigger>
+            <TooltipContent className="wrap-break-word">{tooltip}</TooltipContent>
+          </Tooltip>
+        </TooltipProvider>
       )}
     </Label>
   );

--- a/agents-manage-ui/src/components/agent/sidepane/metadata/metadata-editor.tsx
+++ b/agents-manage-ui/src/components/agent/sidepane/metadata/metadata-editor.tsx
@@ -18,7 +18,7 @@ import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Separator } from '@/components/ui/separator';
 import { Textarea } from '@/components/ui/textarea';
-import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
 import { useRuntimeConfig } from '@/contexts/runtime-config';
 import { agentStore, useAgentActions, useAgentStore } from '@/features/agent/state/use-agent-store';
 import { useAutoPrefillIdZustand } from '@/hooks/use-auto-prefill-id-zustand';
@@ -108,16 +108,18 @@ export function MetadataEditor() {
         <div className="space-y-2">
           <div className="text-sm leading-none font-medium flex items-center gap-1">
             Chat API Base URL
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <Info className="w-3 h-3 text-muted-foreground" />
-              </TooltipTrigger>
-              <TooltipContent>
-                Use this endpoint to chat with your agent by appending /run/api/chat or connect it
-                to the Inkeep widget via the baseUrl prop and specifying the appId. Supports
-                streaming responses with the Vercel AI SDK data stream protocol.
-              </TooltipContent>
-            </Tooltip>
+            <TooltipProvider>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Info className="w-3 h-3 text-muted-foreground" />
+                </TooltipTrigger>
+                <TooltipContent>
+                  Use this endpoint to chat with your agent by appending /run/api/chat or connect it
+                  to the Inkeep widget via the baseUrl prop and specifying the appId. Supports
+                  streaming responses with the Vercel AI SDK data stream protocol.
+                </TooltipContent>
+              </Tooltip>
+            </TooltipProvider>
           </div>
           <CopyableSingleLineCode code={baseUrl} />
           {canUse && (

--- a/agents-manage-ui/src/components/agent/sidepane/nodes/mcp-node-editor.tsx
+++ b/agents-manage-ui/src/components/agent/sidepane/nodes/mcp-node-editor.tsx
@@ -14,7 +14,7 @@ import { ExternalLink } from '@/components/ui/external-link';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Separator } from '@/components/ui/separator';
-import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
 import { useAgentActions } from '@/features/agent/state/use-agent-store';
 import { useNodeEditor } from '@/hooks/use-node-editor';
 import { useMcpToolStatusQuery, useMcpToolsQuery } from '@/lib/query/mcp-tools';
@@ -379,63 +379,65 @@ export function MCPServerNodeEditor({ selectedNode }: MCPServerNodeEditorProps) 
             {/* Header */}
             <div className="grid grid-cols-[1fr_auto] gap-4 px-3 py-2.5 text-xs font-medium text-muted-foreground rounded-t-md border-b">
               <div>Tool</div>
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <div className="flex items-center gap-1.5 cursor-help">
-                    <Shield className="w-3 h-3" />
-                    Needs Approval?
-                    {(() => {
-                      const enabledToolNames =
-                        selectedTools === null
-                          ? activeTools?.map((tool) => tool.name) || []
-                          : selectedTools.filter((toolName) =>
-                              activeTools?.some((tool) => tool.name === toolName)
-                            );
-                      const hasEnabledTools = enabledToolNames.length > 0;
-                      const allEnabledNeedApproval =
-                        hasEnabledTools &&
-                        enabledToolNames.every(
-                          (toolName) => currentToolPolicies[toolName]?.needsApproval
-                        );
-                      const someEnabledNeedApproval =
-                        hasEnabledTools &&
-                        enabledToolNames.some(
-                          (toolName) => currentToolPolicies[toolName]?.needsApproval
-                        );
+              <TooltipProvider>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <div className="flex items-center gap-1.5 cursor-help">
+                      <Shield className="w-3 h-3" />
+                      Needs Approval?
+                      {(() => {
+                        const enabledToolNames =
+                          selectedTools === null
+                            ? activeTools?.map((tool) => tool.name) || []
+                            : selectedTools.filter((toolName) =>
+                                activeTools?.some((tool) => tool.name === toolName)
+                              );
+                        const hasEnabledTools = enabledToolNames.length > 0;
+                        const allEnabledNeedApproval =
+                          hasEnabledTools &&
+                          enabledToolNames.every(
+                            (toolName) => currentToolPolicies[toolName]?.needsApproval
+                          );
+                        const someEnabledNeedApproval =
+                          hasEnabledTools &&
+                          enabledToolNames.some(
+                            (toolName) => currentToolPolicies[toolName]?.needsApproval
+                          );
 
-                      return (
-                        <Checkbox
-                          checked={
-                            allEnabledNeedApproval
-                              ? true
-                              : someEnabledNeedApproval
-                                ? 'indeterminate'
-                                : false
-                          }
-                          disabled={!hasEnabledTools}
-                          onCheckedChange={() => toggleAllApprovalsForEnabledTools()}
-                          onClick={(e) => e.stopPropagation()}
-                          aria-label="Toggle approval for all enabled tools"
-                        />
-                      );
-                    })()}
-                  </div>
-                </TooltipTrigger>
-                <TooltipContent className="max-w-xs">
-                  <div className="text-sm">
-                    Tools requiring approval will pause execution and wait for user confirmation
-                    before running. Use the checkbox to toggle approval for all enabled tools.{' '}
-                    <a
-                      href="https://docs.inkeep.com/visual-builder/tools/tool-approvals"
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      className="underline hover:no-underline"
-                    >
-                      Learn more
-                    </a>
-                  </div>
-                </TooltipContent>
-              </Tooltip>
+                        return (
+                          <Checkbox
+                            checked={
+                              allEnabledNeedApproval
+                                ? true
+                                : someEnabledNeedApproval
+                                  ? 'indeterminate'
+                                  : false
+                            }
+                            disabled={!hasEnabledTools}
+                            onCheckedChange={() => toggleAllApprovalsForEnabledTools()}
+                            onClick={(e) => e.stopPropagation()}
+                            aria-label="Toggle approval for all enabled tools"
+                          />
+                        );
+                      })()}
+                    </div>
+                  </TooltipTrigger>
+                  <TooltipContent className="max-w-xs">
+                    <div className="text-sm">
+                      Tools requiring approval will pause execution and wait for user confirmation
+                      before running. Use the checkbox to toggle approval for all enabled tools.{' '}
+                      <a
+                        href="https://docs.inkeep.com/visual-builder/tools/tool-approvals"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="underline hover:no-underline"
+                      >
+                        Learn more
+                      </a>
+                    </div>
+                  </TooltipContent>
+                </Tooltip>
+              </TooltipProvider>
             </div>
 
             {/* Active tools */}
@@ -499,25 +501,27 @@ export function MCPServerNodeEditor({ selectedNode }: MCPServerNodeEditorProps) 
                       checked={true}
                       onCheckedChange={() => toggleToolSelection(toolName)}
                     />
-                    <Tooltip>
-                      <TooltipTrigger asChild>
-                        <div className="flex-1 min-w-0 flex items-center gap-2">
-                          <div className="flex-1 max-w-full">
-                            <div className="text-sm font-medium truncate">{toolName}</div>
-                            <div className="flex items-center gap-1">
-                              <CircleAlert className="w-3 h-3 text-amber-500 shrink-0" />
-                              <div className="text-xs text-amber-600 dark:text-amber-400">
-                                Tool no longer available
+                    <TooltipProvider>
+                      <Tooltip>
+                        <TooltipTrigger asChild>
+                          <div className="flex-1 min-w-0 flex items-center gap-2">
+                            <div className="flex-1 max-w-full">
+                              <div className="text-sm font-medium truncate">{toolName}</div>
+                              <div className="flex items-center gap-1">
+                                <CircleAlert className="w-3 h-3 text-amber-500 shrink-0" />
+                                <div className="text-xs text-amber-600 dark:text-amber-400">
+                                  Tool no longer available
+                                </div>
                               </div>
                             </div>
                           </div>
-                        </div>
-                      </TooltipTrigger>
-                      <TooltipContent className="max-w-xs text-sm">
-                        This tool was selected but is not available in the MCP server. Uncheck to
-                        remove it.
-                      </TooltipContent>
-                    </Tooltip>
+                        </TooltipTrigger>
+                        <TooltipContent className="max-w-xs text-sm">
+                          This tool was selected but is not available in the MCP server. Uncheck to
+                          remove it.
+                        </TooltipContent>
+                      </Tooltip>
+                    </TooltipProvider>
                   </div>
                   {/* Needs Approval Checkbox hidden b/c we don't support it yet */}
                   <div className="items-center">

--- a/agents-manage-ui/src/components/agent/sidepane/section.tsx
+++ b/agents-manage-ui/src/components/agent/sidepane/section.tsx
@@ -1,17 +1,19 @@
 import { Info } from 'lucide-react';
-import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
 
 function SectionTitle({ title, tooltip }: { title: string; tooltip?: React.ReactNode }) {
   return (
     <h3 className="text-sm font-semibold flex items-center">
       {title}
       {tooltip && (
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <Info className="w-3 h-3 text-muted-foreground ml-1" />
-          </TooltipTrigger>
-          <TooltipContent>{tooltip}</TooltipContent>
-        </Tooltip>
+        <TooltipProvider>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Info className="w-3 h-3 text-muted-foreground ml-1" />
+            </TooltipTrigger>
+            <TooltipContent>{tooltip}</TooltipContent>
+          </Tooltip>
+        </TooltipProvider>
       )}{' '}
     </h3>
   );

--- a/agents-manage-ui/src/components/agent/toolbar/toolbar.tsx
+++ b/agents-manage-ui/src/components/agent/toolbar/toolbar.tsx
@@ -4,7 +4,7 @@ import { useParams } from 'next/navigation';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { FlowButton } from '@/components/agent/flow-button';
 import { Spinner } from '@/components/ui/spinner';
-import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
 import { useAgentStore } from '@/features/agent/state/use-agent-store';
 import { useProjectPermissionsQuery } from '@/lib/query/projects';
 import { cn, isMacOs } from '@/lib/utils';
@@ -72,22 +72,24 @@ export function Toolbar({ onSubmit, toggleSidePane, setShowPlayground }: Toolbar
         <>
           <ShipModal />
           {isDirty || hasOpenModelConfig ? (
-            <Tooltip>
-              <TooltipTrigger asChild>
-                {/**
-                 * Wrap the disabled button in a <div> that can receive hover events since disabled <button> elements
-                 * don't trigger pointer events in the browser
-                 **/}
-                <div>{previewButton}</div>
-              </TooltipTrigger>
-              <TooltipContent>
-                {hasOpenModelConfig
-                  ? 'Please complete model configuration before trying the agent.'
-                  : isDirty
-                    ? 'Please save your changes before trying the agent.'
-                    : 'Please save the agent to try it.'}
-              </TooltipContent>
-            </Tooltip>
+            <TooltipProvider>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  {/**
+                   * Wrap the disabled button in a <div> that can receive hover events since disabled <button> elements
+                   * don't trigger pointer events in the browser
+                   **/}
+                  <div>{previewButton}</div>
+                </TooltipTrigger>
+                <TooltipContent>
+                  {hasOpenModelConfig
+                    ? 'Please complete model configuration before trying the agent.'
+                    : isDirty
+                      ? 'Please save your changes before trying the agent.'
+                      : 'Please save the agent to try it.'}
+                </TooltipContent>
+              </Tooltip>
+            </TooltipProvider>
           ) : (
             previewButton
           )}

--- a/agents-manage-ui/src/components/api-keys/expiration-indicator.tsx
+++ b/agents-manage-ui/src/components/api-keys/expiration-indicator.tsx
@@ -1,7 +1,7 @@
 import { AlertCircle } from 'lucide-react';
 import { Badge } from '@/components/ui/badge';
 import { formatDate } from '@/lib/utils/format-date';
-import { Tooltip, TooltipContent, TooltipTrigger } from '../ui/tooltip';
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '../ui/tooltip';
 
 interface ExpirationIndicatorProps {
   expiresAt: string | undefined;
@@ -50,36 +50,42 @@ export function ExpirationIndicator({ expiresAt }: ExpirationIndicatorProps) {
       )}
 
       {expired && (
-        <Tooltip>
-          <TooltipTrigger>
-            <Badge variant="error">Expired</Badge>
-          </TooltipTrigger>
-          <TooltipContent>
-            <p>This API key expired on {expiresAt ? formatDate(expiresAt) : ''}</p>
-          </TooltipContent>
-        </Tooltip>
+        <TooltipProvider>
+          <Tooltip>
+            <TooltipTrigger>
+              <Badge variant="error">Expired</Badge>
+            </TooltipTrigger>
+            <TooltipContent>
+              <p>This API key expired on {expiresAt ? formatDate(expiresAt) : ''}</p>
+            </TooltipContent>
+          </Tooltip>
+        </TooltipProvider>
       )}
 
       {criticallyExpiring && (
-        <Tooltip>
-          <TooltipTrigger>
-            <AlertCircle className="h-4 w-4 text-red-500" />
-          </TooltipTrigger>
-          <TooltipContent>
-            <p>Expires in less than 24 hours</p>
-          </TooltipContent>
-        </Tooltip>
+        <TooltipProvider>
+          <Tooltip>
+            <TooltipTrigger>
+              <AlertCircle className="h-4 w-4 text-red-500" />
+            </TooltipTrigger>
+            <TooltipContent>
+              <p>Expires in less than 24 hours</p>
+            </TooltipContent>
+          </Tooltip>
+        </TooltipProvider>
       )}
 
       {expiringSoon && (
-        <Tooltip>
-          <TooltipTrigger>
-            <AlertCircle className="h-4 w-4 text-amber-500" />
-          </TooltipTrigger>
-          <TooltipContent>
-            <p>Expires in less than 7 days</p>
-          </TooltipContent>
-        </Tooltip>
+        <TooltipProvider>
+          <Tooltip>
+            <TooltipTrigger>
+              <AlertCircle className="h-4 w-4 text-amber-500" />
+            </TooltipTrigger>
+            <TooltipContent>
+              <p>Expires in less than 7 days</p>
+            </TooltipContent>
+          </Tooltip>
+        </TooltipProvider>
       )}
     </div>
   );

--- a/agents-manage-ui/src/components/api-keys/new-api-key-dialog.tsx
+++ b/agents-manage-ui/src/components/api-keys/new-api-key-dialog.tsx
@@ -13,7 +13,7 @@ import {
   DialogTitle,
   DialogTrigger,
 } from '../ui/dialog';
-import { Tooltip, TooltipContent, TooltipTrigger } from '../ui/tooltip';
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '../ui/tooltip';
 import { ApiKeyDisplay } from './api-key-display';
 import { ApiKeyForm } from './form/api-key-form';
 
@@ -40,22 +40,24 @@ export function NewApiKeyDialog({ agentsOptions }: NewApiKeyDialogProps) {
     <>
       {/* Form Dialog */}
       <Dialog open={isFormOpen} onOpenChange={setIsFormOpen}>
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <div>
-              <DialogTrigger asChild>
-                <Button disabled={!hasAgents}>
-                  <Plus className="size-4" /> New API key
-                </Button>
-              </DialogTrigger>
-            </div>
-          </TooltipTrigger>
-          {!hasAgents && (
-            <TooltipContent className="max-w-3xs">
-              Please create an agent first, then you will be able to create an API key.
-            </TooltipContent>
-          )}
-        </Tooltip>
+        <TooltipProvider>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <div>
+                <DialogTrigger asChild>
+                  <Button disabled={!hasAgents}>
+                    <Plus className="size-4" /> New API key
+                  </Button>
+                </DialogTrigger>
+              </div>
+            </TooltipTrigger>
+            {!hasAgents && (
+              <TooltipContent className="max-w-3xs">
+                Please create an agent first, then you will be able to create an API key.
+              </TooltipContent>
+            )}
+          </Tooltip>
+        </TooltipProvider>
         <DialogContent>
           <DialogHeader>
             <DialogTitle>New API key</DialogTitle>

--- a/agents-manage-ui/src/components/data-components/render/component-render-generator.tsx
+++ b/agents-manage-ui/src/components/data-components/render/component-render-generator.tsx
@@ -15,7 +15,7 @@ import { Label } from '@/components/ui/label';
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { Textarea } from '@/components/ui/textarea';
-import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
 import { UseInYourAppModal } from '@/components/use-in-your-app-modal';
 import { DOCS_BASE_URL } from '@/constants/theme';
 import { updateDataComponent } from '@/lib/api/data-components';
@@ -193,32 +193,34 @@ export function ComponentRenderGenerator({
         <div className="space-y-2">
           <div className="flex items-center gap-1">
             <h3 className="text-md font-medium">Component Renderer</h3>
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <Info className="w-3 h-3 text-muted-foreground ml-1" />
-              </TooltipTrigger>
-              <TooltipContent>
-                <div className="text-sm text-muted-foreground">
-                  Generates a React/Tailwind component from your schema using your project's base
-                  model
-                  {baseModel && (
-                    <>
-                      {' '}
-                      <Badge variant="code">{baseModel}</Badge>
-                    </>
-                  )}
-                  .
-                  <div className="flex mt-1">
-                    <ExternalLink
-                      href={`/${tenantId}/projects/${projectId}/settings`}
-                      className="text-xs ml-0"
-                    >
-                      Edit in settings
-                    </ExternalLink>
+            <TooltipProvider>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Info className="w-3 h-3 text-muted-foreground ml-1" />
+                </TooltipTrigger>
+                <TooltipContent>
+                  <div className="text-sm text-muted-foreground">
+                    Generates a React/Tailwind component from your schema using your project's base
+                    model
+                    {baseModel && (
+                      <>
+                        {' '}
+                        <Badge variant="code">{baseModel}</Badge>
+                      </>
+                    )}
+                    .
+                    <div className="flex mt-1">
+                      <ExternalLink
+                        href={`/${tenantId}/projects/${projectId}/settings`}
+                        className="text-xs ml-0"
+                      >
+                        Edit in settings
+                      </ExternalLink>
+                    </div>
                   </div>
-                </div>
-              </TooltipContent>
-            </Tooltip>
+                </TooltipContent>
+              </Tooltip>
+            </TooltipProvider>
           </div>
         </div>
         <div className="flex gap-2">

--- a/agents-manage-ui/src/components/form/json-schema-builder.tsx
+++ b/agents-manage-ui/src/components/form/json-schema-builder.tsx
@@ -13,7 +13,7 @@ import {
   SelectValue,
 } from '@/components/ui/select';
 import { Table, TableHead, TableHeader, TableRow } from '@/components/ui/table';
-import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
 import {
   type FieldObject,
   fieldsToJsonSchema,
@@ -84,22 +84,24 @@ const Property: FC<PropertyProps> = ({ fieldId, depth = 0, prefix }) => {
     <div className="flex gap-2 items-center" style={{ marginLeft: indentStyle }}>
       {prefix ||
         (hasInPreview && (
-          <Tooltip>
-            <TooltipTrigger asChild>
-              {/* without the wrapping div the checkbox doesn't get the data-state="checked" attribute and the styles are not applied */}
-              <div>
-                <Checkbox
-                  // !! fix warning: Checkbox is changing from uncontrolled to controlled.
-                  checked={!!field.isPreview}
-                  onCheckedChange={(checked) =>
-                    updateField(field.id, { isPreview: checked === true })
-                  }
-                  disabled={readOnly}
-                />
-              </div>
-            </TooltipTrigger>
-            <TooltipContent>Mark this field as available immediately in UI</TooltipContent>
-          </Tooltip>
+          <TooltipProvider>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                {/* without the wrapping div the checkbox doesn't get the data-state="checked" attribute and the styles are not applied */}
+                <div>
+                  <Checkbox
+                    // !! fix warning: Checkbox is changing from uncontrolled to controlled.
+                    checked={!!field.isPreview}
+                    onCheckedChange={(checked) =>
+                      updateField(field.id, { isPreview: checked === true })
+                    }
+                    disabled={readOnly}
+                  />
+                </div>
+              </TooltipTrigger>
+              <TooltipContent>Mark this field as available immediately in UI</TooltipContent>
+            </Tooltip>
+          </TooltipProvider>
         ))}
       <PropertyIcon type={field.type} />
       <SelectType
@@ -133,36 +135,40 @@ const Property: FC<PropertyProps> = ({ fieldId, depth = 0, prefix }) => {
       {!prefix && !readOnly && (
         <>
           {!allRequired && (
+            <TooltipProvider>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  {/* without the wrapping div the checkbox doesn't get the data-state="checked" attribute and the styles are not applied */}
+                  <div>
+                    <Checkbox
+                      checked={field.isRequired}
+                      onCheckedChange={(checked) =>
+                        updateField(field.id, { isRequired: checked === true })
+                      }
+                    />
+                  </div>
+                </TooltipTrigger>
+                <TooltipContent>Mark this field as required</TooltipContent>
+              </Tooltip>
+            </TooltipProvider>
+          )}
+          <TooltipProvider>
             <Tooltip>
               <TooltipTrigger asChild>
-                {/* without the wrapping div the checkbox doesn't get the data-state="checked" attribute and the styles are not applied */}
-                <div>
-                  <Checkbox
-                    checked={field.isRequired}
-                    onCheckedChange={(checked) =>
-                      updateField(field.id, { isRequired: checked === true })
-                    }
-                  />
-                </div>
+                <Button
+                  type="button"
+                  size="icon-sm"
+                  variant="ghost"
+                  onClick={() => {
+                    removeField(field.id);
+                  }}
+                >
+                  <TrashIcon />
+                </Button>
               </TooltipTrigger>
-              <TooltipContent>Mark this field as required</TooltipContent>
+              <TooltipContent>Remove property</TooltipContent>
             </Tooltip>
-          )}
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <Button
-                type="button"
-                size="icon-sm"
-                variant="ghost"
-                onClick={() => {
-                  removeField(field.id);
-                }}
-              >
-                <TrashIcon />
-              </Button>
-            </TooltipTrigger>
-            <TooltipContent>Remove property</TooltipContent>
-          </Tooltip>
+          </TooltipProvider>
         </>
       )}
     </div>
@@ -304,23 +310,25 @@ export const JsonSchemaBuilder: FC<{
               <TableHead className="w-px p-0">
                 <div className="flex items-center gap-1">
                   In Preview
-                  <Tooltip>
-                    <TooltipTrigger>
-                      <Info className="size-3" />
-                    </TooltipTrigger>
-                    <TooltipContent className="text-wrap">
-                      Specifies which fields will be immediately available.{' '}
-                      <a
-                        target="_blank"
-                        rel="noopener"
-                        href="https://docs.inkeep.com/visual-builder/structured-outputs/artifact-components#preview-fields"
-                        className="underline text-primary"
-                      >
-                        Learn more
-                      </a>
-                      .
-                    </TooltipContent>
-                  </Tooltip>
+                  <TooltipProvider>
+                    <Tooltip>
+                      <TooltipTrigger>
+                        <Info className="size-3" />
+                      </TooltipTrigger>
+                      <TooltipContent className="text-wrap">
+                        Specifies which fields will be immediately available.{' '}
+                        <a
+                          target="_blank"
+                          rel="noopener"
+                          href="https://docs.inkeep.com/visual-builder/structured-outputs/artifact-components#preview-fields"
+                          className="underline text-primary"
+                        >
+                          Learn more
+                        </a>
+                        .
+                      </TooltipContent>
+                    </Tooltip>
+                  </TooltipProvider>
                 </div>
               </TableHead>
             )}

--- a/agents-manage-ui/src/components/mcp-servers/form/tool-selector-item.tsx
+++ b/agents-manage-ui/src/components/mcp-servers/form/tool-selector-item.tsx
@@ -12,7 +12,7 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
-import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
 import { ToolOverrideDiff } from './tool-override-diff';
 
 interface ToolSelectorItemProps {
@@ -103,14 +103,16 @@ export function ToolSelectorItem({
             </div>
           </div>
 
-          <Tooltip delayDuration={800}>
-            <TooltipTrigger asChild>
-              <p className="text-sm text-muted-foreground line-clamp-1">{description}</p>
-            </TooltipTrigger>
-            <TooltipContent side="bottom" align="start">
-              {description}
-            </TooltipContent>
-          </Tooltip>
+          <TooltipProvider>
+            <Tooltip delayDuration={800}>
+              <TooltipTrigger asChild>
+                <p className="text-sm text-muted-foreground line-clamp-1">{description}</p>
+              </TooltipTrigger>
+              <TooltipContent side="bottom" align="start">
+                {description}
+              </TooltipContent>
+            </Tooltip>
+          </TooltipProvider>
         </div>
       </div>
       {isCompareOpen && override && (

--- a/agents-manage-ui/src/components/mcp-servers/view-mcp-server-details-shared.tsx
+++ b/agents-manage-ui/src/components/mcp-servers/view-mcp-server-details-shared.tsx
@@ -2,7 +2,7 @@
 
 import { cn } from '@/lib/utils';
 import { Badge } from '../ui/badge';
-import { Tooltip, TooltipContent, TooltipTrigger } from '../ui/tooltip';
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '../ui/tooltip';
 
 export function ActiveToolBadge({
   toolName,
@@ -24,12 +24,14 @@ export function ActiveToolBadge({
 
   if (!isAvailable) {
     return (
-      <Tooltip>
-        <TooltipTrigger asChild>{badge}</TooltipTrigger>
-        <TooltipContent>
-          <p>This tool is not available in the MCP server.</p>
-        </TooltipContent>
-      </Tooltip>
+      <TooltipProvider>
+        <Tooltip>
+          <TooltipTrigger asChild>{badge}</TooltipTrigger>
+          <TooltipContent>
+            <p>This tool is not available in the MCP server.</p>
+          </TooltipContent>
+        </Tooltip>
+      </TooltipProvider>
     );
   }
 

--- a/agents-manage-ui/src/components/skills/form/skill-form.tsx
+++ b/agents-manage-ui/src/components/skills/form/skill-form.tsx
@@ -14,7 +14,7 @@ import { Button } from '@/components/ui/button';
 import { Dialog, DialogTrigger } from '@/components/ui/dialog';
 import { Form } from '@/components/ui/form';
 import { Spinner } from '@/components/ui/spinner';
-import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
 import { useProjectPermissionsQuery } from '@/lib/query/projects';
 import { useSkillQuery, useUpsertSkillMutation } from '@/lib/query/skills';
 import type { Skill } from '@/lib/types/skills';
@@ -126,19 +126,22 @@ export const SkillForm: FC<SkillFormProps> = ({ onSuccess }) => {
           label={
             <>
               Description
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <Info className="size-3 text-muted-foreground" />
-                </TooltipTrigger>
-                <TooltipContent className="text-wrap">
-                  <Check className="inline size-3 text-green-500" /> Good example: Extracts text and
-                  tables from PDF files, fills PDF forms, and merges multiple PDFs. Use when working
-                  with PDF documents or when the user mentions PDFs, forms, or document extraction.
-                  <br />
-                  <br />
-                  <X className="inline size-3 text-red-500" /> Bad example: Helps with PDFs.
-                </TooltipContent>
-              </Tooltip>
+              <TooltipProvider>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Info className="size-3 text-muted-foreground" />
+                  </TooltipTrigger>
+                  <TooltipContent className="text-wrap">
+                    <Check className="inline size-3 text-green-500" /> Good example: Extracts text
+                    and tables from PDF files, fills PDF forms, and merges multiple PDFs. Use when
+                    working with PDF documents or when the user mentions PDFs, forms, or document
+                    extraction.
+                    <br />
+                    <br />
+                    <X className="inline size-3 text-red-500" /> Bad example: Helps with PDFs.
+                  </TooltipContent>
+                </Tooltip>
+              </TooltipProvider>
             </>
           }
           placeholder="High-level summary of what this skill enforces."

--- a/agents-manage-ui/src/components/skills/skill-selector.tsx
+++ b/agents-manage-ui/src/components/skills/skill-selector.tsx
@@ -15,7 +15,7 @@ import {
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
 import { ExternalLink } from '@/components/ui/external-link';
-import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
 import { DOCS_BASE_URL } from '@/constants/theme';
 import { useSkillsQuery } from '@/lib/query/skills';
 import { cn } from '@/lib/utils';
@@ -105,21 +105,24 @@ export const SkillSelector: FC<SkillSelectorProps> = ({ selectedSkills = [], onC
         <div className="border rounded-md text-xs">
           <div className="flex gap-2 px-3 py-2.5 font-medium text-muted-foreground rounded-t-md">
             Skill
-            <Tooltip>
-              <TooltipTrigger asChild>
-                {/* use span instead of button */}
-                <span className="cursor-help ml-auto">Always loaded</span>
-              </TooltipTrigger>
-              <TooltipContent>
-                When enabled, this skill is included in every prompt. Disable to load it on demand.
-                <ExternalLink
-                  href={`${DOCS_BASE_URL}/visual-builder/skills#always-loaded-and-on-demand-skills`}
-                  className="text-xs normal-case inline"
-                >
-                  Learn more
-                </ExternalLink>
-              </TooltipContent>
-            </Tooltip>
+            <TooltipProvider>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  {/* use span instead of button */}
+                  <span className="cursor-help ml-auto">Always loaded</span>
+                </TooltipTrigger>
+                <TooltipContent>
+                  When enabled, this skill is included in every prompt. Disable to load it on
+                  demand.
+                  <ExternalLink
+                    href={`${DOCS_BASE_URL}/visual-builder/skills#always-loaded-and-on-demand-skills`}
+                    className="text-xs normal-case inline"
+                  >
+                    Learn more
+                  </ExternalLink>
+                </TooltipContent>
+              </Tooltip>
+            </TooltipProvider>
           </div>
           <ul>
             {selectedSkills.map((skill) => (

--- a/agents-manage-ui/src/components/traces/conversation-stats/conversation-list-item.tsx
+++ b/agents-manage-ui/src/components/traces/conversation-stats/conversation-list-item.tsx
@@ -1,7 +1,7 @@
 import { Hash } from 'lucide-react';
 import Link from 'next/link';
 import { Badge } from '@/components/ui/badge';
-import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
 import { SLACK_BRAND_COLOR } from '@/constants/theme';
 import type { ConversationStats } from '@/lib/api/signoz-stats';
 import { formatDateAgo, formatDateTime } from '@/lib/utils/format-date';
@@ -62,18 +62,20 @@ export function ConversationListItem({ conversation, projectId }: ConversationLi
                     return (
                       <>
                         <span className="text-gray-400 dark:text-white/40">•</span>
-                        <Tooltip>
-                          <TooltipTrigger asChild>
-                            <span className="text-gray-400 dark:text-white/40 cursor-help">
-                              {formatDateAgo(isoString)}
-                            </span>
-                          </TooltipTrigger>
-                          <TooltipContent>
-                            <p className="text-xs">
-                              Started: {formatDateTime(isoString, { local: true })}
-                            </p>
-                          </TooltipContent>
-                        </Tooltip>
+                        <TooltipProvider>
+                          <Tooltip>
+                            <TooltipTrigger asChild>
+                              <span className="text-gray-400 dark:text-white/40 cursor-help">
+                                {formatDateAgo(isoString)}
+                              </span>
+                            </TooltipTrigger>
+                            <TooltipContent>
+                              <p className="text-xs">
+                                Started: {formatDateTime(isoString, { local: true })}
+                              </p>
+                            </TooltipContent>
+                          </Tooltip>
+                        </TooltipProvider>
                       </>
                     );
                   } catch (error) {
@@ -90,18 +92,20 @@ export function ConversationListItem({ conversation, projectId }: ConversationLi
           </div>
           <div className="flex items-center gap-2">
             {toolsUsed.length > 0 && (
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <Badge variant="primary" className="text-xs">
-                    {toolsUsed.length} tool{toolsUsed.length > 1 ? 's' : ''} used
-                  </Badge>
-                </TooltipTrigger>
-                <TooltipContent>
-                  <p className="text-xs font-mono text-muted-foreground">
-                    {toolsUsed.map((tool) => tool.name).join(', ')}
-                  </p>
-                </TooltipContent>
-              </Tooltip>
+              <TooltipProvider>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Badge variant="primary" className="text-xs">
+                      {toolsUsed.length} tool{toolsUsed.length > 1 ? 's' : ''} used
+                    </Badge>
+                  </TooltipTrigger>
+                  <TooltipContent>
+                    <p className="text-xs font-mono text-muted-foreground">
+                      {toolsUsed.map((tool) => tool.name).join(', ')}
+                    </p>
+                  </TooltipContent>
+                </Tooltip>
+              </TooltipProvider>
             )}
             {hasErrors && (
               <Badge variant="error" className="flex items-center gap-1">

--- a/agents-manage-ui/src/components/ui/sidebar.tsx
+++ b/agents-manage-ui/src/components/ui/sidebar.tsx
@@ -514,15 +514,17 @@ function SidebarMenuButton({
   }
 
   return (
-    <Tooltip>
-      <TooltipTrigger asChild>{button}</TooltipTrigger>
-      <TooltipContent
-        side="right"
-        align="center"
-        hidden={state !== 'collapsed' || isMobile}
-        {...tooltip}
-      />
-    </Tooltip>
+    <TooltipProvider>
+      <Tooltip>
+        <TooltipTrigger asChild>{button}</TooltipTrigger>
+        <TooltipContent
+          side="right"
+          align="center"
+          hidden={state !== 'collapsed' || isMobile}
+          {...tooltip}
+        />
+      </Tooltip>
+    </TooltipProvider>
   );
 }
 

--- a/agents-manage-ui/src/components/ui/tooltip.tsx
+++ b/agents-manage-ui/src/components/ui/tooltip.tsx
@@ -19,11 +19,7 @@ function TooltipProvider({
 }
 
 function Tooltip(props: React.ComponentProps<typeof TooltipPrimitive.Root>) {
-  return (
-    <TooltipProvider>
-      <TooltipPrimitive.Root data-slot="tooltip" {...props} />
-    </TooltipProvider>
-  );
+  return <TooltipPrimitive.Root data-slot="tooltip" {...props} />;
 }
 
 function TooltipTrigger(props: React.ComponentProps<typeof TooltipPrimitive.Trigger>) {

--- a/agents-manage-ui/src/features/work-apps/slack/components/agent-configuration-card/workspace-default-section.tsx
+++ b/agents-manage-ui/src/features/work-apps/slack/components/agent-configuration-card/workspace-default-section.tsx
@@ -13,7 +13,7 @@ import {
 } from '@/components/ui/command';
 import { Label } from '@/components/ui/label';
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
-import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
 import { cn } from '@/lib/utils';
 import { ChannelAccessPopover } from './channel-access-popover';
 import type { DefaultAgentConfig, SlackAgentOption } from './types';
@@ -83,19 +83,21 @@ export function WorkspaceDefaultSection({
               </Button>
             </PopoverTrigger>
             {defaultAgent && (
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <Button
-                    onClick={onRemoveDefaultAgent}
-                    variant="outline"
-                    aria-label="Remove default agent"
-                    type="button"
-                  >
-                    <X />
-                  </Button>
-                </TooltipTrigger>
-                <TooltipContent>Remove the default agent for this workspace.</TooltipContent>
-              </Tooltip>
+              <TooltipProvider>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Button
+                      onClick={onRemoveDefaultAgent}
+                      variant="outline"
+                      aria-label="Remove default agent"
+                      type="button"
+                    >
+                      <X />
+                    </Button>
+                  </TooltipTrigger>
+                  <TooltipContent>Remove the default agent for this workspace.</TooltipContent>
+                </Tooltip>
+              </TooltipProvider>
             )}
           </ButtonGroup>
           <PopoverContent className="w-full p-0" align="start">

--- a/agents-manage-ui/src/features/work-apps/slack/components/workspace-hero.tsx
+++ b/agents-manage-ui/src/features/work-apps/slack/components/workspace-hero.tsx
@@ -50,7 +50,7 @@ import {
 } from '@/components/ui/select';
 import { Separator } from '@/components/ui/separator';
 import { Skeleton } from '@/components/ui/skeleton';
-import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
 import { WorkAppIcon } from '../../common/components/work-app-icon';
 import { slackApi } from '../api/slack-api';
 import { useSlack } from '../context/slack-provider';
@@ -228,53 +228,59 @@ export function WorkspaceHero() {
                     </a>
                   </div>
                   <div className="flex items-center gap-2">
-                    <Tooltip>
-                      <TooltipTrigger asChild>
-                        <Badge
-                          variant={
-                            health.healthy ? 'success' : health.checking ? 'warning' : 'error'
-                          }
-                        >
-                          {health.checking && <Loader2 className="h-3 w-3 mr-1 animate-spin" />}
-                          {health.checking ? 'Checking...' : health.healthy ? 'Healthy' : 'Issue'}
-                        </Badge>
-                      </TooltipTrigger>
-                      <TooltipContent>
-                        {health.healthy ? (
-                          <p>Bot is connected and working</p>
-                        ) : (
-                          <p>{health.error || 'Bot connection issue'}</p>
-                        )}
-                      </TooltipContent>
-                    </Tooltip>
+                    <TooltipProvider>
+                      <Tooltip>
+                        <TooltipTrigger asChild>
+                          <Badge
+                            variant={
+                              health.healthy ? 'success' : health.checking ? 'warning' : 'error'
+                            }
+                          >
+                            {health.checking && <Loader2 className="h-3 w-3 mr-1 animate-spin" />}
+                            {health.checking ? 'Checking...' : health.healthy ? 'Healthy' : 'Issue'}
+                          </Badge>
+                        </TooltipTrigger>
+                        <TooltipContent>
+                          {health.healthy ? (
+                            <p>Bot is connected and working</p>
+                          ) : (
+                            <p>{health.error || 'Bot connection issue'}</p>
+                          )}
+                        </TooltipContent>
+                      </Tooltip>
+                    </TooltipProvider>
                     {workspace.hasDefaultAgent ? (
-                      <Tooltip>
-                        <TooltipTrigger asChild>
-                          <Badge variant="code" className="text-xs">
-                            {workspace.defaultAgentName}
-                          </Badge>
-                        </TooltipTrigger>
-                        <TooltipContent>
-                          <p>
-                            The default agent for all <code>@Inkeep</code> mentions and{' '}
-                            <code>/inkeep</code> commands in {workspace.teamName}
-                          </p>
-                        </TooltipContent>
-                      </Tooltip>
+                      <TooltipProvider>
+                        <Tooltip>
+                          <TooltipTrigger asChild>
+                            <Badge variant="code" className="text-xs">
+                              {workspace.defaultAgentName}
+                            </Badge>
+                          </TooltipTrigger>
+                          <TooltipContent>
+                            <p>
+                              The default agent for all <code>@Inkeep</code> mentions and{' '}
+                              <code>/inkeep</code> commands in {workspace.teamName}
+                            </p>
+                          </TooltipContent>
+                        </Tooltip>
+                      </TooltipProvider>
                     ) : (
-                      <Tooltip>
-                        <TooltipTrigger asChild>
-                          <Badge variant="warning" className="text-xs">
-                            No default agent
-                          </Badge>
-                        </TooltipTrigger>
-                        <TooltipContent>
-                          <p>
-                            Channels without a dedicated agent won&apos;t respond to{' '}
-                            <code>@Inkeep</code> mentions or <code>/inkeep</code> commands
-                          </p>
-                        </TooltipContent>
-                      </Tooltip>
+                      <TooltipProvider>
+                        <Tooltip>
+                          <TooltipTrigger asChild>
+                            <Badge variant="warning" className="text-xs">
+                              No default agent
+                            </Badge>
+                          </TooltipTrigger>
+                          <TooltipContent>
+                            <p>
+                              Channels without a dedicated agent won&apos;t respond to{' '}
+                              <code>@Inkeep</code> mentions or <code>/inkeep</code> commands
+                            </p>
+                          </TooltipContent>
+                        </Tooltip>
+                      </TooltipProvider>
                     )}
                   </div>
                 </div>


### PR DESCRIPTION
Fixes #2786 

TooltipProvider was being mounted at the root level inside SidebarProvider, wrapping the entire app. Moved it to each individual Tooltip usage following the official shadcn/ui pattern. This avoids a single global provider re-rendering unnecessarily and aligns with the shadcn component guidelines.