### PR TITLE
fix(ci): use GitHub App token for auto-commits to trigger CI

### DIFF
--- a/.github/workflows/auto-format.yml
+++ b/.github/workflows/auto-format.yml
@@ -56,6 +56,17 @@ jobs:
         run: |
           echo "::notice::Checkout failed — branch was likely deleted (PR merged). Skipping."
 
+      # Generate a GitHub App token so that auto-commits trigger downstream CI
+      # workflows. The default GITHUB_TOKEN's commits are ignored by GitHub to
+      # prevent infinite loops.
+      - name: Generate GitHub App Token
+        id: app-token
+        if: steps.pr-check.outputs.skip != 'true' && steps.checkout.outcome == 'success'
+        uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1
+        with:
+          app-id: ${{ secrets.INTERNAL_CI_APP_ID }}
+          private-key: ${{ secrets.INTERNAL_CI_APP_PRIVATE_KEY }}
+
       - name: Setup Node.js
         if: steps.pr-check.outputs.skip != 'true' && steps.checkout.outcome == 'success'
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
@@ -112,11 +123,18 @@ jobs:
         if: steps.pr-check.outputs.skip != 'true' && steps.checkout.outcome == 'success' && steps.changes.outputs.has_changes == 'true'
         env:
           PUSH_REF: ${{ github.event_name == 'pull_request' && github.head_ref || github.ref_name }}
+          APP_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add -u
           git commit -m "style: auto-format with biome"
+
+          # Use GitHub App token so the push triggers downstream CI workflows.
+          # The default GITHUB_TOKEN's commits are ignored by GitHub to prevent loops.
+          if [ -n "$APP_TOKEN" ]; then
+            git remote set-url origin "https://x-access-token:${APP_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+          fi
 
           # Verify remote branch still exists before pushing
           if ! git ls-remote --exit-code --heads origin "$PUSH_REF" > /dev/null 2>&1; then

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,6 +107,20 @@ jobs:
         env:
           HUSKY: 0
 
+      # Generate a GitHub App token so that auto-commits trigger downstream CI
+      # workflows. The default GITHUB_TOKEN's commits are ignored by GitHub to
+      # prevent infinite loops.
+      - name: Generate GitHub App Token
+        id: app-token
+        if: |
+          steps.changeset-check.outputs.is_changeset != 'true' &&
+          github.event_name == 'pull_request' &&
+          github.event.pull_request.head.repo.full_name == github.repository
+        uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1
+        with:
+          app-id: ${{ secrets.INTERNAL_CI_APP_ID }}
+          private-key: ${{ secrets.INTERNAL_CI_APP_PRIVATE_KEY }}
+
       # Auto-update OpenAPI snapshot on PRs (skip fork PRs since GITHUB_TOKEN is read-only)
       # Gate: only run when files that affect the OpenAPI spec changed.
       # These paths mirror the pre-commit hook in package.json lint-staged config.
@@ -143,7 +157,14 @@ jobs:
       - name: Commit OpenAPI snapshot if changed
         if: steps.changeset-check.outputs.is_changeset != 'true' && steps.openapi-changes.outputs.changed == 'true'
         run: |
+          # Use GitHub App token so the push triggers downstream CI workflows.
+          # The default GITHUB_TOKEN's commits are ignored by GitHub to prevent loops.
+          if [ -n "$APP_TOKEN" ]; then
+            git remote set-url origin "https://x-access-token:${APP_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+          fi
           scripts/ci-commit-and-push.sh agents-api/__snapshots__/openapi.json "chore: update OpenAPI snapshot" "${{ github.head_ref }}"
+        env:
+          APP_TOKEN: ${{ steps.app-token.outputs.token }}
 
       - name: Install Playwright
         if: steps.changeset-check.outputs.is_changeset != 'true'


### PR DESCRIPTION
## Summary
- Bot commits pushed with the default `GITHUB_TOKEN` (`github-actions[bot]`) don't trigger workflow runs — a deliberate GitHub protection against infinite loops
- This caused PR #2866 to be stuck for 30 minutes waiting on required CI/Cypress checks that never ran after an OpenAPI snapshot auto-commit
- Now uses the `inkeep-internal-ci` GitHub App token (already used in `release.yml`) for both OpenAPI snapshot commits (`ci.yml`) and auto-format commits (`auto-format.yml`)
- App token commits are attributed to `inkeep-internal-ci[bot]` which triggers downstream workflow runs

## Test plan
- [ ] Push a PR that modifies OpenAPI-affecting files → verify the auto-committed snapshot update triggers CI/Cypress runs on the new HEAD
- [ ] Push a PR with formatting issues → verify the auto-format commit triggers CI runs on the new HEAD
- [ ] Verify `INTERNAL_CI_APP_ID` and `INTERNAL_CI_APP_PRIVATE_KEY` secrets are accessible to both workflows

🤖 Generated with [Claude Code](https://claude.com/claude-code)