### PR TITLE
fix: handle SSE failure when streaming approval request

### DIFF
--- a/.changeset/possible-aquamarine-smelt.md
+++ b/.changeset/possible-aquamarine-smelt.md
@@ -1,0 +1,6 @@
+---
+"@inkeep/agents-api": patch
+"@inkeep/agents-core": patch
+---
+
+Add pending approval polling endpoint and graceful SSE failure handling for durable tool approvals

--- a/.changeset/possible-aquamarine-smelt.md
+++ b/.changeset/possible-aquamarine-smelt.md
@@ -1,6 +1,5 @@
 ---
 "@inkeep/agents-api": patch
-"@inkeep/agents-core": patch
 ---
 
 Add pending approval polling endpoint and graceful SSE failure handling for durable tool approvals

--- a/agents-api/__snapshots__/openapi.json
+++ b/agents-api/__snapshots__/openapi.json
@@ -6530,6 +6530,61 @@
           }
         ]
       },
+      "PendingApprovalsResponse": {
+        "properties": {
+          "approval": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/PendingToolApproval"
+              },
+              {
+                "properties": {
+                  "suspendedAt": {
+                    "type": "string"
+                  },
+                  "workflowRunId": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "workflowRunId",
+                  "suspendedAt"
+                ],
+                "type": "object"
+              }
+            ]
+          },
+          "hasPending": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "hasPending"
+        ],
+        "type": "object"
+      },
+      "PendingToolApproval": {
+        "properties": {
+          "args": {
+            "nullable": true
+          },
+          "isDelegated": {
+            "type": "boolean"
+          },
+          "toolCallId": {
+            "type": "string"
+          },
+          "toolName": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "toolCallId",
+          "toolName",
+          "isDelegated"
+        ],
+        "type": "object"
+      },
       "PowChallengeResponse": {
         "properties": {
           "algorithm": {
@@ -45996,6 +46051,106 @@
           }
         ],
         "summary": "Get Conversation",
+        "tags": [
+          "Conversations"
+        ],
+        "x-authz": {
+          "description": "Requires a valid API key (Bearer token). Auth is enforced by runApiKeyAuth middleware in createApp.ts."
+        }
+      }
+    },
+    "/run/v1/conversations/{conversationId}/pending-approvals": {
+      "get": {
+        "description": "Discover pending tool approval requests for a conversation. Use this to recover approval state when an SSE stream is interrupted or on page load.",
+        "operationId": "get-conversation-pending-approvals",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "conversationId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PendingApprovalsResponse"
+                }
+              }
+            },
+            "description": "Pending approval status for the conversation"
+          },
+          "400": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BadRequest"
+                }
+              }
+            },
+            "description": "Bad Request"
+          },
+          "401": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Unauthorized"
+                }
+              }
+            },
+            "description": "Unauthorized"
+          },
+          "403": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Forbidden"
+                }
+              }
+            },
+            "description": "Forbidden"
+          },
+          "404": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NotFound"
+                }
+              }
+            },
+            "description": "Not Found"
+          },
+          "422": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UnprocessableEntity"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InternalServerError"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "summary": "Get Pending Approvals",
         "tags": [
           "Conversations"
         ],

