### PR TITLE
fix: propagate delegated denial redirects to parent agent in durable mode

### DIFF
--- a/agents-api/src/domains/run/workflow/steps/agentExecutionSteps.ts
+++ b/agents-api/src/domains/run/workflow/steps/agentExecutionSteps.ts
@@ -989,7 +989,7 @@ export async function executeToolStep(params: ExecuteToolStepParams): Promise<Ex
                 toolName: params.delegatedApproval.toolName,
                 toolCallId: params.delegatedApproval.toolCallId,
                 reason:
-                  params.delegatedApprovalDecision.reason ?? 'The user denied this tool call.',
+                  params.delegatedApprovalDecision.reason ?? 'Tool call was denied by the user.',
               });
             }
           }

--- a/agents-api/src/domains/run/workflow/steps/agentExecutionSteps.ts
+++ b/agents-api/src/domains/run/workflow/steps/agentExecutionSteps.ts
@@ -989,8 +989,7 @@ export async function executeToolStep(params: ExecuteToolStepParams): Promise<Ex
                 toolName: params.delegatedApproval.toolName,
                 toolCallId: params.delegatedApproval.toolCallId,
                 reason:
-                  params.delegatedApprovalDecision.reason ??
-                  'The user denied this tool call.',
+                  params.delegatedApprovalDecision.reason ?? 'The user denied this tool call.',
               });
             }
           }

--- a/agents-api/src/domains/run/workflow/steps/agentExecutionSteps.ts
+++ b/agents-api/src/domains/run/workflow/steps/agentExecutionSteps.ts
@@ -980,6 +980,19 @@ export async function executeToolStep(params: ExecuteToolStepParams): Promise<Ex
               approved: params.delegatedApprovalDecision.approved,
               reason: params.delegatedApprovalDecision.reason,
             };
+
+            // For denials, record the redirect on the parent agent so it survives
+            // the delegation boundary. The delegated agent's denial runs in a separate
+            // A2A context and doesn't populate the parent's taskDenialRedirects.
+            if (!params.delegatedApprovalDecision.approved) {
+              agent.runContext.taskDenialRedirects.push({
+                toolName: params.delegatedApproval.toolName,
+                toolCallId: params.delegatedApproval.toolCallId,
+                reason:
+                  params.delegatedApprovalDecision.reason ??
+                  'The user denied this tool call.',
+              });
+            }
           }
 
           const sessionId = requestId;


### PR DESCRIPTION
## Summary
- When a delegated agent's tool is denied in durable mode, the denial runs in a separate A2A context so the parent agent's `taskDenialRedirects` is never populated
- The post-approval continuation prompt then uses the generic "Continue the conversation" instead of acknowledging the denial, causing the agent to answer from its own knowledge despite the user clicking Deny
- Fix: when `delegatedApprovalDecision.approved === false`, push a denial redirect onto the parent agent's `taskDenialRedirects` in `executeToolStep` before running the tool
- This matches the classic mode behavior where the denial context stays in-process

Closes PRD-6494

## Test plan
- [x] Typecheck passes
- [x] Dashboard durable denial works correctly (verified by user)
- [x] Verified the bug via curl — agent responded with coordinates despite denial
- [x] Fix ensures `denialRedirects` is populated so the LLM gets the denial prompt