### PR TITLE
feat: add GET /agents/{agentId}/tool-status endpoint

### DIFF
--- a/.changeset/marxist-black-fish.md
+++ b/.changeset/marxist-black-fish.md
@@ -1,0 +1,5 @@
+---
+"@inkeep/agents-api": patch
+---
+
+Add GET /agents/{agentId}/tool-status endpoint returning deduped MCP tool health per agent

--- a/agents-api/__snapshots__/openapi.json
+++ b/agents-api/__snapshots__/openapi.json
@@ -439,6 +439,68 @@
         },
         "type": "object"
       },
+      "AgentToolStatusItem": {
+        "properties": {
+          "expiresAt": {
+            "nullable": true,
+            "type": "string"
+          },
+          "id": {
+            "type": "string"
+          },
+          "imageUrl": {
+            "nullable": true,
+            "type": "string"
+          },
+          "lastError": {
+            "nullable": true,
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "status": {
+            "enum": [
+              "healthy",
+              "unhealthy",
+              "unknown",
+              "needs_auth",
+              "unavailable"
+            ],
+            "type": "string"
+          },
+          "subAgentIds": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "id",
+          "name",
+          "status",
+          "lastError",
+          "expiresAt",
+          "imageUrl",
+          "subAgentIds"
+        ],
+        "type": "object"
+      },
+      "AgentToolStatusResponse": {
+        "properties": {
+          "data": {
+            "items": {
+              "$ref": "#/components/schemas/AgentToolStatusItem"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "data"
+        ],
+        "type": "object"
+      },
       "AgentUpdate": {
         "properties": {
           "contextConfigId": {
@@ -24451,6 +24513,138 @@
         "x-authz": {
           "description": "Requires project edit permission (project_admin, or org admin/owner)",
           "permission": "edit",
+          "resource": "project"
+        }
+      }
+    },
+    "/manage/tenants/{tenantId}/projects/{projectId}/agents/{agentId}/tool-status": {
+      "get": {
+        "description": "Returns a deduped list of MCP tools used by any sub-agent of the given agent, with live health status. Probes each unique MCP server once.",
+        "operationId": "get-agent-tool-status",
+        "parameters": [
+          {
+            "description": "Tenant identifier",
+            "in": "path",
+            "name": "tenantId",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/TenantIdPathParam"
+            }
+          },
+          {
+            "description": "Project identifier",
+            "in": "path",
+            "name": "projectId",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/ProjectIdPathParam"
+            }
+          },
+          {
+            "description": "Agent identifier",
+            "in": "path",
+            "name": "agentId",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/AgentIdPathParam"
+            }
+          },
+          {
+            "in": "query",
+            "name": "status",
+            "required": false,
+            "schema": {
+              "enum": [
+                "healthy",
+                "unhealthy",
+                "unknown",
+                "needs_auth",
+                "unavailable"
+              ],
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AgentToolStatusResponse"
+                }
+              }
+            },
+            "description": "Agent tool status retrieved successfully"
+          },
+          "400": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BadRequest"
+                }
+              }
+            },
+            "description": "Bad Request"
+          },
+          "401": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Unauthorized"
+                }
+              }
+            },
+            "description": "Unauthorized"
+          },
+          "403": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Forbidden"
+                }
+              }
+            },
+            "description": "Forbidden"
+          },
+          "404": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NotFound"
+                }
+              }
+            },
+            "description": "Not Found"
+          },
+          "422": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UnprocessableEntity"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InternalServerError"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          }
+        },
+        "summary": "Get Tool Status for Agent",
+        "tags": [
+          "Agents",
+          "Tools"
+        ],
+        "x-authz": {
+          "description": "Requires project view permission (project_viewer+, or org admin/owner)",
+          "permission": "view",
           "resource": "project"
         }
       }

--- a/agents-api/__snapshots__/openapi.json
+++ b/agents-api/__snapshots__/openapi.json
@@ -487,7 +487,7 @@
         ],
         "type": "object"
       },