--- a/agents-api/__snapshots__/openapi.json
+++ b/agents-api/__snapshots__/openapi.json
@@ -6539,7 +6539,7 @@
               },
               {
                 "properties": {
-                  "suspendedAt": {
+                  "updatedAt": {
                     "type": "string"
                   },
                   "workflowRunId": {
@@ -6548,7 +6548,7 @@
                 },
                 "required": [
                   "workflowRunId",
-                  "suspendedAt"
+                  "updatedAt"
                 ],
                 "type": "object"
               }

--- a/agents-api/src/__tests__/run/routes/pending-approvals.test.ts
+++ b/agents-api/src/__tests__/run/routes/pending-approvals.test.ts
@@ -1,0 +1,164 @@
+import {
+  createConversation,
+  createWorkflowExecution,
+  updateWorkflowExecutionStatus,
+} from '@inkeep/agents-core';
+import { describe, expect, it } from 'vitest';
+import runDbClient from '../../../data/db/runDbClient';
+import { makeRequest } from '../../utils/testRequest';
+
+const TENANT_ID = 'test-tenant';
+const PROJECT_ID = 'default';
+
+async function seedConversation(id: string) {
+  return createConversation(runDbClient)({
+    id,
+    tenantId: TENANT_ID,
+    projectId: PROJECT_ID,
+    agentId: 'test-agent',
+    activeSubAgentId: 'sub-agent-1',
+    ref: { type: 'branch', name: 'main', hash: 'abc123' },
+  });
+}
+
+async function seedWorkflowExecution(
+  id: string,
+  conversationId: string,
+  status: 'running' | 'suspended' | 'completed' | 'failed' = 'running',
+  metadata?: Record<string, unknown>
+) {
+  const execution = await createWorkflowExecution(runDbClient)({
+    id,
+    tenantId: TENANT_ID,
+    projectId: PROJECT_ID,
+    agentId: 'test-agent',
+    conversationId,
+    requestId: `req-${id}`,
+    status: 'running',
+  });
+
+  if (status !== 'running' || metadata) {
+    await updateWorkflowExecutionStatus(runDbClient)({
+      tenantId: TENANT_ID,
+      projectId: PROJECT_ID,
+      id,
+      status,
+      metadata,
+    });
+  }
+
+  return execution;
+}
+
+describe('GET /run/v1/conversations/:conversationId/pending-approvals', () => {
+  it('should return hasPending: false when conversation has no workflow execution', async () => {
+    const convId = `conv-no-wf-${crypto.randomUUID()}`;
+    await seedConversation(convId);
+
+    const res = await makeRequest(`/run/v1/conversations/${convId}/pending-approvals`);
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.hasPending).toBe(false);
+    expect(body.approval).toBeUndefined();
+  });
+
+  it('should return hasPending: false when workflow is running (not suspended)', async () => {
+    const convId = `conv-running-${crypto.randomUUID()}`;
+    const wfId = `wf-running-${crypto.randomUUID()}`;
+    await seedConversation(convId);
+    await seedWorkflowExecution(wfId, convId, 'running');
+
+    const res = await makeRequest(`/run/v1/conversations/${convId}/pending-approvals`);
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.hasPending).toBe(false);
+  });
+
+  it('should return hasPending: false when workflow is completed', async () => {
+    const convId = `conv-completed-${crypto.randomUUID()}`;
+    const wfId = `wf-completed-${crypto.randomUUID()}`;
+    await seedConversation(convId);
+    await seedWorkflowExecution(wfId, convId, 'completed');
+
+    const res = await makeRequest(`/run/v1/conversations/${convId}/pending-approvals`);
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.hasPending).toBe(false);
+  });
+
+  it('should return hasPending: false when suspended but no pendingToolApproval in metadata', async () => {
+    const convId = `conv-suspended-no-approval-${crypto.randomUUID()}`;
+    const wfId = `wf-suspended-no-approval-${crypto.randomUUID()}`;
+    await seedConversation(convId);
+    await seedWorkflowExecution(wfId, convId, 'suspended', {
+      continuationStreamNamespace: 'r1',
+    });
+
+    const res = await makeRequest(`/run/v1/conversations/${convId}/pending-approvals`);
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.hasPending).toBe(false);
+  });
+
+  it('should return pending approval details when workflow is suspended with pendingToolApproval', async () => {
+    const convId = `conv-pending-${crypto.randomUUID()}`;
+    const wfId = `wf-pending-${crypto.randomUUID()}`;
+    await seedConversation(convId);
+    await seedWorkflowExecution(wfId, convId, 'suspended', {
+      continuationStreamNamespace: 'r1',
+      pendingToolApproval: {
+        toolCallId: 'call-123',
+        toolName: 'search_docs',
+        args: { query: 'test' },
+        isDelegated: false,
+      },
+    });
+
+    const res = await makeRequest(`/run/v1/conversations/${convId}/pending-approvals`);
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.hasPending).toBe(true);
+    expect(body.approval).toBeDefined();
+    expect(body.approval.toolCallId).toBe('call-123');
+    expect(body.approval.toolName).toBe('search_docs');
+    expect(body.approval.args).toEqual({ query: 'test' });
+    expect(body.approval.isDelegated).toBe(false);
+    expect(body.approval.workflowRunId).toBe(wfId);
+    expect(body.approval.suspendedAt).toBeDefined();
+  });
+
+  it('should return pending approval for delegated approval', async () => {
+    const convId = `conv-delegated-${crypto.randomUUID()}`;
+    const wfId = `wf-delegated-${crypto.randomUUID()}`;
+    await seedConversation(convId);
+    await seedWorkflowExecution(wfId, convId, 'suspended', {
+      continuationStreamNamespace: 'r1',
+      pendingToolApproval: {
+        toolCallId: 'delegated-call-456',
+        toolName: 'execute_code',
+        args: { code: 'console.log("hello")' },
+        isDelegated: true,
+      },
+    });
+
+    const res = await makeRequest(`/run/v1/conversations/${convId}/pending-approvals`);
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.hasPending).toBe(true);
+    expect(body.approval.toolCallId).toBe('delegated-call-456');
+    expect(body.approval.toolName).toBe('execute_code');
+    expect(body.approval.isDelegated).toBe(true);
+  });
+
+  it('should return 404 when conversation does not exist', async () => {
+    const res = await makeRequest('/run/v1/conversations/nonexistent-conv/pending-approvals');
+
+    expect(res.status).toBe(404);
+  });
+});

