### PR TITLE
Add Doltgres DDL constraints to data-model-changes skill

### DIFF
--- a/.agents/skills/data-model-changes/SKILL.md
+++ b/.agents/skills/data-model-changes/SKILL.md
@@ -28,7 +28,7 @@ The framework uses **two separate PostgreSQL databases**:
 
 *Last confirmed on Doltgres v0.55.5 (pinned in `docker-compose.yml`; note that `docker-compose.dbs.yml` and `docker-compose.isolated.yml` use `:latest`) + drizzle-kit 0.31.8 (resolved from `^0.31.6` in `packages/agents-core/package.json`). Re-verify if either version changes.*
 
-Doltgres does not support the full PostgreSQL DDL surface. drizzle-kit generates standard PostgreSQL SQL, which means certain Drizzle schema patterns produce migrations that fail on Doltgres. These constraints apply to schemas targeting Doltgres (in this codebase: `manage-schema.ts` and its migrations in `drizzle/manage/`). Schemas targeting standard PostgreSQL (`runtime-schema.ts`) are unconstrained.
+drizzle-kit generates standard PostgreSQL SQL that may be incompatible with Doltgres. These constraints apply to Doltgres-targeted schemas (in this codebase: `manage-schema.ts` and `drizzle/manage/`). Standard PostgreSQL schemas (`runtime-schema.ts`) are unconstrained.
 
 | Don't use in Doltgres-targeted schemas | Why (Doltgres error) | Use instead |
 |---|---|---|

--- a/.agents/skills/data-model-changes/SKILL.md
+++ b/.agents/skills/data-model-changes/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: data-model-changes
-description: "Guide for making changes to the database schema, validation, types, and data access layer. Use when adding tables, columns, relations, or modifying the data model. Triggers on: add table, add column, modify schema, database change, data model, new entity, schema migration."
+description: "Guide for making changes to the database schema, validation, types, and data access layer. Includes Doltgres DDL compatibility constraints for schemas targeting Doltgres (manage database). Use when adding tables, columns, relations, or modifying the data model. Triggers on: add table, add column, modify schema, database change, data model, new entity, schema migration, manage-schema.ts, runtime-schema.ts, Doltgres, Doltgres compatibility, Doltgres migration, manage database, manage DB, drizzle migration, migration failure, migration error, pgEnum, enum type, DROP TABLE, CASCADE, ALTER TYPE, drizzle-kit generate, pnpm db:generate."
 ---
 
 # Data Model Change Guide
@@ -21,6 +21,41 @@ The framework uses **two separate PostgreSQL databases**:
 **Key Distinction:**
 - **Manage DB**: Configuration that changes infrequently (agent definitions, tool configs). Supports Dolt versioning.
 - **Runtime DB**: High-frequency transactional data (conversations, messages). No cross-DB foreign keys to manage tables.
+
+---
+
+## Doltgres DDL Constraints
+
+*Last confirmed on Doltgres v0.55.5 (pinned in `docker-compose.yml`) + drizzle-kit 0.31.8 (resolved from `^0.31.6` in `packages/agents-core/package.json`). Re-verify if either version changes.*
+
+Doltgres does not support the full PostgreSQL DDL surface. drizzle-kit generates standard PostgreSQL SQL, which means certain Drizzle schema patterns produce migrations that fail on Doltgres. These constraints apply to schemas targeting Doltgres (in this codebase: `manage-schema.ts` and its migrations in `drizzle/manage/`). Schemas targeting standard PostgreSQL (`runtime-schema.ts`) are unconstrained.
+
+| Don't use in Doltgres-targeted schemas | Why (Doltgres error) | Use instead |
+|---|---|---|
+| `pgEnum()` | `ALTER TYPE is not yet supported` — values can never be changed once created. All ALTER TYPE operations fail (ADD VALUE, DROP VALUE, RENAME, SET SCHEMA). | `varchar` + Zod validation (see example below) |
+| `pgSchema()` | `ALTER TABLE SET SCHEMA is not yet supported` — objects can never be moved between schemas. `DROP SCHEMA CASCADE` also fails. | Stay in `public` schema. Use table name prefixes for grouping (e.g., `eval_`, `config_`). |
+| `serial()` / `pgSequence()` | Column creation works, but the implicit sequence can never be tuned — `INCREMENT BY is not yet supported` (and RESTART, MINVALUE, MAXVALUE, CACHE, CYCLE). Only OWNED BY works. | Application-generated varchar IDs (nanoid) |
+| `index().where(sql`...`)` | `WHERE is not yet supported` | Full btree index; filter at query time |
+| `index().concurrently()` | `concurrent index creation is not yet supported` | Plain `CREATE INDEX` — config data has low write volume, the brief lock is fine |
+| `index().using('gin'/'gist'/'hash')` | `index method X is not yet supported` — only btree indexes work | btree on scalar columns; filter JSONB in application code |
+| `index().on(sql`lower(...)`)` | `expression index attribute is not yet supported` | Normalize the value at write time in the data access function; index the stored column directly |
+| `col.desc()` on index | drizzle-kit silently couples `.desc()` with NULLS LAST in its output → `NULLS LAST for indexes is not yet supported`. The error mentions NULLS LAST even though you only wrote `.desc()`. | Omit `.desc()`; handle ordering in `ORDER BY` clauses |
+
+### Instead of pgEnum: varchar + Zod validation
+
+The manage schema already follows this pattern throughout:
+
+```typescript
+// In manage-schema.ts:
+status: varchar('status', { length: 50 }).notNull().default('pending'),
+
+// In validation/schemas.ts:
+const StatusEnum = z.enum(['pending', 'running', 'completed', 'failed', 'cancelled']);
+```
+
+Adding a new allowed value is a code change (update the Zod enum), not a migration — no DDL needed.
+
+If you inherited an existing `pgEnum` column, escape it with a multi-step data migration: (1) add a varchar column, (2) backfill from the enum column via `::text` cast, (3) set NOT NULL on the new column, (4) set the default value, (5) drop the old enum column, (6) rename the new column, (7) drop the unused enum type. Each step works individually on Doltgres (E2E verified).
 
 ---
 