-      "AgentToolStatusResponse": {
+      "AgentToolStatusListResponse": {
         "properties": {
           "data": {
             "items": {
@@ -24570,7 +24570,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/AgentToolStatusResponse"
+                  "$ref": "#/components/schemas/AgentToolStatusListResponse"
                 }
               }
             },

--- a/agents-api/src/__tests__/manage/routes/crud/agent.test.ts
+++ b/agents-api/src/__tests__/manage/routes/crud/agent.test.ts
@@ -1053,5 +1053,16 @@ describe('Agent CRUD Routes - Integration Tests', () => {
       );
       expect(res.status).toBe(404);
     });
+
+    it('should return 400 for invalid status query param', async () => {
+      const tenantId = await createTestTenantWithOrg('agent-tool-status-invalid');
+      await createTestProject(manageDbClient, tenantId, projectId);
+      const { agentId } = await createTestAgent({ tenantId });
+
+      const res = await makeRequest(
+        `/manage/tenants/${tenantId}/projects/${projectId}/agents/${agentId}/tool-status?status=bogus`
+      );
+      expect(res.status).toBe(400);
+    });
   });
 });

--- a/agents-api/src/__tests__/manage/routes/crud/agent.test.ts
+++ b/agents-api/src/__tests__/manage/routes/crud/agent.test.ts
@@ -1,7 +1,8 @@
-import { generateId } from '@inkeep/agents-core';
+import { generateId, MCPTransportType } from '@inkeep/agents-core';
 import { createTestProject } from '@inkeep/agents-core/db/test-manage-client';
 import { describe, expect, it } from 'vitest';
 import manageDbClient from '../../../../data/db/manageDbClient';
+import { createTestAgentToolRelationData } from '../../../utils/testHelpers';
 import { makeRequest } from '../../../utils/testRequest';
 import { createTestSubAgentData } from '../../../utils/testSubAgent';
 import { createTestTenantWithOrg } from '../../../utils/testTenant';
