### PR TITLE
fix: allow unsafe-eval in CSP for DynamicComponentRenderer

### DIFF
--- a/.changeset/clever-magenta-bobolink.md
+++ b/.changeset/clever-magenta-bobolink.md
@@ -1,0 +1,5 @@
+---
+"@inkeep/agents-manage-ui": patch
+---
+
+Fix DynamicComponentRenderer not rendering in production by allowing unsafe-eval in CSP

--- a/agents-manage-ui/src/proxy.ts
+++ b/agents-manage-ui/src/proxy.ts
@@ -58,7 +58,7 @@ function buildCsp() {
     "'self'",
     "'unsafe-inline'",
     "'wasm-unsafe-eval'",
-    process.env.NODE_ENV === 'production' ? null : "'unsafe-eval'",
+    "'unsafe-eval'",
     posthogHost,
   ]
     .filter(Boolean)


### PR DESCRIPTION
## Summary
- `DynamicComponentRenderer` uses `react-runner` which calls `new Function()` to compile and render user-authored component code at runtime
- The CSP `script-src` directive excluded `unsafe-eval` in production, silently blocking execution — components rendered as empty `<div></div>` in prod while working locally
- Allow `unsafe-eval` since this is an authenticated admin dashboard that already permits `unsafe-inline` and external scripts, and the component is by design an eval engine for user-authored code

## Test plan
- [x] Verify `DynamicComponentRenderer` renders in production (currently broken — empty div)
- [x] Verify no regression in local dev (already had `unsafe-eval`)