### PR TITLE
Fix changeset package name breaking version action

### DIFF
--- a/.changeset/soft-cobras-fix.md
+++ b/.changeset/soft-cobras-fix.md
@@ -1,5 +1,5 @@
 ---
-'agents-api': patch
+'@inkeep/agents-api': patch
 ---
 
 Add inline text document attachments to the run chat APIs for `text/plain`, `text/markdown`, `text/html`, `text/csv`, `text/x-log`, and `application/json` while keeping remote URLs limited to PDFs. Persist text attachments as blob-backed file parts and replay them into model input as XML-tagged text blocks.


### PR DESCRIPTION
## Summary
- Fixes `soft-cobras-fix.md` changeset: `'agents-api'` → `'@inkeep/agents-api'`
- The short name isn't recognized as a workspace package, causing the `changesets version` CI action to fail with: `Found changeset soft-cobras-fix for package agents-api which is not in the workspace`

## Test plan
- [ ] Changesets version action passes in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)