### PR TITLE
fix: handle silent schema sync failures in branch-scoped DB middleware

### DIFF
--- a/agents-api/src/middleware/branchScopedDb.ts
+++ b/agents-api/src/middleware/branchScopedDb.ts
@@ -104,22 +104,21 @@ export const branchScopedDbMiddleware = async (c: Context, next: Next) => {
         logger.info({ ref: resolvedRef.name, checkoutMs }, 'Slow checkoutBranch in branchScopedDb');
       }
 
-      // Retry schema sync if it was skipped due to lock contention
-      while (
-        checkoutResult.schemaSync.hadDifferences &&
-        !checkoutResult.schemaSync.performed &&
-        syncAttempts < MAX_SCHEMA_SYNC_RETRIES
-      ) {
+      // Retry schema sync only when skipped due to advisory lock contention.
+      // Other failure modes (merge conflicts, uncommitted changes) are not retryable.
+      while (checkoutResult.schemaSync.skippedDueToLock && syncAttempts < MAX_SCHEMA_SYNC_RETRIES) {
         syncAttempts++;
         logger.warn(
           {
             branch: resolvedRef.name,
-            error: checkoutResult.schemaSync.error,
+            reason: 'skipped due to lock contention',
             attempt: syncAttempts,
           },
           'Schema sync not performed, retrying'
         );
-        await new Promise((resolve) => setTimeout(resolve, 50 * syncAttempts));
+        await new Promise((resolve) =>
+          setTimeout(resolve, 50 * syncAttempts * (1 + Math.random() * 0.5))
+        );
         checkoutResult = await checkoutBranch(requestDb)({
           branchName: resolvedRef.name,
           syncSchema: true,

--- a/agents-api/src/middleware/branchScopedDb.ts
+++ b/agents-api/src/middleware/branchScopedDb.ts
@@ -1,4 +1,8 @@
-import type { AgentsManageDatabaseClient, ResolvedRef } from '@inkeep/agents-core';
+import type {
+  AgentsManageDatabaseClient,
+  CheckoutBranchResult,
+  ResolvedRef,
+} from '@inkeep/agents-core';
 import {
   checkoutBranch,
   doltAddAndCommit,
@@ -15,6 +19,8 @@ import manageDbClient from '../data/db/manageDbClient';
 import { getLogger } from '../logger';
 
 const logger = getLogger('branch-scoped-db');
+
+const MAX_SCHEMA_SYNC_RETRIES = 2;
 
 export function isProjectDeleteOperation(path: string, method: string): boolean {
   const projectDeletePattern = /^\/tenants\/[^/]+\/(?:projects|project-full)\/[^/]+\/?$/;
@@ -85,11 +91,51 @@ export const branchScopedDbMiddleware = async (c: Context, next: Next) => {
 
     if (resolvedRef.type === 'branch') {
       logger.debug({ branch: resolvedRef.name }, 'Checking out branch');
+      let checkoutResult: CheckoutBranchResult | undefined;
+      let syncAttempts = 0;
+
       const checkoutStart = Date.now();
-      await checkoutBranch(requestDb)({ branchName: resolvedRef.name, autoCommitPending: true });
+      checkoutResult = await checkoutBranch(requestDb)({
+        branchName: resolvedRef.name,
+        autoCommitPending: true,
+      });
       const checkoutMs = Date.now() - checkoutStart;
       if (checkoutMs > 5_000) {
         logger.info({ ref: resolvedRef.name, checkoutMs }, 'Slow checkoutBranch in branchScopedDb');
+      }
+
+      // Retry schema sync if it was skipped due to lock contention
+      while (
+        checkoutResult.schemaSync.hadDifferences &&
+        !checkoutResult.schemaSync.performed &&
+        syncAttempts < MAX_SCHEMA_SYNC_RETRIES
+      ) {
+        syncAttempts++;
+        logger.warn(
+          {
+            branch: resolvedRef.name,
+            error: checkoutResult.schemaSync.error,
+            attempt: syncAttempts,
+          },
+          'Schema sync not performed, retrying'
+        );
+        await new Promise((resolve) => setTimeout(resolve, 50 * syncAttempts));
+        checkoutResult = await checkoutBranch(requestDb)({
+          branchName: resolvedRef.name,
+          syncSchema: true,
+          autoCommitPending: true,
+        });
+      }
+
+      if (checkoutResult.schemaSync.hadDifferences && !checkoutResult.schemaSync.performed) {
+        logger.error(
+          {
+            branch: resolvedRef.name,
+            syncError: checkoutResult.schemaSync.error,
+            attempts: syncAttempts + 1,
+          },
+          'Schema sync failed after retries — queries may fail due to outdated schema'
+        );
       }
     } else {
       // For tags/commits, create temporary branch (needed for reads)

--- a/agents-api/src/middleware/errorHandler.ts
+++ b/agents-api/src/middleware/errorHandler.ts
@@ -97,7 +97,7 @@ function logServerError(
         ...getDatabaseErrorLogContext(err),
         message: errorMessage,
         stack: errorStack,
-        ...(cause && { dbError: cause }),
+        ...(cause && { errorCause: cause }),
         path,
         requestId,
       },
@@ -108,7 +108,7 @@ function logServerError(
       {
         ...getDatabaseErrorLogContext(err),
         message: errorMessage,
-        ...(cause && { dbError: cause }),
+        ...(cause && { errorCause: cause }),
         path,
         requestId,
         status,

--- a/agents-api/src/middleware/errorHandler.ts
+++ b/agents-api/src/middleware/errorHandler.ts
@@ -47,6 +47,37 @@ function formatZodValidationError(c: Context, zodIssues: ZodIssue[]) {
 }
 
 /**
+ * Serialize an error's cause chain into a loggable object.
+ * Native Error properties (message, stack, code) are non-enumerable so
+ * JSON.stringify produces "{}". This helper extracts them explicitly.
+ */
+function serializeCause(cause: unknown, depth = 0): Record<string, unknown> | undefined {
+  if (!cause || depth > 3) return undefined;
+  if (cause instanceof Error) {
+    return {
+      message: cause.message,
+      name: cause.name,
+      stack: cause.stack,
+      ...('code' in cause ? { code: (cause as any).code } : {}),
+      ...('severity' in cause ? { severity: (cause as any).severity } : {}),
+      ...('detail' in cause ? { detail: (cause as any).detail } : {}),
+      ...('hint' in cause ? { hint: (cause as any).hint } : {}),
+      ...(cause.cause ? { cause: serializeCause(cause.cause, depth + 1) } : {}),
+    };
+  }
+  if (typeof cause === 'object') {
+    const obj = cause as Record<string, unknown>;
+    return {
+      ...(obj.message != null ? { message: obj.message } : {}),
+      ...(obj.code != null ? { code: obj.code } : {}),
+      ...(obj.severity != null ? { severity: obj.severity } : {}),
+      ...(obj.detail != null ? { detail: obj.detail } : {}),
+    };
+  }
+  return { value: String(cause) };
+}
+
+/**
  * Log server errors with appropriate context
  */
 function logServerError(
@@ -56,15 +87,17 @@ function logServerError(
   status: number,
   isExpectedError: boolean
 ) {
+  const errorMessage = err instanceof Error ? err.message : String(err);
+  const errorStack = err instanceof Error ? err.stack : undefined;
+  const cause = err instanceof Error ? serializeCause(err.cause) : undefined;
+
   if (!isExpectedError) {
-    const errorMessage = err instanceof Error ? err.message : String(err);
-    const errorStack = err instanceof Error ? err.stack : undefined;
     logger.error(
       {
-        error: err,
         ...getDatabaseErrorLogContext(err),
         message: errorMessage,
         stack: errorStack,
+        ...(cause && { dbError: cause }),
         path,
         requestId,
       },
@@ -73,8 +106,9 @@ function logServerError(
   } else {
     logger.error(
       {
-        error: err,
         ...getDatabaseErrorLogContext(err),
+        message: errorMessage,
+        ...(cause && { dbError: cause }),
         path,
         requestId,
         status,

--- a/packages/agents-core/src/dolt/branches-api.ts
+++ b/packages/agents-core/src/dolt/branches-api.ts
@@ -100,6 +100,8 @@ export type CheckoutBranchResult = {
     error?: string;
     /** The merge commit hash if schema was synced */
     mergeCommitHash?: string;
+    /** Whether sync was skipped because another request holds the advisory lock */
+    skippedDueToLock?: boolean;
   };
 };
 
@@ -156,6 +158,7 @@ export const checkoutBranch =
         hadDifferences: schemaSyncResult.hadDifferences,
         error: schemaSyncResult.error,
         mergeCommitHash: schemaSyncResult.mergeCommitHash,
+        skippedDueToLock: schemaSyncResult.skippedDueToLock,
       },
     };
   };


### PR DESCRIPTION
## Summary

- **Root cause**: Schema sync failures during Dolt branch checkout were silently swallowed — `branchScopedDbMiddleware` never inspected the `checkoutBranch` result. When sync failed (lock contention, merge conflicts from recent DROP TABLE migration), queries ran against branches with outdated schemas (missing columns like `is_work_app`), producing 500 errors.
- **Invisible errors**: The pg driver's Error properties (`message`, `code`, `severity`) are non-enumerable, so `JSON.stringify()` produced `cause: {}` in logs, hiding the actual database error.
- Adds retry logic (up to 2 attempts with backoff) for schema sync failures caused by advisory lock contention
- Logs explicit errors with full sync failure details when retries are exhausted
- Adds `serializeCause()` to the error handler that traverses the error cause chain and extracts non-enumerable pg Error properties (`code`, `message`, `severity`, `detail`, `hint`)

## Operational note

Existing branches that are already out of sync need a one-time manual fix:
```
pnpm db:manage:sync-all-branches
```

## Test plan

- [x] TypeScript compiles cleanly (`tsc --noEmit`)
- [x] Existing middleware tests pass
- [x] Existing error utility tests pass
- [ ] Verify on staging: schema sync retries appear in logs when lock is contended
- [ ] Verify on staging: `dbError` field in error logs now contains actual pg error details instead of `{}`
- [ ] Run `pnpm db:manage:sync-all-branches` against production DoltgreSQL

Made with [Cursor](https://cursor.com)