### PR TITLE
refactor: apply scoped logger context to interim PRs

### DIFF
--- a/.agents/skills/api-logging-guidelines/SKILL.md
+++ b/.agents/skills/api-logging-guidelines/SKILL.md
@@ -11,17 +11,40 @@ Comprehensive guidance for appropriate use of logging in API routes to maintain 
 
 ## Core Principles
 
-### 1. Avoid Redundant Logging
+### 1. Use Scoped Logger Context (ALS)
 
-**DON'T log what's already logged by middleware:**
+The codebase uses **AsyncLocalStorage (ALS)** to automatically propagate context fields through the call stack. Middleware sets `tenantId`, `projectId`, `agentId` at the request level. Functions should use `runWithLogContext()` to add operation-level context (e.g., `toolCallId`, `toolName`, `workflowRunId`).
+
+**DON'T manually repeat ambient context in every log call:**
 ```typescript
-// ❌ BAD - Request details are already logged by middleware
-logger.info({ tenantId, projectId }, 'Getting project details');
+// ❌ BAD - tenantId, projectId, toolName are already in ALS context
+logger.info({ tenantId, projectId, toolName, toolCallId }, 'Processing tool call');
 ```
+
+**DO rely on ALS context and only pass per-call data:**
+```typescript
+// ✅ GOOD - ambient fields auto-included from ALS
+logger.info({ duration: 1234 }, 'Processing complete');
+logger.info('Simple status message');
+```
+
+**DO wrap functions in `runWithLogContext` when they receive IDs used across multiple log calls:**
+```typescript
+// ✅ GOOD - set context once, all nested log calls inherit it
+function processTool(toolCallId: string, toolName: string) {
+  return runWithLogContext({ toolCallId, toolName }, async () => {
+    logger.info('Starting');     // toolCallId + toolName auto-included
+    logger.warn('Retrying');     // toolCallId + toolName auto-included
+    logger.info('Complete');     // toolCallId + toolName auto-included
+  });
+}
+```
+
+### 2. Avoid Redundant Logging
 
 **DO rely on request middleware logging:**
 - Request/response middleware already logs: method, path, status, duration, path params
-- These logs include tenant/project IDs from the URL path
+- ALS middleware provides tenant/project/agent IDs on every log line automatically
 - Adding duplicate logs creates noise without value
 
 ### 2. Log Level Guidelines
@@ -35,21 +58,19 @@ logger.info({ tenantId, projectId }, 'Getting project details');
 
 ### 3. What TO Log
 
-**Log these important events:**
+**Log these important events (ambient context comes from ALS automatically):**
 
 ```typescript
-// ✅ GOOD - Important business event
+// ✅ GOOD - Important business event (tenantId/projectId from ALS)
 logger.info({
-  userId,
   oldPlan: 'free',
   newPlan: 'pro',
   mrr: 99
 }, 'User upgraded subscription');
 
-// ✅ GOOD - Error with context
+// ✅ GOOD - Error with per-call context (tenantId from ALS)
 logger.error({
   error,
-  tenantId,
   webhookUrl,
   attemptNumber: 3
 }, 'Webhook delivery failed after retries');
@@ -57,14 +78,12 @@ logger.error({
 // ✅ GOOD - Security-relevant event
 logger.warn({
   ip: c.req.header('x-forwarded-for'),
-  userId,
   attemptedResource
 }, 'Unauthorized access attempt');
 
 // ✅ GOOD - Performance issue
 logger.warn({
   duration: 5234,
-  query,
   resultCount: 10000
 }, 'Slow query detected');
 ```