--- a/agents-api/src/__tests__/run/routes/pending-approvals.test.ts
+++ b/agents-api/src/__tests__/run/routes/pending-approvals.test.ts
@@ -129,7 +129,7 @@ describe('GET /run/v1/conversations/:conversationId/pending-approvals', () => {
     expect(body.approval.args).toEqual({ query: 'test' });
     expect(body.approval.isDelegated).toBe(false);
     expect(body.approval.workflowRunId).toBe(wfId);
-    expect(body.approval.suspendedAt).toBeDefined();
+    expect(body.approval.updatedAt).toBeDefined();
   });
 
   it('should return pending approval for delegated approval', async () => {

--- a/agents-api/src/domains/run/agents/tools/tool-approval.ts
+++ b/agents-api/src/domains/run/agents/tools/tool-approval.ts
@@ -122,12 +122,23 @@ export async function waitForToolApproval(
 
     const streamHelper = ctx.isDelegatedAgent ? undefined : ctx.streamHelper;
     if (streamHelper) {
-      await streamHelper.writeToolApprovalRequest({
-        approvalId: `aitxt-${toolCallId}`,
-        toolCallId,
-        toolName,
-        input: args as Record<string, unknown>,
-      });
+      try {
+        await streamHelper.writeToolApprovalRequest({
+          approvalId: `aitxt-${toolCallId}`,
+          toolCallId,
+          toolName,
+          input: args as Record<string, unknown>,
+        });
+      } catch (sseError) {
+        logger.warn(
+          {
+            toolCallId,
+            toolName,
+            error: sseError instanceof Error ? sseError.message : String(sseError),
+          },
+          'Failed to stream tool approval request to client — approval is persisted and recoverable via polling'
+        );
+      }
     }
 
     ctx.pendingDurableApproval = { toolCallId, toolName, args };

--- a/agents-api/src/domains/run/routes/conversations.ts
+++ b/agents-api/src/domains/run/routes/conversations.ts
@@ -568,6 +568,11 @@ app.openapi(
       throw createApiError({ code: 'not_found', message: 'Conversation not found' });
     }
 
+    const endUserId = executionContext.metadata?.endUserId;
+    if (conversation.userId && conversation.userId !== endUserId) {
+      throw createApiError({ code: 'not_found', message: 'Conversation not found' });
+    }
+
     const execution = await getWorkflowExecutionByConversation(runDbClient)({
       tenantId,
       projectId,

--- a/agents-api/src/domains/run/routes/conversations.ts
+++ b/agents-api/src/domains/run/routes/conversations.ts
@@ -523,7 +523,7 @@ const PendingApprovalsResponseSchema = z
     hasPending: z.boolean(),
     approval: PendingToolApprovalSchema.extend({
       workflowRunId: z.string(),
-      suspendedAt: z.string(),
+      updatedAt: z.string(),
     }).optional(),
   })
   .openapi('PendingApprovalsResponse');
@@ -595,7 +595,7 @@ app.openapi(
         args: pendingToolApproval.args,
         isDelegated: pendingToolApproval.isDelegated,
         workflowRunId: execution.id,
-        suspendedAt: execution.updatedAt,
+        updatedAt: execution.updatedAt,
       },
     });
   }