@@ -340,16 +375,43 @@ Location: `packages/agents-core/src/data-access/index.ts`
 export * from './manage/myNewTable';
 ```
 
-### Step 7: Generate and Apply Migration
+### Step 7: Generate, Review, and Apply Migration
 
 ```bash
-# Generate migration SQL
 pnpm db:generate
+```
 
-# Review generated SQL in drizzle/manage/ or drizzle/runtime/
-# Make minor edits if needed (ONLY to newly generated files)
+**For Doltgres-targeted migrations (`drizzle/manage/`) — review generated SQL before applying:**
 
-# Apply migration
+| Pattern in generated SQL | Doltgres error | How to fix |
+|---|---|---|
+| `DROP TABLE ... CASCADE` | `CASCADE is not yet supported` | Remove `CASCADE`. Drop dependent objects (child tables, FKs) explicitly in FK-dependency order before the parent table. |
+| `ALTER COLUMN ... SET DATA TYPE ... USING` | `ALTER TABLE with USING is not supported yet` | Replace with multi-step: (1) add new column with target type, (2) `UPDATE` to backfill with cast, (3) drop old column, (4) rename new column. |
+
+drizzle-kit 0.31.x hardcodes `CASCADE` on every `DROP TABLE` — there is no configuration to disable it. You must edit the generated SQL manually (precedent: PR #2929).
+
+Note: `DROP INDEX` is broken on Doltgres 0.55.5 (returns `table not found` regardless). If a migration drops a table and its indexes, remove the `DROP INDEX` statements — `DROP TABLE` implicitly removes associated indexes.
+
+**Quick review** (run against newly generated manage migration):
+
+```bash
+NEW_MIGRATION=$(ls -t packages/agents-core/drizzle/manage/*.sql | head -1)
+
+# Tier 1 — blockers (must fix before applying):
+grep -n -i 'DROP.*CASCADE\|ALTER TYPE\|CONCURRENTLY\|USING gin\|USING gist\|USING hash\|USING brin\|SET SCHEMA\|ADD VALUE\|NULLS' "$NEW_MIGRATION"
+
+# Tier 2 — needs review (may be fine, verify):
+grep -n 'ON CONFLICT\|SET DATA TYPE' "$NEW_MIGRATION"
+grep -n 'CREATE.*INDEX.*WHERE' "$NEW_MIGRATION"
+```
+
+Tier 1 matches must be fixed. Tier 2: `SET DATA TYPE` is safe for simple widening (e.g., `varchar(64)` → `varchar(256)`) but dangerous with USING; `ON CONFLICT DO NOTHING` works but `DO UPDATE` may not.
+
+drizzle-kit v1 beta (1.0.0-beta.19) reportedly removes CASCADE hardcoding. This repo uses stable 0.31.8.
+
+**For all migrations** (manage and runtime): review the generated SQL in `drizzle/manage/` or `drizzle/runtime/`. Make minor edits if needed (ONLY to newly generated files, NEVER to previously applied migrations).
+
+```bash
 pnpm db:migrate
 ```
 
@@ -389,11 +451,15 @@ registerFieldSchemas(existingSchema, {
 });
 ```
 
-### Step 3: Generate and Apply Migration
+### Step 3: Generate, Review, and Apply Migration
 
 ```bash
 pnpm db:generate
-# Review the generated migration SQL
+```
+
+**For Doltgres-targeted migrations (`drizzle/manage/`):** Review the generated SQL for Doltgres-incompatible patterns before applying (see the review table and grep checklist in "Adding a New Table" → Step 7).
+
+```bash
 pnpm db:migrate
 ```
 
@@ -489,3 +555,8 @@ Before completing any data model change, verify:
 - [ ] Migration generated and reviewed
 - [ ] Changeset created
 - [ ] Tests written for new data access functions
+- [ ] **Doltgres schemas only:** No `pgEnum()` used (use varchar + Zod instead)
+- [ ] **Doltgres schemas only:** No `pgSchema()` used (everything in `public`)
+- [ ] **Doltgres schemas only:** No `serial()` / `pgSequence()` used (use application-generated varchar IDs)
+- [ ] **Doltgres schemas only:** Generated migration SQL reviewed for incompatible patterns (see Step 7 review checklist)
+- [ ] **Doltgres schemas only:** Indexes use basic btree only (no `.concurrently()`, `.where()`, `.using('gin')`, `.desc()`, expressions)

--- a/.agents/skills/data-model-changes/SKILL.md
+++ b/.agents/skills/data-model-changes/SKILL.md
@@ -26,7 +26,7 @@ The framework uses **two separate PostgreSQL databases**:
 
 ## Doltgres DDL Constraints
 
-*Last confirmed on Doltgres v0.55.5 (pinned in `docker-compose.yml`) + drizzle-kit 0.31.8 (resolved from `^0.31.6` in `packages/agents-core/package.json`). Re-verify if either version changes.*
+*Last confirmed on Doltgres v0.55.5 (pinned in `docker-compose.yml`; note that `docker-compose.dbs.yml` and `docker-compose.isolated.yml` use `:latest`) + drizzle-kit 0.31.8 (resolved from `^0.31.6` in `packages/agents-core/package.json`). Re-verify if either version changes.*
 
 Doltgres does not support the full PostgreSQL DDL surface. drizzle-kit generates standard PostgreSQL SQL, which means certain Drizzle schema patterns produce migrations that fail on Doltgres. These constraints apply to schemas targeting Doltgres (in this codebase: `manage-schema.ts` and its migrations in `drizzle/manage/`). Schemas targeting standard PostgreSQL (`runtime-schema.ts`) are unconstrained.
 
@@ -35,22 +35,22 @@ Doltgres does not support the full PostgreSQL DDL surface. drizzle-kit generates
 | `pgEnum()` | `ALTER TYPE is not yet supported` — values can never be changed once created. All ALTER TYPE operations fail (ADD VALUE, DROP VALUE, RENAME, SET SCHEMA). | `varchar` + Zod validation (see example below) |
 | `pgSchema()` | `ALTER TABLE SET SCHEMA is not yet supported` — objects can never be moved between schemas. `DROP SCHEMA CASCADE` also fails. | Stay in `public` schema. Use table name prefixes for grouping (e.g., `eval_`, `config_`). |
 | `serial()` / `pgSequence()` | Column creation works, but the implicit sequence can never be tuned — `INCREMENT BY is not yet supported` (and RESTART, MINVALUE, MAXVALUE, CACHE, CYCLE). Only OWNED BY works. | Application-generated varchar IDs (nanoid) |
-| `index().where(sql`...`)` | `WHERE is not yet supported` | Full btree index; filter at query time |
+| ``index().where(sql`...`)`` | `WHERE is not yet supported` | Full btree index; filter at query time |
 | `index().concurrently()` | `concurrent index creation is not yet supported` | Plain `CREATE INDEX` — config data has low write volume, the brief lock is fine |
 | `index().using('gin'/'gist'/'hash')` | `index method X is not yet supported` — only btree indexes work | btree on scalar columns; filter JSONB in application code |
-| `index().on(sql`lower(...)`)` | `expression index attribute is not yet supported` | Normalize the value at write time in the data access function; index the stored column directly |
+| ``index().on(sql`lower(...)`)`` | `expression index attribute is not yet supported` | Normalize the value at write time in the data access function; index the stored column directly |
 | `col.desc()` on index | drizzle-kit silently couples `.desc()` with NULLS LAST in its output → `NULLS LAST for indexes is not yet supported`. The error mentions NULLS LAST even though you only wrote `.desc()`. | Omit `.desc()`; handle ordering in `ORDER BY` clauses |
 
 ### Instead of pgEnum: varchar + Zod validation
 
-The manage schema already follows this pattern throughout:
+The manage schema already follows this pattern — for example:
 
 ```typescript
 // In manage-schema.ts:
-status: varchar('status', { length: 50 }).notNull().default('pending'),
+credentialScope: varchar('credential_scope', { length: 50 }).notNull().default('project'), // 'project' | 'user'
 
-// In validation/schemas.ts:
-const StatusEnum = z.enum(['pending', 'running', 'completed', 'failed', 'cancelled']);
+// Validated at the application layer via Zod:
+const CredentialScopeEnum = z.enum(['project', 'user']);
 ```
 
 Adding a new allowed value is a code change (update the Zod enum), not a migration — no DDL needed.
@@ -388,7 +388,7 @@ pnpm db:generate
 | `DROP TABLE ... CASCADE` | `CASCADE is not yet supported` | Remove `CASCADE`. Drop dependent objects (child tables, FKs) explicitly in FK-dependency order before the parent table. |
 | `ALTER COLUMN ... SET DATA TYPE ... USING` | `ALTER TABLE with USING is not supported yet` | Replace with multi-step: (1) add new column with target type, (2) `UPDATE` to backfill with cast, (3) drop old column, (4) rename new column. |
 
-drizzle-kit 0.31.x hardcodes `CASCADE` on every `DROP TABLE` — there is no configuration to disable it. You must edit the generated SQL manually (precedent: PR #2929).
+drizzle-kit 0.31.x hardcodes `CASCADE` on every `DROP TABLE` — there is no configuration to disable it. You must edit the generated SQL manually (precedent: [PR #2929](https://github.com/inkeep/agents/pull/2929)).
 
 Note: `DROP INDEX` is broken on Doltgres 0.55.5 (returns `table not found` regardless). If a migration drops a table and its indexes, remove the `DROP INDEX` statements — `DROP TABLE` implicitly removes associated indexes.
 
@@ -407,7 +407,7 @@ grep -n 'CREATE.*INDEX.*WHERE' "$NEW_MIGRATION"
 
 Tier 1 matches must be fixed. Tier 2: `SET DATA TYPE` is safe for simple widening (e.g., `varchar(64)` → `varchar(256)`) but dangerous with USING; `ON CONFLICT DO NOTHING` works but `DO UPDATE` may not.
 
-drizzle-kit v1 beta (1.0.0-beta.19) reportedly removes CASCADE hardcoding. This repo uses stable 0.31.8.
+drizzle-kit v1 beta reportedly removes CASCADE hardcoding (PR #4439). This repo uses stable 0.31.8.
 
 **For all migrations** (manage and runtime): review the generated SQL in `drizzle/manage/` or `drizzle/runtime/`. Make minor edits if needed (ONLY to newly generated files, NEVER to previously applied migrations).
 


### PR DESCRIPTION
## Summary

Add Doltgres DDL compatibility constraints to the `data-model-changes` skill — the 8 Drizzle schema patterns that produce migrations incompatible with Doltgres, the 2 drizzle-kit outputs that require manual editing, and a grep-based review checklist.

One file changed: `.agents/skills/data-model-changes/SKILL.md` (+79, -8)

## What's in the skill update

### Section A: Prevention table (8 constraints)

| Constraint | Doltgres root cause | drizzle-kit trigger | E2E tested? |
|---|---|---|---|
| `pgEnum()` | [`alter_type.go:34`](https://github.com/dolthub/doltgresql/blob/main/server/ast/alter_type.go#L34) — `ALTER TYPE is not yet supported` | [`AlterTypeAddValueConvertor`](https://github.com/drizzle-team/drizzle-orm/blob/drizzle-kit%400.31.8/drizzle-kit/src/sqlgenerator.ts#L1420) | Yes — schema → `ALTER TYPE ADD VALUE` → hard error |
| `pgSchema()` | [`alter_table.go:96`](https://github.com/dolthub/doltgresql/blob/main/server/ast/alter_table.go#L96) — `ALTER TABLE SET SCHEMA is not yet supported` | [`PgAlterTableSetSchemaConvertor`](https://github.com/drizzle-team/drizzle-orm/blob/drizzle-kit%400.31.8/drizzle-kit/src/sqlgenerator.ts#L3679) | Yes — move table between schemas → hard error |
| `serial()`/`pgSequence()` | [`alter_sequence.go:105`](https://github.com/dolthub/doltgresql/blob/main/server/ast/alter_sequence.go#L105) — generic unsupported handler | [`AlterPgSequenceConvertor`](https://github.com/drizzle-team/drizzle-orm/blob/drizzle-kit%400.31.8/drizzle-kit/src/sqlgenerator.ts#L1355) | Yes — modify increment → hard error |
| `index().where()` | [`create_index.go:33`](https://github.com/dolthub/doltgresql/blob/main/server/ast/create_index.go#L33) — `WHERE is not yet supported` | [`CreatePgIndexConvertor`](https://github.com/drizzle-team/drizzle-orm/blob/drizzle-kit%400.31.8/drizzle-kit/src/sqlgenerator.ts#L3498) (pass-through) | Yes |
| `index().concurrently()` | [`create_index.go:27`](https://github.com/dolthub/doltgresql/blob/main/server/ast/create_index.go#L27) — `concurrent index creation is not yet supported` | Same convertor (conditional) | Yes |
| `index().using('gin'/'gist'/'hash')` | [`create_index.go:30`](https://github.com/dolthub/doltgresql/blob/main/server/ast/create_index.go#L30) — `index method %s is not yet supported` | Same convertor (pass-through) | Yes |
| `index().on(sql\`...\`)` | [`index_elem.go:32`](https://github.com/dolthub/doltgresql/blob/main/server/ast/index_elem.go#L32) — `expression index attribute is not yet supported` | Same convertor (pass-through) | Yes |
| `col.desc()` | [`index_elem.go:57`](https://github.com/dolthub/doltgresql/blob/main/server/ast/index_elem.go#L57) — `NULLS LAST for indexes is not yet supported` | Same convertor — `.desc()` silently emits `DESC NULLS LAST` | Yes |

### Section B: Migration review gate (Step 7 + Step 3)

| Hand-edit pattern | drizzle-kit source | Doltgres source | E2E tested? |
|---|---|---|---|
| `DROP TABLE ... CASCADE` | [`sqlgenerator.ts:1543`](https://github.com/drizzle-team/drizzle-orm/blob/drizzle-kit%400.31.8/drizzle-kit/src/sqlgenerator.ts#L1543) — unconditional CASCADE | [`drop_table.go:46`](https://github.com/dolthub/doltgresql/blob/main/server/ast/drop_table.go#L46) — `CASCADE is not yet supported` | Yes. Precedent: [PR #2929](https://github.com/inkeep/agents/pull/2929) ([generated](https://github.com/inkeep/agents/commit/3db7b394c4) → [manually removed](https://github.com/inkeep/agents/commit/aec413cf63)) |
| `ALTER COLUMN ... USING` | [`sqlgenerator.ts:1943`](https://github.com/drizzle-team/drizzle-orm/blob/drizzle-kit%400.31.8/drizzle-kit/src/sqlgenerator.ts#L1943) — branches 3-4 add USING | [`alter_table.go:379`](https://github.com/dolthub/doltgresql/blob/main/server/ast/alter_table.go#L379) — `ALTER TABLE with USING is not supported yet` | Yes. Workaround (add/backfill/drop/rename) also E2E verified — data intact. |

### Also added

- **Grep checklist** (Tier 1 blockers + Tier 2 needs-review) — validated against all 17 manage migrations, zero false positives
- **5 Doltgres-schema-only checklist items** in the final verification checklist
- **Expanded frontmatter triggers** for Doltgres-related routing

### Verification method

Every constraint tested end-to-end: Drizzle TypeScript schema → `npx drizzle-kit generate` (v0.31.8) → inspect SQL → execute against real Doltgres 0.55.5 Docker container. Both workarounds (multi-step type change, pgEnum→varchar escape) also E2E tested with data integrity checks.

## Test plan

- [x] All 8 prevention constraints E2E tested: real Drizzle schema → drizzle-kit 0.31.8 → real Doltgres 0.55.5
- [x] Both hand-edit patterns (CASCADE, USING) E2E tested through full chain
- [x] Both workarounds E2E tested (multi-step type change: 4 steps; pgEnum escape: 7 steps — data intact)
- [x] Grep checklist validated against all 17 manage migrations — zero false positives, zero false negatives
- [x] drizzle-kit source traced at tagged release ([`sqlgenerator.ts`](https://github.com/drizzle-team/drizzle-orm/blob/drizzle-kit%400.31.8/drizzle-kit/src/sqlgenerator.ts))
- [x] Doltgres source traced for all error messages ([`server/ast/`](https://github.com/dolthub/doltgresql/tree/main/server/ast))
- [x] [PR #2929](https://github.com/inkeep/agents/pull/2929) git archaeology confirms CASCADE manual-edit precedent
- [ ] CI passes
- [ ] Skill auto-loads when editing `manage-schema.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)