@@ -893,6 +894,164 @@ describe('Agent CRUD Routes - Integration Tests', () => {
       expect(body.data.subAgents[subAgentId].canTransferTo).toEqual([]);
       expect(body.data.subAgents[subAgentId].canDelegateTo).toEqual([]);
       expect(body.data.subAgents[subAgentId].canUse).toEqual([]);
+    });
+  });
+
+  describe('GET /{agentId}/tool-status', () => {
+    const createTestTool = async ({
+      tenantId,
+      suffix = '',
+    }: {
+      tenantId: string;
+      suffix?: string;
+    }) => {
+      const toolData = {
+        id: generateId(),
+        name: `Test MCP Tool${suffix}`,
+        description: `Test MCP tool description${suffix}`,
+        config: {
+          type: 'mcp' as const,
+          mcp: {
+            server: {
+              url: 'https://api.example.com/mcp',
+              timeout: 5000,
+            },
+            transport: {
+              type: MCPTransportType.streamableHttp,
+              requestInit: {},
+            },
+            activeTools: ['test-function'],
+          },
+        },
+      };
+      const res = await makeRequest(`/manage/tenants/${tenantId}/projects/${projectId}/tools`, {
+        method: 'POST',
+        body: JSON.stringify(toolData),
+      });
+      expect(res.status).toBe(201);
+      const body = await res.json();
+      return body.data.id as string;
+    };
+
+    const linkToolToSubAgent = async ({
+      tenantId,
+      agentId,
+      subAgentId,
+      toolId,
+    }: {
+      tenantId: string;
+      agentId: string;
+      subAgentId: string;
+      toolId: string;
+    }) => {
+      const relationData = createTestAgentToolRelationData({ agentId, subAgentId, toolId });
+      const res = await makeRequest(
+        `/manage/tenants/${tenantId}/projects/${projectId}/agents/${agentId}/sub-agent-tool-relations`,
+        {
+          method: 'POST',
+          body: JSON.stringify(relationData),
+        }
+      );
+      expect(res.status).toBe(201);
+    };
+
+    it('should return empty list when agent has no sub-agent tool relations', async () => {
+      const tenantId = await createTestTenantWithOrg('agent-tool-status-empty');
+      await createTestProject(manageDbClient, tenantId, projectId);
+      const { agentId } = await createTestAgent({ tenantId });
+
+      const res = await makeRequest(
+        `/manage/tenants/${tenantId}/projects/${projectId}/agents/${agentId}/tool-status`
+      );
+
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.data).toEqual([]);
+    });
+
+    it('should dedupe tools shared across sub-agents and aggregate subAgentIds', async () => {
+      const tenantId = await createTestTenantWithOrg('agent-tool-status-dedupe');
+      await createTestProject(manageDbClient, tenantId, projectId);
+      const { agentId } = await createTestAgent({ tenantId });
+
+      const { subAgentId: subAgent1 } = await createTestSubAgent({
+        tenantId,
+        agentId,
+        suffix: ' One',
+      });
+      const { subAgentId: subAgent2 } = await createTestSubAgent({
+        tenantId,
+        agentId,
+        suffix: ' Two',
+      });
+
+      // SubAgent1: Linear + Asana ; SubAgent2: Asana + Hubspot
+      const linearId = await createTestTool({ tenantId, suffix: ' Linear' });
+      const asanaId = await createTestTool({ tenantId, suffix: ' Asana' });
+      const hubspotId = await createTestTool({ tenantId, suffix: ' Hubspot' });
+
+      await linkToolToSubAgent({ tenantId, agentId, subAgentId: subAgent1, toolId: linearId });
+      await linkToolToSubAgent({ tenantId, agentId, subAgentId: subAgent1, toolId: asanaId });
+      await linkToolToSubAgent({ tenantId, agentId, subAgentId: subAgent2, toolId: asanaId });
+      await linkToolToSubAgent({ tenantId, agentId, subAgentId: subAgent2, toolId: hubspotId });
+
+      const res = await makeRequest(
+        `/manage/tenants/${tenantId}/projects/${projectId}/agents/${agentId}/tool-status`
+      );
+      expect(res.status).toBe(200);
+      const body = await res.json();
+
+      // 3 unique tools, not 4
+      expect(body.data).toHaveLength(3);
+      const byId = new Map<string, any>(body.data.map((t: any) => [t.id, t]));
+
+      expect(byId.get(linearId).subAgentIds).toEqual([subAgent1]);
+      expect(byId.get(hubspotId).subAgentIds).toEqual([subAgent2]);
+      expect(byId.get(asanaId).subAgentIds.sort()).toEqual([subAgent1, subAgent2].sort());
+
+      // Live probe runs against an unreachable URL → unhealthy (or needs_auth)
+      for (const item of body.data) {
+        expect(item.status).toBeDefined();
+        expect(item).toHaveProperty('lastError');
+      }
+    });
+
+    it('should filter by status when ?status= is provided', async () => {
+      const tenantId = await createTestTenantWithOrg('agent-tool-status-filter');
+      await createTestProject(manageDbClient, tenantId, projectId);
+      const { agentId } = await createTestAgent({ tenantId });
+      const { subAgentId } = await createTestSubAgent({ tenantId, agentId });
+      const toolId = await createTestTool({ tenantId });
+      await linkToolToSubAgent({ tenantId, agentId, subAgentId, toolId });
+
+      // Discover what status the probe assigned (test URL → not 'healthy')
+      const allRes = await makeRequest(
+        `/manage/tenants/${tenantId}/projects/${projectId}/agents/${agentId}/tool-status`
+      );
+      const allBody = await allRes.json();
+      const actualStatus = allBody.data[0].status;
+
+      const matchRes = await makeRequest(
+        `/manage/tenants/${tenantId}/projects/${projectId}/agents/${agentId}/tool-status?status=${actualStatus}`
+      );
+      expect(matchRes.status).toBe(200);
+      expect((await matchRes.json()).data).toHaveLength(1);
+
+      const missRes = await makeRequest(
+        `/manage/tenants/${tenantId}/projects/${projectId}/agents/${agentId}/tool-status?status=healthy`
+      );
+      expect(missRes.status).toBe(200);
+      expect((await missRes.json()).data).toEqual([]);
+    });
+
+    it('should return 404 when agent does not exist', async () => {
+      const tenantId = await createTestTenantWithOrg('agent-tool-status-404');
+      await createTestProject(manageDbClient, tenantId, projectId);
+
+      const res = await makeRequest(
+        `/manage/tenants/${tenantId}/projects/${projectId}/agents/non-existent-agent/tool-status`
+      );
+      expect(res.status).toBe(404);
     });
   });
 });

--- a/agents-api/src/domains/manage/routes/agent.ts
+++ b/agents-api/src/domains/manage/routes/agent.ts
@@ -20,7 +20,6 @@ import {
   listAgentToolRelations,
   PaginationQueryParamsSchema,
   RelatedAgentInfoListResponse,
-  type SubAgentToolRelationSelect,
   TenantProjectAgentParamsSchema,
   TenantProjectAgentSubAgentParamsSchema,
   TenantProjectIdParamsSchema,
@@ -222,11 +221,11 @@ const AgentToolStatusItemSchema = z
   })
   .openapi('AgentToolStatusItem');
 
-const AgentToolStatusResponseSchema = z
+const AgentToolStatusListResponseSchema = z
   .object({
     data: z.array(AgentToolStatusItemSchema),
   })