@@ -209,42 +228,31 @@ if (process.env.NODE_ENV === 'development') {
 
 ## Migration Strategy
 
-When refactoring existing verbose logging:
+When refactoring existing verbose logging to the scoped context pattern:
 
-1. **Identify redundant logs**: Remove logs that duplicate middleware logging
-2. **Downgrade routine operations**: Move routine operations from INFO to DEBUG
-3. **Enhance error logs**: Add more context to error logs
-4. **Add business event logs**: Ensure important business events are logged
-5. **Review log levels**: Ensure each log uses the appropriate level
+1. **Wrap functions in `runWithLogContext`**: If a function receives IDs that appear in every log call, wrap the body
+2. **Strip ambient fields from log calls**: Remove `tenantId`, `projectId`, `agentId`, `toolName`, `toolCallId`, etc. that are now in ALS
+3. **Use string-only overloads**: When a log call has no per-call data, use `logger.info('message')` instead of `logger.info({}, 'message')`
+4. **Use `.with()` for class members**: `this.logger = getLogger('Name').with({ sessionId })` in constructors
 
 ### Before:
 ```typescript
-router.get('/:id', async (c) => {
-  const { id } = c.req.param();
-  logger.info({ id }, 'Getting item by ID');  // Redundant
-
-  const item = await getItem(id);
-  logger.info({ item }, 'Retrieved item');     // Too verbose
-
-  return c.json(item);
-});
+function processItem(tenantId: string, projectId: string, itemId: string) {
+  logger.info({ tenantId, projectId, itemId }, 'Starting');
+  logger.info({ tenantId, projectId, itemId }, 'Validating');
+  logger.info({ tenantId, projectId, itemId }, 'Complete');
+}
 ```
 
 ### After:
 ```typescript
-router.get('/:id', async (c) => {
-  const { id } = c.req.param();
-
-  try {
-    const item = await getItem(id);
-    // No logging needed - routine successful operation
-    return c.json(item);
-  } catch (error) {
-    // Only log errors
-    logger.error({ error, id }, 'Failed to retrieve item');
-    return c.json({ error: 'Item not found' }, 404);
-  }
-});
+function processItem(tenantId: string, projectId: string, itemId: string) {
+  return runWithLogContext({ tenantId, projectId, itemId }, () => {
+    logger.info('Starting');
+    logger.info('Validating');
+    logger.info('Complete');
+  });
+}
 ```
 
 ---

--- a/.changeset/back-white-warbler.md
+++ b/.changeset/back-white-warbler.md
@@ -1,0 +1,5 @@
+---
+"@inkeep/agents-api": patch
+---
+
+Migrate tool-approval and tool-wrapper logger calls to scoped context pattern

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -487,6 +487,65 @@ Any code in `agents-api` or `agents-work-apps` that makes **internal A2A calls o
 | Calling an **external** service or third-party API | Global `fetch` |
 | Test environments (falls back automatically) | Either (auto-fallback) |
 
+### Logger: Scoped Context Pattern
+All logger calls must use the scoped context pattern powered by AsyncLocalStorage (ALS). This eliminates repetitive context fields (`tenantId`, `projectId`, `agentId`, etc.) from individual log calls — middleware and `runWithLogContext` wrappers provide them automatically.
+
+**Core APIs** (from `@inkeep/agents-core`, re-exported via `agents-api/src/logger.ts`):
+
+| API | Purpose |
+|---|---|
+| `getLogger(name)` | Get a module-scoped logger. Automatically resolves ALS context at call time. |
+| `runWithLogContext(bindings, fn)` | Create a child ALS scope — all logger calls inside `fn` inherit `bindings`. |
+| `logger.with(bindings)` | Snapshot logger for class members — captures ALS context at creation + adds `bindings`. |
+
+**Three patterns for new code:**
+
+```typescript
+// Pattern 1: Route handlers / middleware — context set by middleware in createApp.ts
+// tenantId, projectId, agentId are already in ALS. Just log the per-call fields.
+const logger = getLogger('myModule');
+logger.info({ count: 5 }, 'Processing items');  // tenantId/projectId auto-included
+logger.info('Simple message');                   // string-only overload also works
+
+// Pattern 2: Service functions / workflow steps — add operation-level context
+function processItem({ tenantId, projectId, itemId }) {
+  return runWithLogContext({ tenantId, projectId, itemId }, () => {
+    logger.info('Starting');    // tenantId + projectId + itemId auto-included
+    logger.info('Done');        // no need to repeat in every call
+  });
+}
+
+// Pattern 3: Class members — snapshot at construction
+class MyService {
+  private logger: PinoLogger;
+  constructor(sessionId: string) {
+    this.logger = getLogger('MyService').with({ sessionId });
+  }
+  doWork() {
+    this.logger.info('Working');  // sessionId + ALS context included
+  }
+}
+```
+
+**What NOT to do:**
+```typescript
+// BAD: manually repeating ambient context in every call
+logger.info({ tenantId, projectId, agentId, toolName }, 'message');
+
+// GOOD: let ALS provide ambient fields, only pass per-call data
+logger.info({ extraData }, 'message');
+// or just:
+logger.info('message');
+```
+
+**When to use `runWithLogContext`:**
+| Scenario | Use |
+|---|---|
+| Function receives IDs that appear in all its log calls | Wrap body in `runWithLogContext({ id1, id2 }, () => { ... })` |
+| Middleware already set the context (route handlers) | Just call `logger.info(...)` — context is inherited |
+| Class with long-lived context | `this.logger = getLogger('Name').with({ id })` in constructor |
+| Outside any request scope (scripts, tests) | Falls back to base logger — no crash, just no ambient context |
+
 ### Route Authorization Pattern (`createProtectedRoute`)
 All API routes in `agents-api` **must** use `createProtectedRoute()` from `@inkeep/agents-core/middleware` instead of the plain `createRoute()` from `@hono/zod-openapi`. This is enforced by Biome lint rules and ensures every route has explicit authorization metadata (`x-authz`) in the OpenAPI spec.
 

--- a/agents-api/src/domains/run/agents/tools/tool-approval.ts
+++ b/agents-api/src/domains/run/agents/tools/tool-approval.ts
@@ -5,7 +5,7 @@ import {
 } from '@inkeep/agents-core';
 import type { Span } from '@opentelemetry/api';
 import { SpanStatusCode, trace } from '@opentelemetry/api';
-import { getLogger } from '../../../../logger';
+import { getLogger, runWithLogContext } from '../../../../logger';
 import { pendingToolApprovalManager } from '../../session/PendingToolApprovalManager';
 import { toolApprovalUiBus } from '../../session/ToolApprovalUiBus';
 import { createDeniedToolResult } from '../../utils/tool-result';
@@ -23,7 +23,21 @@ export async function waitForToolApproval(
 ): Promise<
   { approved: false; deniedResult: unknown } | { approved: true } | { approved: 'pending' }
 > {
-  logger.info({ toolName, toolCallId, args }, 'Tool requires approval - waiting for user response');
+  return runWithLogContext({ toolCallId, toolName }, () =>
+    waitForToolApprovalInner(ctx, toolCallId, toolName, args, providerMetadata)
+  );
+}
+
+async function waitForToolApprovalInner(
+  ctx: AgentRunContext,
+  toolCallId: string,
+  toolName: string,
+  args: unknown,
+  providerMetadata: unknown
+): Promise<
+  { approved: false; deniedResult: unknown } | { approved: true } | { approved: 'pending' }
+> {
+  logger.info({ args }, 'Tool requires approval - waiting for user response');
 
   const currentSpan = trace.getActiveSpan();
   if (currentSpan) {
@@ -60,7 +74,7 @@ export async function waitForToolApproval(
             },
             (denialSpan: Span) => {
               logger.info(
-                { toolName, toolCallId, reason: preApproved.reason },
+                { reason: preApproved.reason },
                 'Tool execution denied (durable pre-approved decision)'
               );
               denialSpan.setStatus({ code: SpanStatusCode.OK });
@@ -75,7 +89,7 @@ export async function waitForToolApproval(
           'tool.approval_approved',
           { attributes: baseSpanAttributes },
           (approvedSpan: Span) => {
-            logger.info({ toolName, toolCallId }, 'Tool approved (durable pre-approved decision)');
+            logger.info('Tool approved (durable pre-approved decision)');
             approvedSpan.setStatus({ code: SpanStatusCode.OK });
             approvedSpan.end();
           }
@@ -104,11 +118,7 @@ export async function waitForToolApproval(
         });
       } catch (sseError) {
         logger.warn(
-          {
-            toolCallId,
-            toolName,
-            error: sseError instanceof Error ? sseError.message : String(sseError),
-          },
+          { error: sseError instanceof Error ? sseError.message : String(sseError) },
           'Failed to stream tool approval request to client — approval is persisted and recoverable via polling'
         );
       }
@@ -179,10 +189,7 @@ export async function waitForToolApproval(
         },
       },
       (denialSpan: Span) => {
-        logger.info(
-          { toolName, toolCallId, reason: approvalResult.reason },
-          'Tool execution denied by user'
-        );
+        logger.info({ reason: approvalResult.reason }, 'Tool execution denied by user');
         denialSpan.setStatus({ code: SpanStatusCode.OK });
         denialSpan.end();
         return createDeniedToolResult(toolCallId, approvalResult.reason);
@@ -196,7 +203,7 @@ export async function waitForToolApproval(
     'tool.approval_approved',
     { attributes: baseSpanAttributes },
     (approvedSpan: Span) => {
-      logger.info({ toolName, toolCallId }, 'Tool approved, continuing with execution');
+      logger.info('Tool approved, continuing with execution');
       approvedSpan.setStatus({ code: SpanStatusCode.OK });
       approvedSpan.end();
     }
@@ -239,34 +246,33 @@ export async function parseAndCheckApproval<T>(
 ): Promise<
   { args: T; denied: false; pendingApproval?: true } | { args: T; denied: true; result: unknown }
 > {
-  let processedArgs: T;
-  try {
-    processedArgs = parseEmbeddedJson(args);
-    if (JSON.stringify(args) !== JSON.stringify(processedArgs)) {
+  return runWithLogContext({ toolCallId, toolName }, async () => {
+    let processedArgs: T;
+    try {
+      processedArgs = parseEmbeddedJson(args);
+      if (JSON.stringify(args) !== JSON.stringify(processedArgs)) {
+        logger.warn('Fixed stringified JSON parameters (indicates schema ambiguity)');
+      }
+    } catch (error) {
       logger.warn(
-        { toolName, toolCallId },
-        'Fixed stringified JSON parameters (indicates schema ambiguity)'
+        { error: (error as Error).message },
+        'Failed to parse embedded JSON, using original args'
       );
+      processedArgs = args;
     }
-  } catch (error) {
-    logger.warn(
-      { toolName, toolCallId, error: (error as Error).message },
-      'Failed to parse embedded JSON, using original args'
-    );
-    processedArgs = args;
-  }
 
-  if (needsApproval) {
-    const approval = await waitForToolApproval(ctx, toolCallId, toolName, args, providerMetadata);
-    if (approval.approved === 'pending') {
-      return { args: processedArgs, denied: false, pendingApproval: true };
+    if (needsApproval) {
+      const approval = await waitForToolApproval(ctx, toolCallId, toolName, args, providerMetadata);
+      if (approval.approved === 'pending') {
+        return { args: processedArgs, denied: false, pendingApproval: true };
+      }
+      if (!approval.approved) {
+        const deniedResult = approval.deniedResult as { reason?: string } | undefined;
+        recordDenial(ctx, toolName, toolCallId, deniedResult?.reason);
+        return { args: processedArgs, denied: true, result: approval.deniedResult };
+      }
     }
-    if (!approval.approved) {
-      const deniedResult = approval.deniedResult as { reason?: string } | undefined;
-      recordDenial(ctx, toolName, toolCallId, deniedResult?.reason);
-      return { args: processedArgs, denied: true, result: approval.deniedResult };
-    }
-  }
 
-  return { args: processedArgs, denied: false };
+    return { args: processedArgs, denied: false };
+  });
 }

--- a/agents-api/src/domains/run/agents/tools/tool-wrapper.ts
+++ b/agents-api/src/domains/run/agents/tools/tool-wrapper.ts
@@ -14,7 +14,7 @@ import {
 import { trace } from '@opentelemetry/api';
 import type { ToolSet } from 'ai';
 import runDbClient from '../../../../data/db/runDbClient';
-import { getLogger } from '../../../../logger';
+import { getLogger, runWithLogContext } from '../../../../logger';
 import { agentSessionManager, type ToolCallData } from '../../session/AgentSession';
 import { generateToolId } from '../../utils/agent-operations';
 import { isToolResultDenied } from '../../utils/tool-result';
@@ -104,308 +104,307 @@ export function wrapToolWithStreaming(
     execute: async (args: any, context?: any) => {
       const startTime = Date.now();
       const toolCallId = context?.toolCallId || generateToolId();
-      const streamHelper = ctx.isDelegatedAgent ? undefined : ctx.streamHelper;
 
-      const activeSpan = trace.getActiveSpan();
-      if (activeSpan) {
-        const attributes: Record<string, any> = {
-          'conversation.id': ctx.conversationId,
-          'tool.purpose': toolDefinition.description || 'No description provided',
-          'ai.toolType': toolType || 'unknown',
-          'subAgent.name': ctx.config.name || 'unknown',
-          'subAgent.id': ctx.config.id || 'unknown',
-          'agent.id': ctx.config.agentId || 'unknown',
-        };
+      return runWithLogContext({ toolName, toolCallId }, async () => {
+        const streamHelper = ctx.isDelegatedAgent ? undefined : ctx.streamHelper;
 
-        if (options?.mcpServerId) {
-          attributes['ai.toolCall.mcpServerId'] = options.mcpServerId;
+        const activeSpan = trace.getActiveSpan();
+        if (activeSpan) {
+          const attributes: Record<string, any> = {
+            'conversation.id': ctx.conversationId,
+            'tool.purpose': toolDefinition.description || 'No description provided',
+            'ai.toolType': toolType || 'unknown',
+            'subAgent.name': ctx.config.name || 'unknown',
+            'subAgent.id': ctx.config.id || 'unknown',
+            'agent.id': ctx.config.agentId || 'unknown',
+          };
+
+          if (options?.mcpServerId) {
+            attributes['ai.toolCall.mcpServerId'] = options.mcpServerId;
+          }
+          if (options?.mcpServerName) {
+            attributes['ai.toolCall.mcpServerName'] = options.mcpServerName;
+          }
+
+          activeSpan.setAttributes(attributes);
         }
-        if (options?.mcpServerName) {
-          attributes['ai.toolCall.mcpServerName'] = options.mcpServerName;
-        }
 
-        activeSpan.setAttributes(attributes);
-      }
+        const isInternalTool =
+          toolName.includes(SAVE_TOOL_RESULT_TOOL) || toolName.startsWith(TRANSFER_TOOL_PREFIX);
+        const isInternalToolForUi =
+          isInternalTool ||
+          toolName.startsWith(DELEGATE_TOOL_PREFIX) ||
+          toolName === LOAD_SKILL_TOOL;
 
-      const isInternalTool =
-        toolName.includes(SAVE_TOOL_RESULT_TOOL) || toolName.startsWith(TRANSFER_TOOL_PREFIX);
-      const isInternalToolForUi =
-        isInternalTool || toolName.startsWith(DELEGATE_TOOL_PREFIX) || toolName === LOAD_SKILL_TOOL;
+        // In durable workflows, delegate_to_ tool results must be stored in
+        // conversation history so the next callLlmStep sees the delegation outcome
+        // and doesn't re-delegate in a loop.
+        const isDurableDelegation =
+          !!ctx.durableWorkflowRunId && toolName.startsWith(DELEGATE_TOOL_PREFIX);
+        const skipHistoryStorage = isInternalToolForUi && !isDurableDelegation;
 
-      // In durable workflows, delegate_to_ tool results must be stored in
-      // conversation history so the next callLlmStep sees the delegation outcome
-      // and doesn't re-delegate in a loop.
-      const isDurableDelegation =
-        !!ctx.durableWorkflowRunId && toolName.startsWith(DELEGATE_TOOL_PREFIX);
-      const skipHistoryStorage = isInternalToolForUi && !isDurableDelegation;
+        const needsApproval = options?.needsApproval || false;
 
-      const needsApproval = options?.needsApproval || false;
+        const preApprovedEntry = ctx.durableWorkflowRunId
+          ? ctx.approvedToolCalls?.[toolCallId]
+          : undefined;
+        const isPreApproved = !!preApprovedEntry;
 
-      const preApprovedEntry = ctx.durableWorkflowRunId
-        ? ctx.approvedToolCalls?.[toolCallId]
-        : undefined;
-      const isPreApproved = !!preApprovedEntry;
+        if (streamRequestId && streamHelper && !isInternalToolForUi && !isPreApproved) {
+          const inputText = JSON.stringify(args ?? {});
 
-      if (streamRequestId && streamHelper && !isInternalToolForUi && !isPreApproved) {
-        const inputText = JSON.stringify(args ?? {});
+          await streamHelper.writeToolInputStart({ toolCallId: toolCallId, toolName });
 
-        await streamHelper.writeToolInputStart({ toolCallId: toolCallId, toolName });
+          for (const part of chunkString(inputText, 16)) {
+            await streamHelper.writeToolInputDelta({
+              toolCallId: toolCallId,
+              inputTextDelta: part,
+            });
+          }
 
-        for (const part of chunkString(inputText, 16)) {
-          await streamHelper.writeToolInputDelta({
+          await streamHelper.writeToolInputAvailable({
             toolCallId: toolCallId,
-            inputTextDelta: part,
+            toolName,
+            input: args ?? {},
+            providerMetadata: context?.providerMetadata,
           });
         }
 
-        await streamHelper.writeToolInputAvailable({
-          toolCallId: toolCallId,
-          toolName,
-          input: args ?? {},
-          providerMetadata: context?.providerMetadata,
-        });
-      }
+        if (streamRequestId && !isInternalToolForUi) {
+          const toolCallData: ToolCallData = {
+            toolName,
+            input: args,
+            toolCallId: toolCallId,
+            relationshipId,
+            inDelegatedAgent: ctx.isDelegatedAgent,
+          };
 
-      if (streamRequestId && !isInternalToolForUi) {
-        const toolCallData: ToolCallData = {
-          toolName,
-          input: args,
-          toolCallId: toolCallId,
-          relationshipId,
-          inDelegatedAgent: ctx.isDelegatedAgent,
-        };
-
-        if (needsApproval) {
-          toolCallData.needsApproval = true;
-          toolCallData.conversationId = ctx.conversationId;
-        }
-
-        await agentSessionManager.recordEvent(
-          streamRequestId,
-          SESSION_EVENT_TOOL_CALL,
-          ctx.config.id,
-          toolCallData
-        );
-      }
-
-      try {
-        const artifactParser = streamRequestId
-          ? agentSessionManager.getArtifactParser(streamRequestId)
-          : null;
-        const parsedArgsForResolution = artifactParser ? parseEmbeddedJson(args) : args;
-        const resolvedArgs = artifactParser
-          ? await artifactParser.resolveArgs(parsedArgsForResolution)
-          : args;
-
-        const parameters = (toolDefinition as AiSdkToolDefinition).parameters;
-        if (artifactParser && parameters?.safeParse) {
-          const resolvedChanged =
-            JSON.stringify(parsedArgsForResolution) !== JSON.stringify(resolvedArgs);
-          if (resolvedChanged) {
-            const validation = parameters.safeParse(resolvedArgs);
-            if (!validation.success) {
-              throw new Error(
-                `Resolved tool args failed schema validation for '${toolName}': ${validation.error.message}`
-              );
-            }
+          if (needsApproval) {
+            toolCallData.needsApproval = true;
+            toolCallData.conversationId = ctx.conversationId;
           }
+
+          await agentSessionManager.recordEvent(
+            streamRequestId,
+            SESSION_EVENT_TOOL_CALL,
+            ctx.config.id,
+            toolCallData
+          );
         }
 
-        const result = await originalExecute(resolvedArgs, context);
-        const duration = Date.now() - startTime;
+        try {
+          const artifactParser = streamRequestId
+            ? agentSessionManager.getArtifactParser(streamRequestId)
+            : null;
+          const parsedArgsForResolution = artifactParser ? parseEmbeddedJson(args) : args;
+          const resolvedArgs = artifactParser
+            ? await artifactParser.resolveArgs(parsedArgsForResolution)
+            : args;
 
-        if (ctx.durableWorkflowRunId && result && typeof result === 'object') {
-          const resultObj = result as Record<string, unknown>;
-          const taskResult = resultObj?.result as Record<string, unknown> | undefined;
-
-          const findApprovalRequired = (
-            parts: Array<Record<string, unknown>> | undefined
-          ): Record<string, unknown> | undefined => {
-            if (!Array.isArray(parts)) return undefined;
-            for (const part of parts) {
-              if (part?.kind === 'data') {
-                const data = part.data as Record<string, unknown> | undefined;
-                if (data?.type === DURABLE_APPROVAL_ARTIFACT_TYPE) return data;
+          const parameters = (toolDefinition as AiSdkToolDefinition).parameters;
+          if (artifactParser && parameters?.safeParse) {
+            const resolvedChanged =
+              JSON.stringify(parsedArgsForResolution) !== JSON.stringify(resolvedArgs);
+            if (resolvedChanged) {
+              const validation = parameters.safeParse(resolvedArgs);
+              if (!validation.success) {
+                throw new Error(
+                  `Resolved tool args failed schema validation for '${toolName}': ${validation.error.message}`
+                );
               }
             }
-            return undefined;
-          };
+          }
 
-          const findApprovalInArtifacts = (
-            artifacts: Array<Record<string, unknown>> | undefined
-          ): Record<string, unknown> | undefined => {
-            if (!Array.isArray(artifacts)) return undefined;
-            for (const artifact of artifacts) {
-              const found = findApprovalRequired(
-                artifact?.parts as Array<Record<string, unknown>> | undefined
-              );
-              if (found) return found;
-            }
-            return undefined;
-          };
+          const result = await originalExecute(resolvedArgs, context);
+          const duration = Date.now() - startTime;
 
-          const approvalDataRaw =
-            findApprovalRequired(taskResult?.parts as Array<Record<string, unknown>> | undefined) ??
-            findApprovalInArtifacts(
-              taskResult?.artifacts as Array<Record<string, unknown>> | undefined
-            );
+          if (ctx.durableWorkflowRunId && result && typeof result === 'object') {
+            const resultObj = result as Record<string, unknown>;
+            const taskResult = resultObj?.result as Record<string, unknown> | undefined;
 
-          if (approvalDataRaw) {
-            const approvalData = approvalDataRaw as unknown as DurableApprovalData;
-            const delegatedToolCallId = approvalData.toolCallId;
-            const delegatedToolName = approvalData.toolName;
-
-            if (typeof delegatedToolCallId !== 'string' || !delegatedToolCallId) {
-              logger.error(
-                { approvalData, parentToolName: toolName },
-                'Malformed durable-approval-required artifact: invalid toolCallId'
-              );
-              return result;
-            }
-            if (typeof delegatedToolName !== 'string' || !delegatedToolName) {
-              logger.error(
-                { approvalData, parentToolName: toolName },
-                'Malformed durable-approval-required artifact: invalid toolName'
-              );
-              return result;
-            }
-
-            ctx.pendingDurableApproval = {
-              toolCallId: toolCallId,
-              toolName,
-              args: resolvedArgs,
-              delegatedApproval: {
-                toolCallId: delegatedToolCallId,
-                toolName: delegatedToolName,
-                args: approvalData.args,
-                subAgentId: toolName.replace(DELEGATE_TOOL_PREFIX, ''),
-              },
+            const findApprovalRequired = (
+              parts: Array<Record<string, unknown>> | undefined
+            ): Record<string, unknown> | undefined => {
+              if (!Array.isArray(parts)) return undefined;
+              for (const part of parts) {
+                if (part?.kind === 'data') {
+                  const data = part.data as Record<string, unknown> | undefined;
+                  if (data?.type === DURABLE_APPROVAL_ARTIFACT_TYPE) return data;
+                }
+              }
+              return undefined;
             };
+
+            const findApprovalInArtifacts = (
+              artifacts: Array<Record<string, unknown>> | undefined
+            ): Record<string, unknown> | undefined => {
+              if (!Array.isArray(artifacts)) return undefined;
+              for (const artifact of artifacts) {
+                const found = findApprovalRequired(
+                  artifact?.parts as Array<Record<string, unknown>> | undefined
+                );
+                if (found) return found;
+              }
+              return undefined;
+            };
+
+            const approvalDataRaw =
+              findApprovalRequired(
+                taskResult?.parts as Array<Record<string, unknown>> | undefined
+              ) ??
+              findApprovalInArtifacts(
+                taskResult?.artifacts as Array<Record<string, unknown>> | undefined
+              );
+
+            if (approvalDataRaw) {
+              const approvalData = approvalDataRaw as unknown as DurableApprovalData;
+              const delegatedToolCallId = approvalData.toolCallId;
+              const delegatedToolName = approvalData.toolName;
+
+              if (typeof delegatedToolCallId !== 'string' || !delegatedToolCallId) {
+                logger.error(
+                  { approvalData },
+                  'Malformed durable-approval-required artifact: invalid toolCallId'
+                );
+                return result;
+              }
+              if (typeof delegatedToolName !== 'string' || !delegatedToolName) {
+                logger.error(
+                  { approvalData },
+                  'Malformed durable-approval-required artifact: invalid toolName'
+                );
+                return result;
+              }
+
+              ctx.pendingDurableApproval = {
+                toolCallId: toolCallId,
+                toolName,
+                args: resolvedArgs,
+                delegatedApproval: {
+                  toolCallId: delegatedToolCallId,
+                  toolName: delegatedToolName,
+                  args: approvalData.args,
+                  subAgentId: toolName.replace(DELEGATE_TOOL_PREFIX, ''),
+                },
+              };
+              return result;
+            }
+          }
+
+          if (ctx.pendingDurableApproval) {
             return result;
           }
-        }
 
-        if (ctx.pendingDurableApproval) {
-          return result;
-        }
+          const toolResultConversationId = ctx.conversationId;
 
-        const toolResultConversationId = ctx.conversationId;
-
-        if (streamRequestId && !skipHistoryStorage && toolResultConversationId) {
-          try {
-            const messageId = generateId();
-            const messageContent = await buildToolResultForConversationHistory(
-              ctx,
-              toolName,
-              args,
-              result,
-              toolCallId,
-              toolResultConversationId,
-              messageId
-            );
-            await createMessage(runDbClient)({
-              scopes: { tenantId: ctx.config.tenantId, projectId: ctx.config.projectId },
-              data: {
-                id: messageId,
-                conversationId: toolResultConversationId,
-                role: 'assistant',
-                content: messageContent,
-                visibility: 'internal',
-                messageType: 'tool-result',
-                fromSubAgentId: ctx.config.id,
-                metadata: {
-                  a2a_metadata: {
-                    toolName,
-                    toolCallId: toolCallId,
-                    toolArgs: args,
-                    toolOutput: result,
-                    timestamp: Date.now(),
-                    delegationId: ctx.delegationId,
-                    isDelegated: ctx.isDelegatedAgent,
+          if (streamRequestId && !skipHistoryStorage && toolResultConversationId) {
+            try {
+              const messageId = generateId();
+              const messageContent = await buildToolResultForConversationHistory(
+                ctx,
+                toolName,
+                args,
+                result,
+                toolCallId,
+                toolResultConversationId,
+                messageId
+              );
+              await createMessage(runDbClient)({
+                scopes: { tenantId: ctx.config.tenantId, projectId: ctx.config.projectId },
+                data: {
+                  id: messageId,
+                  conversationId: toolResultConversationId,
+                  role: 'assistant',
+                  content: messageContent,
+                  visibility: 'internal',
+                  messageType: 'tool-result',
+                  fromSubAgentId: ctx.config.id,
+                  metadata: {
+                    a2a_metadata: {
+                      toolName,
+                      toolCallId: toolCallId,
+                      toolArgs: args,
+                      toolOutput: result,
+                      timestamp: Date.now(),
+                      delegationId: ctx.delegationId,
+                      isDelegated: ctx.isDelegatedAgent,
+                    },
                   },
                 },
-              },
-            });
-          } catch (error) {
-            logger.warn(
+              });
+            } catch (error) {
+              logger.warn({ error }, 'Failed to store tool result in conversation history');
+            }
+          }
+
+          if (streamRequestId && !isInternalToolForUi) {
+            agentSessionManager.recordEvent(
+              streamRequestId,
+              SESSION_EVENT_TOOL_RESULT,
+              ctx.config.id,
               {
-                error,
                 toolName,
+                output: result,
                 toolCallId: toolCallId,
-                conversationId: toolResultConversationId,
-              },
-              'Failed to store tool result in conversation history'
+                duration,
+                relationshipId,
+                needsApproval,
+                inDelegatedAgent: ctx.isDelegatedAgent,
+              }
             );
           }
-        }
 
-        if (streamRequestId && !isInternalToolForUi) {
-          agentSessionManager.recordEvent(
-            streamRequestId,
-            SESSION_EVENT_TOOL_RESULT,
-            ctx.config.id,
-            {
-              toolName,
-              output: result,
-              toolCallId: toolCallId,
-              duration,
-              relationshipId,
-              needsApproval,
-              inDelegatedAgent: ctx.isDelegatedAgent,
+          const isDeniedResult = isToolResultDenied(result);
+
+          if (streamRequestId && streamHelper && !isInternalToolForUi) {
+            if (isDeniedResult) {
+              await streamHelper.writeToolOutputDenied({ toolCallId: toolCallId });
+            } else {
+              await streamHelper.writeToolOutputAvailable({
+                toolCallId: toolCallId,
+                output: result,
+              });
             }
-          );
-        }
+          }
 
-        const isDeniedResult = isToolResultDenied(result);
-
-        if (streamRequestId && streamHelper && !isInternalToolForUi) {
           if (isDeniedResult) {
-            await streamHelper.writeToolOutputDenied({ toolCallId: toolCallId });
-          } else {
-            await streamHelper.writeToolOutputAvailable({
+            return result.reason ?? 'Tool call was denied by the user.';
+          }
+
+          return result;
+        } catch (error) {
+          const duration = Date.now() - startTime;
+          const rootCause = unwrapError(error);
+          const errorMessage = rootCause.message;
+
+          if (streamRequestId && !isInternalToolForUi) {
+            agentSessionManager.recordEvent(
+              streamRequestId,
+              SESSION_EVENT_TOOL_RESULT,
+              ctx.config.id,
+              {
+                toolName,
+                output: null,
+                toolCallId: toolCallId,
+                duration,
+                error: errorMessage,
+                relationshipId,
+                needsApproval,
+                inDelegatedAgent: ctx.isDelegatedAgent,
+              }
+            );
+          }
+
+          if (streamRequestId && streamHelper && !isInternalToolForUi) {
+            await streamHelper.writeToolOutputError({
               toolCallId: toolCallId,
-              output: result,
+              errorText: errorMessage,
             });
           }
+
+          throw rootCause;
         }
-
-        if (isDeniedResult) {
-          return result.reason ?? 'Tool call was denied by the user.';
-        }
-
-        return result;
-      } catch (error) {
-        const duration = Date.now() - startTime;
-        const rootCause = unwrapError(error);
-        const errorMessage = rootCause.message;
-
-        if (streamRequestId && !isInternalToolForUi) {
-          agentSessionManager.recordEvent(
-            streamRequestId,
-            SESSION_EVENT_TOOL_RESULT,
-            ctx.config.id,
-            {
-              toolName,
-              output: null,
-              toolCallId: toolCallId,
-              duration,
-              error: errorMessage,
-              relationshipId,
-              needsApproval,
-              inDelegatedAgent: ctx.isDelegatedAgent,
-            }
-          );
-        }
-
-        if (streamRequestId && streamHelper && !isInternalToolForUi) {
-          await streamHelper.writeToolOutputError({
-            toolCallId: toolCallId,
-            errorText: errorMessage,
-          });
-        }
-
-        throw rootCause;
-      }
+      });
     },
   };
 }


### PR DESCRIPTION
## Summary
- Migrates `tool-approval.ts` and `tool-wrapper.ts` to the scoped logger context pattern (ALS) introduced in #3067
- These files were modified by #3062 and #3064 which merged after the logger migration but weren't updated to use `runWithLogContext`
- Adds logger scoped context guidance to AGENTS.md and updates the `api-logging-guidelines` skill

## Changes
- **`tool-approval.ts`**: Wraps `waitForToolApproval` and `parseAndCheckApproval` in `runWithLogContext({ toolCallId, toolName })`, strips repeated `toolName`/`toolCallId` from 8 logger calls
- **`tool-wrapper.ts`**: Wraps the `execute` closure in `runWithLogContext({ toolName, toolCallId })`, strips repeated fields from 3 logger calls
- **`AGENTS.md`**: New "Logger: Scoped Context Pattern" section documenting `getLogger`, `runWithLogContext`, and `.with()` patterns
- **`api-logging-guidelines` skill**: Updated to teach the ALS scoped context pattern as the primary approach

## Test plan
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm format` passes
- [x] All 153 test files pass (2244 tests), including `pending-approvals.test.ts`
- [x] Pre-commit hooks pass (lint-staged + test runner + artifact validation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)