--- a/agents-api/src/domains/run/routes/conversations.ts
+++ b/agents-api/src/domains/run/routes/conversations.ts
@@ -509,4 +509,96 @@ app.openapi(resumeConversationStreamRoute, async (c) => {
   return new Response(null, { status: 204 });
 });
 
+const PendingToolApprovalSchema = z
+  .object({
+    toolCallId: z.string(),
+    toolName: z.string(),
+    args: z.unknown().optional(),
+    isDelegated: z.boolean(),
+  })
+  .openapi('PendingToolApproval');
+
+const PendingApprovalsResponseSchema = z
+  .object({
+    hasPending: z.boolean(),
+    approval: PendingToolApprovalSchema.extend({
+      workflowRunId: z.string(),
+      suspendedAt: z.string(),
+    }).optional(),
+  })
+  .openapi('PendingApprovalsResponse');
+
+app.openapi(
+  createProtectedRoute({
+    method: 'get',
+    path: '/{conversationId}/pending-approvals',
+    summary: 'Get Pending Approvals',
+    description:
+      'Discover pending tool approval requests for a conversation. Use this to recover approval state when an SSE stream is interrupted or on page load.',
+    operationId: 'get-conversation-pending-approvals',
+    tags: ['Conversations'],
+    security: [{ bearerAuth: [] }],
+    permission: inheritedRunApiKeyAuth(),
+    request: {
+      params: z.object({ conversationId: z.string() }),
+    },
+    responses: {
+      200: {
+        description: 'Pending approval status for the conversation',
+        content: {
+          'application/json': {
+            schema: PendingApprovalsResponseSchema,
+          },
+        },
+      },
+      ...commonGetErrorResponses,
+    },
+  }),
+  async (c) => {
+    const executionContext = c.get('executionContext');
+    const { tenantId, projectId } = executionContext;
+    const { conversationId } = c.req.valid('param');
+
+    const conversation = await getConversation(runDbClient)({
+      scopes: { tenantId, projectId },
+      conversationId,
+    });
+
+    if (!conversation) {
+      throw createApiError({ code: 'not_found', message: 'Conversation not found' });
+    }
+
+    const execution = await getWorkflowExecutionByConversation(runDbClient)({
+      tenantId,
+      projectId,
+      conversationId,
+    });
+
+    if (!execution || execution.status !== 'suspended') {
+      return c.json({ hasPending: false });
+    }
+
+    const metadata = execution.metadata as Record<string, unknown> | null;
+    const pendingToolApproval = metadata?.pendingToolApproval as
+      | { toolCallId: string; toolName: string; args: unknown; isDelegated: boolean }
+      | undefined;
+
+    if (!pendingToolApproval) {
+      return c.json({ hasPending: false });
+    }
+
+    return c.json({
+      hasPending: true,
+      approval: {
+        toolCallId: pendingToolApproval.toolCallId,
+        toolName: pendingToolApproval.toolName,
+        args: pendingToolApproval.args,
+        isDelegated: pendingToolApproval.isDelegated,
+        workflowRunId: execution.id,
+        suspendedAt: execution.updatedAt,
+      },
+    });
+  }
+);
+
 export default app;

--- a/agents-api/src/domains/run/routes/conversations.ts
+++ b/agents-api/src/domains/run/routes/conversations.ts
@@ -579,13 +579,13 @@ app.openapi(
     }
 
     const metadata = execution.metadata as Record<string, unknown> | null;
-    const pendingToolApproval = metadata?.pendingToolApproval as
-      | { toolCallId: string; toolName: string; args: unknown; isDelegated: boolean }
-      | undefined;
+    const parsed = PendingToolApprovalSchema.safeParse(metadata?.pendingToolApproval);
 
