### PR TITLE
fix: normalize @claude trigger to be case-insensitive

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -39,33 +39,7 @@ jobs:
           token: ${{ steps.app-token.outputs.token }}
 
       - name: Normalize @claude trigger case
-        run: |
-          python3 -c "
-          import json, re, os
-          path = os.environ['GITHUB_EVENT_PATH']
-          with open(path) as f:
-              event = json.load(f)
-          modified = False
-          for key in ['comment', 'review']:
-              if key in event and isinstance(event.get(key), dict) and 'body' in event[key] and event[key]['body']:
-                  new_body = re.sub(r'@claude', '@claude', event[key]['body'], flags=re.IGNORECASE)
-                  if new_body != event[key]['body']:
-                      event[key]['body'] = new_body
-                      modified = True
-          if 'issue' in event and isinstance(event.get('issue'), dict):
-              for field in ['body', 'title']:
-                  if field in event['issue'] and event['issue'][field]:
-                      new_val = re.sub(r'@claude', '@claude', event['issue'][field], flags=re.IGNORECASE)
-                      if new_val != event['issue'][field]:
-                          event['issue'][field] = new_val
-                          modified = True
-          if modified:
-              with open(path, 'w') as f:
-                  json.dump(event, f)
-              print('Normalized @claude trigger case in event payload')
-          else:
-              print('No case normalization needed')
-          "
+        run: sed -i 's/@[Cc][Ll][Aa][Uu][Dd][Ee]/@claude/g' "$GITHUB_EVENT_PATH"
 
       - name: Run Claude Code
         id: claude

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -38,6 +38,35 @@ jobs:
           fetch-depth: 1
           token: ${{ steps.app-token.outputs.token }}
 
+      - name: Normalize @claude trigger case
+        run: |
+          python3 -c "
+          import json, re, os
+          path = os.environ['GITHUB_EVENT_PATH']
+          with open(path) as f:
+              event = json.load(f)
+          modified = False
+          for key in ['comment', 'review']:
+              if key in event and isinstance(event.get(key), dict) and 'body' in event[key] and event[key]['body']:
+                  new_body = re.sub(r'@claude', '@claude', event[key]['body'], flags=re.IGNORECASE)
+                  if new_body != event[key]['body']:
+                      event[key]['body'] = new_body
+                      modified = True
+          if 'issue' in event and isinstance(event.get('issue'), dict):
+              for field in ['body', 'title']:
+                  if field in event['issue'] and event['issue'][field]:
+                      new_val = re.sub(r'@claude', '@claude', event['issue'][field], flags=re.IGNORECASE)
+                      if new_val != event['issue'][field]:
+                          event['issue'][field] = new_val
+                          modified = True
+          if modified:
+              with open(path, 'w') as f:
+                  json.dump(event, f)
+              print('Normalized @claude trigger case in event payload')
+          else:
+              print('No case normalization needed')
+          "
+
       - name: Run Claude Code
         id: claude
         uses: anthropics/claude-code-action@26ec041249acb0a944c0a47b6c0c13f05dbc5b44 # v1


### PR DESCRIPTION
## Summary

The `claude-code-action`'s internal trigger matching is case-sensitive, so typing `@Claude` (capital C) in a PR comment passes the workflow's `if` condition (GitHub's `contains()` is case-insensitive) but the action itself skips with "No trigger found".

This caused https://github.com/inkeep/agents/actions/runs/24406448639 to be a no-op.

## Changes

- Add a pre-processing step before the Claude Code action that normalizes any case variant of `@claude` (e.g. `@Claude`, `@CLAUDE`) to lowercase in the GitHub event payload
- Covers comment body, review body, issue body, and issue title fields

## Test plan

- [ ] Comment `@Claude` (capital C) on a PR and verify the action triggers
- [ ] Comment `@claude` (lowercase) still works as before