-  .openapi('AgentToolStatusResponse');
+  .openapi('AgentToolStatusListResponse');
 
 app.openapi(
   createProtectedRoute({
@@ -249,7 +248,7 @@ app.openapi(
         description: 'Agent tool status retrieved successfully',
         content: {
           'application/json': {
-            schema: AgentToolStatusResponseSchema,
+            schema: AgentToolStatusListResponseSchema,
           },
         },
       },
@@ -273,33 +272,46 @@ app.openapi(
       });
     }
 
-    const relationsResult = await listAgentToolRelations(db)({
-      scopes: { tenantId, projectId, agentId },
-      pagination: { page: 1, limit: 100 },
-    });
-    const relations = relationsResult.data as SubAgentToolRelationSelect[];
-
     const subAgentIdsByToolId = new Map<string, Set<string>>();
-    for (const relation of relations) {
-      const set = subAgentIdsByToolId.get(relation.toolId) ?? new Set<string>();
-      set.add(relation.subAgentId);
-      subAgentIdsByToolId.set(relation.toolId, set);
+    let page = 1;
+    let hasMore = true;
+    while (hasMore) {
+      const relationsResult = await listAgentToolRelations(db)({
+        scopes: { tenantId, projectId, agentId },
+        pagination: { page, limit: 100 },
+      });
+      for (const relation of relationsResult.data) {
+        const set = subAgentIdsByToolId.get(relation.toolId) ?? new Set<string>();
+        set.add(relation.subAgentId);
+        subAgentIdsByToolId.set(relation.toolId, set);
+      }
+      hasMore = page < relationsResult.pagination.pages;
+      page++;
     }
 
     const uniqueToolIds = Array.from(subAgentIdsByToolId.keys());
 
-    const probedTools = await Promise.all(
-      uniqueToolIds.map(async (toolId) => {
-        const tool = await getToolById(db)({ scopes: { tenantId, projectId }, toolId });
-        if (!tool) {
-          return null;
+    const PROBE_CONCURRENCY = 5;
+    const probedTools: Awaited<ReturnType<typeof dbResultToMcpTool>>[] = [];
+    for (let i = 0; i < uniqueToolIds.length; i += PROBE_CONCURRENCY) {
+      const batch = uniqueToolIds.slice(i, i + PROBE_CONCURRENCY);
+      const results = await Promise.allSettled(
+        batch.map(async (toolId) => {
+          const tool = await getToolById(db)({ scopes: { tenantId, projectId }, toolId });
+          if (!tool) {
+            return null;
+          }
+          return dbResultToMcpTool(tool, db, credentialStores, undefined, userId);
+        })
+      );
+      for (const r of results) {
+        if (r.status === 'fulfilled' && r.value !== null) {
+          probedTools.push(r.value);
         }
-        return dbResultToMcpTool(tool, db, credentialStores, undefined, userId);
-      })
-    );
+      }
+    }
 
     const data = probedTools
-      .filter((tool): tool is NonNullable<typeof tool> => tool !== null)
       .map((tool) => ({
         id: tool.id,
         name: tool.name,

--- a/agents-api/src/domains/manage/routes/agent.ts
+++ b/agents-api/src/domains/manage/routes/agent.ts
@@ -8,24 +8,30 @@ import {
   commonGetErrorResponses,
   createAgent,
   createApiError,
+  dbResultToMcpTool,
   deleteAgent,
   ErrorResponseSchema,
   generateId,
   getAgentById,
   getAgentSubAgentInfos,
   getFullAgentDefinition,
+  getToolById,
   listAgentsPaginated,
+  listAgentToolRelations,
   PaginationQueryParamsSchema,
   RelatedAgentInfoListResponse,
+  type SubAgentToolRelationSelect,
   TenantProjectAgentParamsSchema,
   TenantProjectAgentSubAgentParamsSchema,
   TenantProjectIdParamsSchema,
   TenantProjectParamsSchema,
+  ToolStatusSchema,
   throwIfUniqueConstraintError,
   updateAgent,
 } from '@inkeep/agents-core';
 import { createProtectedRoute } from '@inkeep/agents-core/middleware';
 import { clearWorkspaceConnectionCache } from '@inkeep/agents-work-apps/slack';
+import { z } from 'zod';
 import { requireProjectPermission } from '../../../middleware/projectAccess';
 import type { ManageAppVariables } from '../../../types/app';
 import {
@@ -201,6 +207,111 @@ app.openapi(
     }
 
     return c.json({ data: fullAgent });
+  }
+);
+
+const AgentToolStatusItemSchema = z
+  .object({
+    id: z.string(),
+    name: z.string(),
+    status: ToolStatusSchema,
+    lastError: z.string().nullable(),
+    expiresAt: z.string().nullable(),
+    imageUrl: z.string().nullable(),
+    subAgentIds: z.array(z.string()),
+  })
+  .openapi('AgentToolStatusItem');
+
+const AgentToolStatusResponseSchema = z
+  .object({
+    data: z.array(AgentToolStatusItemSchema),
+  })
+  .openapi('AgentToolStatusResponse');
+
+app.openapi(
+  createProtectedRoute({
+    method: 'get',
+    path: '/{agentId}/tool-status',
+    summary: 'Get Tool Status for Agent',
+    description:
+      'Returns a deduped list of MCP tools used by any sub-agent of the given agent, with live health status. Probes each unique MCP server once.',
+    operationId: 'get-agent-tool-status',
+    tags: ['Agents', 'Tools'],
+    permission: requireProjectPermission('view'),
+    request: {
+      params: TenantProjectAgentParamsSchema,
+      query: z.object({
+        status: ToolStatusSchema.optional(),
+      }),
+    },
+    responses: {
+      200: {
+        description: 'Agent tool status retrieved successfully',
+        content: {
+          'application/json': {
+            schema: AgentToolStatusResponseSchema,
+          },
+        },
+      },
+      ...commonGetErrorResponses,
+    },
+  }),
+  async (c) => {
+    const db = c.get('db');
+    const { tenantId, projectId, agentId } = c.req.valid('param');
+    const { status: statusFilter } = c.req.valid('query');
+    const credentialStores = c.get('credentialStores');
+    const userId = c.get('userId');
+
+    const agent = await getAgentById(db)({
+      scopes: { tenantId, projectId, agentId },
+    });
+    if (!agent) {
+      throw createApiError({
+        code: 'not_found',
+        message: 'Agent not found',
+      });
+    }
+
+    const relationsResult = await listAgentToolRelations(db)({
+      scopes: { tenantId, projectId, agentId },
+      pagination: { page: 1, limit: 100 },
+    });
+    const relations = relationsResult.data as SubAgentToolRelationSelect[];
+
+    const subAgentIdsByToolId = new Map<string, Set<string>>();
+    for (const relation of relations) {
+      const set = subAgentIdsByToolId.get(relation.toolId) ?? new Set<string>();
+      set.add(relation.subAgentId);
+      subAgentIdsByToolId.set(relation.toolId, set);
+    }
+
+    const uniqueToolIds = Array.from(subAgentIdsByToolId.keys());
+
+    const probedTools = await Promise.all(
+      uniqueToolIds.map(async (toolId) => {
+        const tool = await getToolById(db)({ scopes: { tenantId, projectId }, toolId });
+        if (!tool) {
+          return null;
+        }
+        return dbResultToMcpTool(tool, db, credentialStores, undefined, userId);
+      })
+    );
+
+    const data = probedTools
+      .filter((tool): tool is NonNullable<typeof tool> => tool !== null)
+      .map((tool) => ({
+        id: tool.id,
+        name: tool.name,
+        status: tool.status,
+        lastError: tool.lastError ?? null,
+        expiresAt: tool.expiresAt ?? null,
+        imageUrl: tool.imageUrl ?? null,
+        subAgentIds: Array.from(subAgentIdsByToolId.get(tool.id) ?? []),
+      }))
+      .filter((tool) => (statusFilter ? tool.status === statusFilter : true));
+
+    return c.json({ data });
   }
 );
 


### PR DESCRIPTION
## Summary
- Adds `GET /agents/{agentId}/tool-status` endpoint that returns deduped MCP tool health across all sub-agents
- Each unique MCP server is probed once; results include `status`, `lastError`, `expiresAt`, `imageUrl`, and which `subAgentIds` use the tool
- Supports optional `?status=` query param for filtering (e.g. `?status=healthy`)
- Returns 404 when the agent doesn't exist

## Test plan
- [x] Empty state — agent with no tool relations returns `[]`
- [x] Dedup/aggregation — shared tools appear once with all sub-agent IDs aggregated
- [x] Status filtering — `?status=` returns only matching tools; mismatched filter returns `[]`
- [x] 404 — non-existent agent returns 404
- [x] All 31 agent CRUD tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)