### PR TITLE
fix: preserve message file parts through A2A transfers and compression

### DIFF
--- a/.changeset/optimistic-amaranth-mastodon.md
+++ b/.changeset/optimistic-amaranth-mastodon.md
@@ -1,0 +1,5 @@
+---
+"@inkeep/agents-api": patch
+---
+
+Preserve message file parts through A2A transfers, compression, and history reconstruction

--- a/agents-api/src/__tests__/run/data/conversations.test.ts
+++ b/agents-api/src/__tests__/run/data/conversations.test.ts
@@ -1,34 +1,50 @@
 import type { MessageSelect } from '@inkeep/agents-core';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import {
   formatMessagesAsConversationHistory,
   reconstructMessageText,
 } from '../../../domains/run/data/conversations';
 
+const mockDownload = vi.fn();
+
+vi.mock('../../../domains/run/services/blob-storage', async () => {
+  const actual = await vi.importActual<typeof import('../../../domains/run/services/blob-storage')>(
+    '../../../domains/run/services/blob-storage'
+  );
+  return {
+    ...actual,
+    getBlobStorageProvider: () => ({
+      download: mockDownload,
+      upload: vi.fn(),
+      delete: vi.fn(),
+    }),
+  };
+});
+
 describe('reconstructMessageText', () => {
-  it('falls back to content.text when content has no parts array', () => {
+  it('falls back to content.text when content has no parts array', async () => {
     const msg = { content: { text: 'Hello world' } };
-    expect(reconstructMessageText(msg)).toBe('Hello world');
+    await expect(reconstructMessageText(msg)).resolves.toBe('Hello world');
   });
 
-  it('falls back to content.text when parts is empty', () => {
+  it('falls back to content.text when parts is empty', async () => {
     const msg = { content: { text: 'fallback text', parts: [] } };
-    expect(reconstructMessageText(msg)).toBe('fallback text');
+    await expect(reconstructMessageText(msg)).resolves.toBe('fallback text');
   });
 
-  it('returns empty string when content has no text and no parts', () => {
+  it('returns empty string when content has no text and no parts', async () => {
     const msg = { content: {} };
-    expect(reconstructMessageText(msg)).toBe('');
+    await expect(reconstructMessageText(msg)).resolves.toBe('');
   });
 
-  it('uses part.type when kind is omitted (legacy shape)', () => {
+  it('uses part.type when kind is omitted (legacy shape)', async () => {
     const msg = {
       content: { parts: [{ type: 'text', text: 'legacy' } as any] },
     } as Pick<MessageSelect, 'content'>;
-    expect(reconstructMessageText(msg)).toBe('legacy');
+    await expect(reconstructMessageText(msg)).resolves.toBe('legacy');
   });
 
-  it('concatenates text parts in order', () => {
+  it('concatenates text parts in order', async () => {
     const msg = {
       content: {
         parts: [
@@ -37,19 +53,21 @@ describe('reconstructMessageText', () => {
         ],
       },
     };
-    expect(reconstructMessageText(msg)).toBe('Hello world');
+    await expect(reconstructMessageText(msg)).resolves.toBe('Hello world');
   });
 
-  it('converts data parts with artifactId + toolCallId to artifact:ref tags', () => {
+  it('converts data parts with artifactId + toolCallId to artifact:ref tags', async () => {
     const msg = {
       content: {
         parts: [{ kind: 'data', data: { artifactId: 'art-1', toolCallId: 'tool-1' } }],
       },
     };
-    expect(reconstructMessageText(msg)).toBe('<artifact:ref id="art-1" tool="tool-1" />');
+    await expect(reconstructMessageText(msg)).resolves.toBe(
+      '<artifact:ref id="art-1" tool="tool-1" />'
+    );
   });
 
-  it('interleaves text and artifact:ref tags correctly', () => {
+  it('interleaves text and artifact:ref tags correctly', async () => {
     const msg = {
       content: {
         parts: [
@@ -59,12 +77,12 @@ describe('reconstructMessageText', () => {
         ],
       },
     };
-    expect(reconstructMessageText(msg)).toBe(
+    await expect(reconstructMessageText(msg)).resolves.toBe(
       'Here is the result. <artifact:ref id="art-abc" tool="toolu_xyz" /> And more text.'
     );
   });
 
-  it('handles data parts with JSON string data', () => {
+  it('handles data parts with JSON string data', async () => {
     const msg = {
       content: {
         parts: [
@@ -75,46 +93,48 @@ describe('reconstructMessageText', () => {
         ],
       },
     };
-    expect(reconstructMessageText(msg)).toBe('<artifact:ref id="art-json" tool="tool-json" />');
+    await expect(reconstructMessageText(msg)).resolves.toBe(
+      '<artifact:ref id="art-json" tool="tool-json" />'
+    );
   });
 
-  it('ignores data parts without artifactId', () => {
+  it('ignores data parts without artifactId', async () => {
     const msg = {
       content: {
         parts: [{ kind: 'data', data: { toolCallId: 'tool-1' } }],
       },
     };
-    expect(reconstructMessageText(msg)).toBe('');
+    await expect(reconstructMessageText(msg)).resolves.toBe('');
   });
 
-  it('ignores data parts without toolCallId', () => {
+  it('ignores data parts without toolCallId', async () => {
     const msg = {
       content: {
         parts: [{ kind: 'data', data: { artifactId: 'art-1' } }],
       },
     };
-    expect(reconstructMessageText(msg)).toBe('');
+    await expect(reconstructMessageText(msg)).resolves.toBe('');
   });
 
-  it('ignores data parts with unparseable JSON string', () => {
+  it('ignores data parts with unparseable JSON string', async () => {
     const msg = {
       content: {
         parts: [{ kind: 'data', data: 'not-valid-json' }],
       },
     };
-    expect(reconstructMessageText(msg)).toBe('');
+    await expect(reconstructMessageText(msg)).resolves.toBe('');
   });
 
-  it('returns empty string for unknown part types', () => {
+  it('returns empty string for unknown part types', async () => {
     const msg = {
       content: {
         parts: [{ kind: 'image' }],
       },
     };
-    expect(reconstructMessageText(msg)).toBe('');
+    await expect(reconstructMessageText(msg)).resolves.toBe('');
   });
 
-  it('handles multiple artifact refs in a single message', () => {
+  it('handles multiple artifact refs in a single message', async () => {
     const msg = {
       content: {
         parts: [
@@ -125,18 +145,155 @@ describe('reconstructMessageText', () => {
         ],
       },
     };
-    expect(reconstructMessageText(msg)).toBe(
+    await expect(reconstructMessageText(msg)).resolves.toBe(
       'First: <artifact:ref id="art-1" tool="tool-1" /> Second: <artifact:ref id="art-2" tool="tool-2" />'
     );
   });
 
-  it('handles missing text property in text part gracefully', () => {
+  it('handles missing text property in text part gracefully', async () => {
     const msg = {
       content: {
         parts: [{ kind: 'text' }],
       },
     };
-    expect(reconstructMessageText(msg)).toBe('');
+    await expect(reconstructMessageText(msg)).resolves.toBe('');
+  });
+
+  describe('file parts', () => {
+    const TEXT_CONTENT = 'hello from file';
+    const textB64 = Buffer.from(TEXT_CONTENT, 'utf-8').toString('base64');
+
+    it('inlines file content from A2A wire shape with base64 bytes', async () => {
+      const msg = {
+        content: {
+          parts: [
+            {
+              kind: 'file',
+              file: { bytes: textB64, mimeType: 'text/plain' },
+              metadata: { filename: 'notes.txt' },
+            } as any,
+          ],
+        },
+      };
+      await expect(reconstructMessageText(msg)).resolves.toBe(
+        `<file name="notes.txt">\n${TEXT_CONTENT}\n</file>`
+      );
+    });
+
+    it('inlines file content from A2A wire shape with a data-URI', async () => {
+      const msg = {
+        content: {
+          parts: [
+            {
+              kind: 'file',
+              file: { uri: `data:text/plain;base64,${textB64}` },
+              metadata: { filename: 'notes.txt' },
+            } as any,
+          ],
+        },
+      };
+      await expect(reconstructMessageText(msg)).resolves.toBe(
+        `<file name="notes.txt">\n${TEXT_CONTENT}\n</file>`
+      );
+    });
+
+    it('inlines file content from persisted-content shape with a data-URI', async () => {
+      const msg = {
+        content: {
+          parts: [
+            {
+              kind: 'file',
+              data: `data:text/plain;base64,${textB64}`,
+              metadata: { filename: 'notes.txt' },
+            } as any,
+          ],
+        },
+      };
+      await expect(reconstructMessageText(msg)).resolves.toBe(
+        `<file name="notes.txt">\n${TEXT_CONTENT}\n</file>`
+      );
+    });
+
+    it('downloads and inlines file content from a blob:// URI via the storage provider', async () => {
+      mockDownload.mockResolvedValueOnce({
+        data: Buffer.from(TEXT_CONTENT, 'utf-8'),
+        contentType: 'text/plain',
+      });
+      const msg = {
+        content: {
+          parts: [
+            {
+              kind: 'file',
+              data: 'blob://some/key/notes.txt',
+              metadata: { filename: 'notes.txt' },
+            } as any,
+          ],
+        },
+      };
+      await expect(reconstructMessageText(msg)).resolves.toBe(
+        `<file name="notes.txt">\n${TEXT_CONTENT}\n</file>`
+      );
+      expect(mockDownload).toHaveBeenCalledWith('some/key/notes.txt');
+    });
+
+    it('returns a placeholder when the blob download fails', async () => {
+      mockDownload.mockRejectedValueOnce(new Error('not found'));
+      const msg = {
+        content: {
+          parts: [
+            {
+              kind: 'file',
+              data: 'blob://missing/key',
+              metadata: { filename: 'missing.txt' },
+            } as any,
+          ],
+        },
+      };
+      await expect(reconstructMessageText(msg)).resolves.toBe('<file name="missing.txt" />');
+    });
+
+    it('emits a filename placeholder for external http(s) URIs', async () => {
+      const msg = {
+        content: {
+          parts: [
+            {
+              kind: 'file',
+              data: 'https://example.com/notes.txt',
+              metadata: { filename: 'notes.txt' },
+            } as any,
+          ],
+        },
+      };
+      await expect(reconstructMessageText(msg)).resolves.toBe('<file name="notes.txt" />');
+    });
+
+    it('interleaves file content with surrounding text parts', async () => {
+      const msg = {
+        content: {
+          parts: [
+            { kind: 'text', text: 'Before. ' },
+            {
+              kind: 'file',
+              data: `data:text/plain;base64,${textB64}`,
+              metadata: { filename: 'notes.txt' },
+            } as any,
+            { kind: 'text', text: ' After.' },
+          ],
+        },
+      };
+      await expect(reconstructMessageText(msg)).resolves.toBe(
+        `Before. <file name="notes.txt">\n${TEXT_CONTENT}\n</file> After.`
+      );
+    });
+
+    it('returns empty string for a file part with no usable content and no filename', async () => {
+      const msg = {
+        content: {
+          parts: [{ kind: 'file' } as any],
+        },
+      };
+      await expect(reconstructMessageText(msg)).resolves.toBe('');
+    });
   });
 });
 

--- a/agents-api/src/domains/run/a2a/handlers.ts
+++ b/agents-api/src/domains/run/a2a/handlers.ts
@@ -4,6 +4,7 @@ import {
   generateId,
   type Message,
   type MessageSendParams,
+  type Part,
   type Task,
   TaskState,
   updateTask,
@@ -225,6 +226,20 @@ async function handleMessageSend(
         .map((part) => (part as any).text)
         .join(' ');
 
+      // Serialize file parts for JSONB storage — ensure bytes are a base64 string, not a
+      // Buffer/typed array that would lose fidelity when JSON-encoded.
+      const serializableParts: Part[] = params.message.parts.map((part) => {
+        if (part.kind === 'file' && 'bytes' in part.file && part.file.bytes) {
+          const rawBytes = part.file.bytes as unknown;
+          const bytesStr =
+            typeof rawBytes === 'string'
+              ? rawBytes
+              : Buffer.from(rawBytes as Uint8Array).toString('base64');
+          return { ...part, file: { ...part.file, bytes: bytesStr } };
+        }
+        return part;
+      });
+
       try {
         const messageData: any = {
           id: generateId(),
@@ -234,6 +249,7 @@ async function handleMessageSend(
           role: 'agent',
           content: {
             text: messageText,
+            parts: serializableParts,
           },
           visibility: params.message.metadata?.fromExternalAgentId ? 'external' : 'internal',
           messageType: 'a2a-request',

--- a/agents-api/src/domains/run/data/conversations.ts
+++ b/agents-api/src/domains/run/data/conversations.ts
@@ -19,6 +19,7 @@ import {
   CONVERSATION_ARTIFACTS_LIMIT,
   CONVERSATION_HISTORY_DEFAULT_LIMIT,
 } from '../constants/execution-limits';
+import { fromBlobUri, getBlobStorageProvider, isBlobUri } from '../services/blob-storage';
 
 const logger = getLogger('conversations');
 
@@ -627,6 +628,18 @@ async function performActualCompression(
     return messages;
   }
 
+  // Preserve messages that contain file parts — these must survive compression
+  // because the widget may not re-send files on follow-up messages (diffed by content),
+  // and the compressor cannot meaningfully summarize binary file content.
+  const fileMessages = messages.filter((msg) => {
+    const parts = msg.content?.parts;
+    if (!Array.isArray(parts)) return false;
+    return parts.some((p) => {
+      const kind = (p as { kind?: string; type?: string }).kind ?? (p as { type?: string }).type;
+      return kind === 'file';
+    });
+  });
+
   logger.info(
     {
       conversationId,
@@ -676,9 +689,9 @@ async function performActualCompression(
         'Conversation compression saved to messages table'
       );
 
-      // Return just the compression summary message
+      // Return compression summary + any preserved file-bearing messages
       compressor.fullCleanup();
-      return [compressionMessage];
+      return [...fileMessages, compressionMessage];
     }
 
     compressor.fullCleanup();
@@ -866,10 +879,74 @@ function buildCompressionSummaryMessage(summary: any, artifactIds: string[]): st
 }
 
 /**
+ * A `file` part can reach history reconstruction in two shapes:
+ *  - A2A wire shape (persisted by `a2a/handlers.ts` from inbound delegation requests):
+ *      `{ kind: 'file', file: { bytes } | { uri }, metadata }`
+ *  - Persisted-content shape (written by `makeMessageContentParts` on the widget upload path):
+ *      `{ kind: 'file', data: '<blob://…>' | '<data:…>' | '<http(s)://…>', metadata }`
+ */
+type FilePartLike = {
+  kind: 'file';
+  file?: { bytes?: string; uri?: string };
+  data?: string;
+  metadata?: { filename?: string; mimeType?: string; [key: string]: unknown };
+};
+
+function tryDecodeDataUri(uri: string): string | undefined {
+  const base64Data = uri.split(',')[1];
+  if (!base64Data) return undefined;
+  try {
+    return Buffer.from(base64Data, 'base64').toString('utf-8');
+  } catch {
+    return undefined;
+  }
+}
+
+async function reconstructFilePart(part: FilePartLike): Promise<string> {
+  const filename = part.metadata?.filename;
+  const file = part.file;
+  const persistedData = part.data;
+
+  let fileContent: string | undefined;
+
+  if (file?.bytes) {
+    try {
+      fileContent = Buffer.from(file.bytes, 'base64').toString('utf-8');
+    } catch {
+      // binary or invalid base64 — fall through to placeholder
+    }
+  } else if (file?.uri?.startsWith('data:')) {
+    fileContent = tryDecodeDataUri(file.uri);
+  } else if (persistedData?.startsWith('data:')) {
+    fileContent = tryDecodeDataUri(persistedData);
+  } else if (persistedData && isBlobUri(persistedData)) {
+    try {
+      const downloaded = await getBlobStorageProvider().download(fromBlobUri(persistedData));
+      fileContent = Buffer.from(downloaded.data).toString('utf-8');
+    } catch (err) {
+      logger.warn(
+        { err, filename },
+        'reconstructMessageText: failed to download file part from blob storage'
+      );
+    }
+  }
+  // External http(s) URIs are not inlined — fall through to the filename placeholder.
+
+  if (fileContent) {
+    const label = filename ? `<file name="${filename}">` : '<file>';
+    return `${label}\n${fileContent}\n</file>`;
+  }
+  if (filename) {
+    return `<file name="${filename}" />`;
+  }
+  return '';
+}
+
+/**
  * Reconstruct message text from multi-part content, converting artifact data parts to `<artifact:ref>` tags.
  * Falls back to `content.text` when there are no parts or when parts yield no reconstructable text.
  */
-export function reconstructMessageText(msg: Pick<MessageSelect, 'content'>): string {
+export async function reconstructMessageText(msg: Pick<MessageSelect, 'content'>): Promise<string> {
   const parts = msg.content?.parts ?? [];
   const textFallback = msg.content?.text ?? '';
 
@@ -877,13 +954,16 @@ export function reconstructMessageText(msg: Pick<MessageSelect, 'content'>): str
     return textFallback;
   }
 
-  const fromParts = parts
-    .map((part: any) => {
+  const fromParts = await Promise.all(
+    parts.map(async (part: any) => {
       // Canonical `MessageContent.parts` use `kind`; older persisted rows and some external payloads might still use `type`.
       const partKind = part.kind ?? part.type;
 
       if (partKind === 'text') {
         return part.text ?? '';
+      }
+      if (partKind === 'file') {
+        return await reconstructFilePart(part as FilePartLike);
       }
       if (partKind === 'data') {
         try {
@@ -897,9 +977,9 @@ export function reconstructMessageText(msg: Pick<MessageSelect, 'content'>): str
       }
       return '';
     })
-    .join('');
+  );
 
-  return fromParts || textFallback;
+  return fromParts.join('') || textFallback;
 }
 
 export async function formatMessagesAsConversationHistory(
@@ -935,7 +1015,7 @@ export async function formatMessagesAsConversationHistory(
         roleLabel = msg.role || 'system';
       }
 
-      const reconstructedMessage = reconstructMessageText(msg);
+      const reconstructedMessage = await reconstructMessageText(msg);
       if (!reconstructedMessage) {
         return null;
       }

--- a/agents-api/src/domains/run/handlers/executionHandler.ts
+++ b/agents-api/src/domains/run/handlers/executionHandler.ts
@@ -2,7 +2,9 @@ import {
   AGENT_EXECUTION_TRANSFER_COUNT_DEFAULT,
   createMessage,
   createTask,
+  type DataPart,
   DURABLE_APPROVAL_ARTIFACT_TYPE,
+  type FilePart,
   type FullExecutionContext,
   generateId,
   generateServiceToken,
@@ -14,6 +16,7 @@ import {
   type Part,
   type SendMessageResponse,
   setSpanWithError,
+  type TextPart,
   unwrapError,
   updateTask,
 } from '@inkeep/agents-core';
@@ -329,12 +332,21 @@ export class ExecutionHandler {
             messageMetadata.approved_tool_calls = JSON.stringify(params.approvedToolCalls ?? {});
           }
 
-          // On the first iteration, use the original message parts if provided (includes data parts from triggers)
-          // On subsequent iterations (after transfers), use text-only since currentMessage is updated
-          const partsToSend: Part[] =
-            iterations === 1 && messageParts && messageParts.length > 0
-              ? messageParts
-              : [{ kind: 'text', text: currentMessage }];
+          // On the first iteration, use the original message parts if provided (includes data parts from triggers).
+          // On subsequent iterations (after transfers), preserve non-text parts (files, images) from the
+          // original message alongside the updated text — so transferred agents can see file attachments.
+          let partsToSend: Part[];
+          if (iterations === 1 && messageParts && messageParts.length > 0) {
+            partsToSend = messageParts;
+          } else {
+            const nonTextParts: Part[] = messageParts
+              ? messageParts.filter((p): p is FilePart | DataPart => p.kind !== 'text')
+              : [];
+            partsToSend = [
+              { kind: 'text', text: currentMessage } satisfies TextPart,
+              ...nonTextParts,
+            ];
+          }
 
           messageResponse = await a2aClient.sendMessage({
             message: {


### PR DESCRIPTION
## Summary

- **A2A handler**: Persist `content.parts` (with base64-normalized file bytes) alongside `content.text` on inbound A2A request messages, so file attachments survive into conversation history
- **ExecutionHandler**: On agent transfer iterations (>= 2), preserve non-text parts (files, data) from the original message instead of rebuilding as text-only — so transferred agents see file attachments
- **Conversation compression**: Shield file-bearing messages from summarization, since the compressor can't meaningfully represent binary file content
- **History reconstruction**: Add `reconstructFilePart` helper that decodes files from 4 storage shapes (`file.bytes`, `file.uri` data URI, persisted `data:` URI, `blob://` storage reference) and inlines them as `<file name="...">content</file>` tags in the LLM prompt

### Context
Files sent via `InkeepEmbeddedChat`'s `files` prop were silently dropped during agent transfers/delegations. The widget upload path (`makeMessageContentParts`) correctly persists files to blob storage, but three downstream hops lost them:
1. A2A handler only stored text, not parts
2. ExecutionHandler stripped non-text parts on transfer
3. Compression and history reconstruction had no file-part awareness

### Known limitations (follow-up)
- No file-size cap or MIME-type check before UTF-8 decode (large binary files could produce garbage)
- Blob downloads are sequential per-part; could batch via `resolve-blob-uris.ts`
- `any` casts remain in pre-existing code (only new code was tightened)

## Test plan
- [x] 15 existing `reconstructMessageText` tests updated for async signature — all pass
- [x] 8 new file-part tests covering: base64 bytes, data URI, persisted data URI, blob:// URI (mocked provider), failed blob download, http placeholder, text+file interleave, empty file part
- [x] `pnpm check` passes (only pre-existing manage-ui browser test failure from missing Docker)
- [ ] Manual: send files via InkeepEmbeddedChat widget, verify agent transfer preserves file content

🤖 Generated with [Claude Code](https://claude.com/claude-code)