### PR TITLE
fix(ci): skip CI when PR only changes .changeset/ files

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,23 @@ jobs:
             fi
           fi
 
+          # Check if PR only contains .changeset/ file changes
+          if [ "$IS_CHANGESET" = "false" ] && [ "$GITHUB_EVENT_NAME" != "push" ]; then
+            if [ "$GITHUB_EVENT_NAME" = "pull_request" ] && [ -n "$PR_NUMBER" ]; then
+              CHANGED_FILES=$(gh pr diff "$PR_NUMBER" --name-only --repo "$GITHUB_REPOSITORY" 2>/dev/null || echo "")
+            elif [ "$GITHUB_EVENT_NAME" = "merge_group" ] && [ -n "$PR_NUM" ]; then
+              CHANGED_FILES=$(gh pr diff "$PR_NUM" --name-only --repo "$GITHUB_REPOSITORY" 2>/dev/null || echo "")
+            fi
+
+            if [ -n "$CHANGED_FILES" ]; then
+              NON_CHANGESET=$(echo "$CHANGED_FILES" | grep -v '^\.changeset/' || true)
+              if [ -z "$NON_CHANGESET" ]; then
+                IS_CHANGESET=true
+                echo "Only .changeset/ files changed — skipping CI checks"
+              fi
+            fi
+          fi
+
           echo "is_changeset=$IS_CHANGESET" >> $GITHUB_OUTPUT
           if [ "$IS_CHANGESET" = "true" ]; then
             echo "Changeset PR — skipping CI checks"
@@ -67,6 +84,7 @@ jobs:
           GITHUB_EVENT_NAME: ${{ github.event_name }}
           MERGE_GROUP_HEAD_REF: ${{ github.event.merge_group.head_ref }}
           GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
 
       - name: Checkout code
         if: steps.changeset-check.outputs.is_changeset != 'true'
@@ -341,6 +359,23 @@ jobs:
             fi
           fi
 
+          # Check if PR only contains .changeset/ file changes
+          if [ "$IS_CHANGESET" = "false" ] && [ "$GITHUB_EVENT_NAME" != "push" ]; then
+            if [ "$GITHUB_EVENT_NAME" = "pull_request" ] && [ -n "$PR_NUMBER" ]; then
+              CHANGED_FILES=$(gh pr diff "$PR_NUMBER" --name-only --repo "$GITHUB_REPOSITORY" 2>/dev/null || echo "")
+            elif [ "$GITHUB_EVENT_NAME" = "merge_group" ] && [ -n "$PR_NUM" ]; then
+              CHANGED_FILES=$(gh pr diff "$PR_NUM" --name-only --repo "$GITHUB_REPOSITORY" 2>/dev/null || echo "")
+            fi
+
+            if [ -n "$CHANGED_FILES" ]; then
+              NON_CHANGESET=$(echo "$CHANGED_FILES" | grep -v '^\.changeset/' || true)
+              if [ -z "$NON_CHANGESET" ]; then
+                IS_CHANGESET=true
+                echo "Only .changeset/ files changed — skipping E2E tests"
+              fi
+            fi
+          fi
+
           echo "is_changeset=$IS_CHANGESET" >> $GITHUB_OUTPUT
           if [ "$IS_CHANGESET" = "true" ]; then
             echo "Changeset PR — skipping E2E tests"
@@ -350,6 +385,7 @@ jobs:
           GITHUB_EVENT_NAME: ${{ github.event_name }}
           MERGE_GROUP_HEAD_REF: ${{ github.event.merge_group.head_ref }}
           GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
 
       - name: Checkout code
         if: steps.changeset-check.outputs.is_changeset != 'true'

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -76,6 +76,23 @@ jobs:
             fi
           fi
 
+          # Check if PR only contains .changeset/ file changes
+          if [ "$IS_CHANGESET" = "false" ] && [ "$GITHUB_EVENT_NAME" != "push" ]; then
+            if [ "$GITHUB_EVENT_NAME" = "pull_request" ] && [ -n "$PR_NUMBER" ]; then
+              CHANGED_FILES=$(gh pr diff "$PR_NUMBER" --name-only --repo "$GITHUB_REPOSITORY" 2>/dev/null || echo "")
+            elif [ "$GITHUB_EVENT_NAME" = "merge_group" ] && [ -n "$PR_NUM" ]; then
+              CHANGED_FILES=$(gh pr diff "$PR_NUM" --name-only --repo "$GITHUB_REPOSITORY" 2>/dev/null || echo "")
+            fi
+
+            if [ -n "$CHANGED_FILES" ]; then
+              NON_CHANGESET=$(echo "$CHANGED_FILES" | grep -v '^\.changeset/' || true)
+              if [ -z "$NON_CHANGESET" ]; then
+                IS_CHANGESET=true
+                echo "Only .changeset/ files changed — skipping Cypress tests"
+              fi
+            fi
+          fi
+
           echo "is_changeset=$IS_CHANGESET" >> $GITHUB_OUTPUT
           if [ "$IS_CHANGESET" = "true" ]; then
             echo "Changeset PR — skipping Cypress tests"
@@ -85,6 +102,7 @@ jobs:
           GITHUB_EVENT_NAME: ${{ github.event_name }}
           MERGE_GROUP_HEAD_REF: ${{ github.event.merge_group.head_ref }}
           GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
 
       - name: Checkout code
         if: steps.changeset-check.outputs.is_changeset != 'true'


### PR DESCRIPTION
## Summary
- Extends changeset detection in `ci.yml` and `cypress.yml` to also skip CI when a PR's **only** changes are files in `.changeset/` (changelog entries, config)
- Previously, only the automated `changeset-release/main` bot PR was detected — now any PR with changeset-only changes skips the expensive CI pipeline (32GB runners, databases, Playwright, Cypress)
- Uses `gh pr diff --name-only` to check changed files; fail-safe — if the API call fails, CI runs normally

## Test plan
- [ ] PR with only `.changeset/*.md` files → CI skipped
- [ ] PR with `.changeset/*.md` + code changes → CI runs
- [ ] `changeset-release/main` bot PR → CI skipped (existing behavior preserved)
- [ ] Push to main → CI always runs
- [ ] Merge group with changeset-only PR → CI skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)