### PR TITLE
Promote playground app startup logs from DEBUG to INFO

### DIFF
--- a/.changeset/poised-harlequin-beaver.md
+++ b/.changeset/poised-harlequin-beaver.md
@@ -1,0 +1,5 @@
+---
+"@inkeep/agents-api": patch
+---
+
+Improve playground app startup logging for production observability

--- a/agents-api/src/startup/playground-app.ts
+++ b/agents-api/src/startup/playground-app.ts
@@ -8,7 +8,7 @@ const logger = getLogger('playground-app');
 export async function ensurePlaygroundAppKey(): Promise<void> {
   const publicKeyB64 = env.INKEEP_AGENTS_TEMP_JWT_PUBLIC_KEY;
   if (!publicKeyB64) {
-    logger.debug(
+    logger.info(
       {},
       'INKEEP_AGENTS_TEMP_JWT_PUBLIC_KEY not set, skipping playground key registration'
     );
@@ -16,9 +16,11 @@ export async function ensurePlaygroundAppKey(): Promise<void> {
   }
 
   const appId = env.INKEEP_PLAYGROUND_APP_ID || 'app_playground';
+  logger.info({ appId }, 'Registering playground app public key');
+
   const app = await getAppById(runDbClient)(appId);
   if (!app) {
-    logger.debug({ appId }, 'Playground app not found, skipping key registration');
+    logger.info({ appId }, 'Playground app not found, skipping key registration');
     return;
   }
 
@@ -39,7 +41,7 @@ export async function ensurePlaygroundAppKey(): Promise<void> {
   }>;
 
   if (existingKeys.some((k) => k.kid === kid)) {
-    logger.debug({ appId, kid }, 'Playground key already registered');
+    logger.info({ appId, kid }, 'Playground key already registered');
     return;
   }
 


### PR DESCRIPTION
## Summary
- Promotes all skip-path logs in `ensurePlaygroundAppKey()` from DEBUG to INFO level so every code path is observable in production without debug logging enabled
- Adds a "Registering playground app public key" log at the start of the registration attempt
- Addresses a production debugging gap where empty `publicKeys` on the playground app couldn't be diagnosed from INFO-level logs

## Test plan
- [ ] Deploy and verify one of the following INFO logs appears on startup:
  - `INKEEP_AGENTS_TEMP_JWT_PUBLIC_KEY not set, skipping playground key registration`
  - `Registering playground app public key` followed by one of:
    - `Playground app not found, skipping key registration`
    - `Playground key already registered`
    - `Registered playground public key`

🤖 Generated with [Claude Code](https://claude.com/claude-code)