-    if (!pendingToolApproval) {
+    if (!parsed.success) {
       return c.json({ hasPending: false });
     }
+
+    const pendingToolApproval = parsed.data;
 
     return c.json({
       hasPending: true,

--- a/agents-api/src/domains/run/workflow/functions/agentExecution.ts
+++ b/agents-api/src/domains/run/workflow/functions/agentExecution.ts
@@ -77,14 +77,20 @@ async function _agentExecutionWorkflow(payload: AgentExecutionPayload) {
       if (llmResult.type === 'tool_calls') {
         for (const toolCall of llmResult.toolCalls) {
           const continuationNs = `r${approvalRound + 1}`;
+          const hookToolCallId = llmResult.delegatedApproval?.toolCallId ?? toolCall.toolCallId;
           await markWorkflowSuspendedStep({
             tenantId: payload.tenantId,
             projectId: payload.projectId,
             workflowRunId,
             continuationStreamNamespace: continuationNs,
+            pendingToolApproval: {
+              toolCallId: hookToolCallId,
+              toolName: toolCall.toolName,
+              args: toolCall.args,
+              isDelegated: !!llmResult.delegatedApproval,
+            },
           });
 
-          const hookToolCallId = llmResult.delegatedApproval?.toolCallId ?? toolCall.toolCallId;
           const token = `tool-approval:${payload.conversationId}:${workflowRunId}:${hookToolCallId}`;
 
           console.info('[agentExecution] Creating tool approval hook', {

--- a/agents-api/src/domains/run/workflow/steps/agentExecutionSteps.ts
+++ b/agents-api/src/domains/run/workflow/steps/agentExecutionSteps.ts
@@ -1154,6 +1154,7 @@ export async function markWorkflowResumingStep(params: {
     projectId,
     id: workflowRunId,
     status: 'running',
+    metadata: { pendingToolApproval: null },
   });
 
   logger.info({ workflowRunId }, 'Workflow execution marked as running (resuming after approval)');

--- a/agents-api/src/domains/run/workflow/steps/agentExecutionSteps.ts
+++ b/agents-api/src/domains/run/workflow/steps/agentExecutionSteps.ts
@@ -1110,9 +1110,16 @@ export async function markWorkflowSuspendedStep(params: {
   projectId: string;
   workflowRunId: string;
   continuationStreamNamespace: string;
+  pendingToolApproval?: {
+    toolCallId: string;
+    toolName: string;
+    args: unknown;
+    isDelegated: boolean;
+  };
 }): Promise<void> {
   'use step';
-  const { tenantId, projectId, workflowRunId, continuationStreamNamespace } = params;
+  const { tenantId, projectId, workflowRunId, continuationStreamNamespace, pendingToolApproval } =
+    params;
 
   const { updateWorkflowExecutionStatus } = await import('@inkeep/agents-core');
   const { default: runDbClient } = await import('../../../../data/db/runDbClient');
@@ -1122,7 +1129,10 @@ export async function markWorkflowSuspendedStep(params: {
     projectId,
     id: workflowRunId,
     status: 'suspended',
-    metadata: { continuationStreamNamespace },
+    metadata: {
+      continuationStreamNamespace,
+      ...(pendingToolApproval ? { pendingToolApproval } : {}),
+    },
   });
 
   logger.info({ workflowRunId }, 'Workflow execution marked as suspended (awaiting tool approval)');


### PR DESCRIPTION
## Summary
- Store pending tool approval details (toolCallId, toolName, args, isDelegated) in workflow execution metadata when suspending for durable approval
- Add `GET /run/v1/conversations/:conversationId/pending-approvals` endpoint so the UI can discover pending approvals on page load or after SSE disconnection
- Wrap SSE `writeToolApprovalRequest` in try-catch so a stream failure does not break the workflow — the approval remains persisted and recoverable via polling

## Test plan
- [x] Unit tests for the new pending-approvals endpoint (7 test cases):
  - No workflow execution -> hasPending: false
  - Running workflow -> hasPending: false
  - Completed workflow -> hasPending: false
  - Suspended without pendingToolApproval metadata -> hasPending: false
  - Suspended with pendingToolApproval -> returns full approval details
  - Delegated approval -> returns isDelegated: true
  - Nonexistent conversation -> 404
- [x] `pnpm format` passes
- [x] `pnpm typecheck` passes
- [x] All lint-staged hooks pass (biome, tests, openapi snapshot)

Closes PRD-6454