### PR TITLE
Fix cost page timeout by aggregating cost queries at the database level

### DIFF
--- a/.changeset/prime-beige-echidna.md
+++ b/.changeset/prime-beige-echidna.md
@@ -1,0 +1,5 @@
+---
+"@inkeep/agents-manage-ui": patch
+---
+
+Fix cost page timeout by aggregating cost queries at the database level

--- a/agents-manage-ui/src/components/cost/cost-dashboard.tsx
+++ b/agents-manage-ui/src/components/cost/cost-dashboard.tsx
@@ -64,19 +64,21 @@ export function CostDashboard({ tenantId, projectId, startTime, endTime }: CostD
         const start = new Date(startTime).getTime();
         const end = new Date(endTime).getTime();
 
-        const [byModel, byAgent, byType, byProvider, eventsList, costPerDay] = await Promise.all([
-          client.getUsageCostSummary(start, end, 'model', projectId),
-          client.getUsageCostSummary(start, end, 'agent', projectId),
-          client.getUsageCostSummary(start, end, 'generation_type', projectId),
-          client.getUsageCostSummary(start, end, 'provider', projectId),
+        const [summaries, eventsList, costPerDay] = await Promise.all([
+          client.getUsageCostSummaries(
+            start,
+            end,
+            ['model', 'agent', 'generation_type', 'provider'] as const,
+            projectId
+          ),
           client.getUsageEventsList(start, end, projectId, undefined, 200),
           client.getUsageCostPerDay(start, end, projectId),
         ]);
 
-        setSummaryByModel(byModel);
-        setSummaryByAgent(byAgent);
-        setSummaryByType(byType);
-        setSummaryByProvider(byProvider);
+        setSummaryByModel(summaries.model);
+        setSummaryByAgent(summaries.agent);
+        setSummaryByType(summaries.generation_type);
+        setSummaryByProvider(summaries.provider);
         setEvents(eventsList);
         setChartData(costPerDay);
       } catch (error) {

--- a/agents-manage-ui/src/components/cost/cost-dashboard.tsx
+++ b/agents-manage-ui/src/components/cost/cost-dashboard.tsx
@@ -55,10 +55,13 @@ export function CostDashboard({ tenantId, projectId, startTime, endTime }: CostD
   const [events, setEvents] = useState<SigNozUsageEvent[]>([]);
   const [chartData, setChartData] = useState<Array<{ date: string; cost: number }>>([]);
   const [isLoading, setIsLoading] = useState(true);
+  const [loadError, setLoadError] = useState<string | null>(null);
 
   useEffect(() => {
+    let cancelled = false;
     async function fetchData() {
       setIsLoading(true);
+      setLoadError(null);
       try {
         const client = getSigNozStatsClient(tenantId);
         const start = new Date(startTime).getTime();
@@ -75,6 +78,8 @@ export function CostDashboard({ tenantId, projectId, startTime, endTime }: CostD
           client.getUsageCostPerDay(start, end, projectId),
         ]);
 
+        if (cancelled) return;
+
         setSummaryByModel(summaries.model);
         setSummaryByAgent(summaries.agent);
         setSummaryByType(summaries.generation_type);
@@ -83,10 +88,16 @@ export function CostDashboard({ tenantId, projectId, startTime, endTime }: CostD
         setChartData(costPerDay);
       } catch (error) {
         console.error('Failed to fetch usage data:', error);
+        if (cancelled) return;
+        setLoadError(error instanceof Error ? error.message : 'Failed to load cost data');
+      } finally {
+        if (!cancelled) setIsLoading(false);
       }
-      setIsLoading(false);
     }
     fetchData();
+    return () => {
+      cancelled = true;
+    };
   }, [tenantId, projectId, startTime, endTime]);
 
   const totals = summaryByModel.reduce(
@@ -102,6 +113,14 @@ export function CostDashboard({ tenantId, projectId, startTime, endTime }: CostD
 
   return (
     <>
+      {loadError && (
+        <div
+          role="alert"
+          className="rounded-md border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-800 dark:border-red-900 dark:bg-red-950 dark:text-red-200"
+        >
+          {loadError}
+        </div>
+      )}
       <UsageStatCards totals={totals} modelCount={summaryByModel.length} isLoading={isLoading} />
 
       <div className="grid grid-cols-1 lg:grid-cols-2 xl:grid-cols-3 gap-6">

--- a/agents-manage-ui/src/components/cost/cost-dashboard.tsx
+++ b/agents-manage-ui/src/components/cost/cost-dashboard.tsx
@@ -90,9 +90,8 @@ export function CostDashboard({ tenantId, projectId, startTime, endTime }: CostD
         console.error('Failed to fetch usage data:', error);
         if (cancelled) return;
         setLoadError(error instanceof Error ? error.message : 'Failed to load cost data');
-      } finally {
-        if (!cancelled) setIsLoading(false);
       }
+      if (!cancelled) setIsLoading(false);
     }
     fetchData();
     return () => {

--- a/agents-manage-ui/src/lib/api/signoz-stats.ts
+++ b/agents-manage-ui/src/lib/api/signoz-stats.ts
@@ -234,6 +234,11 @@ const timestampMsFromValue = (raw: unknown): number => {
 
 const extractTimeSeriesBuckets = (resp: any, name: string): Map<string, number> => {
   const buckets = new Map<string, number>();
+  const addToBucket = (ms: number, value: number) => {
+    if (!ms) return;
+    buckets.set(dateKeyFromMs(ms), (buckets.get(dateKeyFromMs(ms)) ?? 0) + value);
+  };
+
   const results = resp?.data?.data?.results ?? resp?.data?.results;
   if (!Array.isArray(results)) return buckets;
   const result = results.find((r: any) => r?.queryName === name);
@@ -243,14 +248,23 @@ const extractTimeSeriesBuckets = (resp: any, name: string): Map<string, number> 
     ? result.aggregations.flatMap((agg: any) => agg.series ?? [])
     : (result.series ?? []);
 
-  for (const s of seriesList) {
-    for (const v of s.values ?? []) {
-      const ms = timestampMsFromValue(v.timestamp ?? v.ts ?? v.time);
-      if (!ms) continue;
-      const cost = Number(v.value ?? 0) || 0;
-      const key = dateKeyFromMs(ms);
-      buckets.set(key, (buckets.get(key) ?? 0) + cost);
+  if (seriesList.length > 0) {
+    for (const s of seriesList) {
+      for (const v of s.values ?? []) {
+        addToBucket(timestampMsFromValue(v.timestamp ?? v.ts ?? v.time), Number(v.value ?? 0) || 0);
+      }
     }
+    return buckets;
+  }
+
+  const columns: Array<{ name: string; columnType: string }> = result.columns ?? [];
+  const rows: unknown[][] = result.data ?? [];
+  if (columns.length === 0 || rows.length === 0) return buckets;
+  const tsIdx = columns.findIndex((c) => /time|timestamp/i.test(c.name));
+  const valIdx = columns.findIndex((c) => c.columnType === 'aggregation');
+  if (tsIdx < 0 || valIdx < 0) return buckets;
+  for (const row of rows) {
+    addToBucket(timestampMsFromValue(row[tsIdx]), Number(row[valIdx] ?? 0) || 0);
   }
   return buckets;
 };
@@ -266,19 +280,23 @@ interface UsageCostSummaryRow {
   eventCount: number;
 }
 
-const USAGE_COST_AGGREGATION_EXPRESSIONS = {
-  inputTokens: `sum(${SPAN_KEYS.GEN_AI_USAGE_INPUT_TOKENS})`,
-  outputTokens: `sum(${SPAN_KEYS.GEN_AI_USAGE_OUTPUT_TOKENS})`,
-  cost: `sum(${SPAN_KEYS.GEN_AI_COST_ESTIMATED_USD})`,
-  eventCount: 'count()',
-} as const;
-
-const USAGE_COST_AGGREGATIONS = [
-  USAGE_COST_AGGREGATION_EXPRESSIONS.inputTokens,
-  USAGE_COST_AGGREGATION_EXPRESSIONS.outputTokens,
-  USAGE_COST_AGGREGATION_EXPRESSIONS.cost,
-  USAGE_COST_AGGREGATION_EXPRESSIONS.eventCount,
+// Single source of truth for cost-summary aggregations: the expression list
+// sent to SigNoz and the response-column indices used to parse it are both
+// derived from this array, so reordering it keeps them in sync.
+const USAGE_COST_AGGREGATION_ORDER = [
+  { key: 'inputTokens', expression: `sum(${SPAN_KEYS.GEN_AI_USAGE_INPUT_TOKENS})` },
+  { key: 'outputTokens', expression: `sum(${SPAN_KEYS.GEN_AI_USAGE_OUTPUT_TOKENS})` },
+  { key: 'cost', expression: `sum(${SPAN_KEYS.GEN_AI_COST_ESTIMATED_USD})` },
+  { key: 'eventCount', expression: 'count()' },
 ] as const;
+
+type UsageCostAggregationKey = (typeof USAGE_COST_AGGREGATION_ORDER)[number]['key'];
+
+const USAGE_COST_AGGREGATIONS = USAGE_COST_AGGREGATION_ORDER.map((a) => a.expression);
+
+const USAGE_COST_AGGREGATION_INDEX = Object.fromEntries(
+  USAGE_COST_AGGREGATION_ORDER.map((a, i) => [a.key, i])
+) as Record<UsageCostAggregationKey, number>;
 
 const usageCostQueryName = (groupBy: UsageCostGroupBy): string => `usageCost_${groupBy}`;
 
@@ -298,20 +316,22 @@ const usageCostGroupByKey = (groupBy: UsageCostGroupBy): string => {
 };
 
 const seriesToUsageSummaryRows = (series: Series[], groupByKey: string): UsageCostSummaryRow[] => {
+  const readNumber = (s: Series, key: UsageCostAggregationKey) =>
+    Number(s.values?.[USAGE_COST_AGGREGATION_INDEX[key]]?.value ?? 0) || 0;
+  const readInt = (s: Series, key: UsageCostAggregationKey) =>
+    parseInt(s.values?.[USAGE_COST_AGGREGATION_INDEX[key]]?.value ?? '0', 10) || 0;
+
   return series
     .map((s) => {
-      const values = s.values ?? [];
-      const inputTokens = Number(values[0]?.value ?? 0) || 0;
-      const outputTokens = Number(values[1]?.value ?? 0) || 0;
-      const cost = Number(values[2]?.value ?? 0) || 0;
-      const eventCount = parseInt(values[3]?.value ?? '0', 10) || 0;
+      const totalInputTokens = readNumber(s, 'inputTokens');
+      const totalOutputTokens = readNumber(s, 'outputTokens');
       return {
         groupKey: s.labels?.[groupByKey] || UNKNOWN_VALUE,
-        totalInputTokens: inputTokens,
-        totalOutputTokens: outputTokens,
-        totalTokens: inputTokens + outputTokens,
-        totalEstimatedCostUsd: cost,
-        eventCount,
+        totalInputTokens,
+        totalOutputTokens,
+        totalTokens: totalInputTokens + totalOutputTokens,
+        totalEstimatedCostUsd: readNumber(s, 'cost'),
+        eventCount: readInt(s, 'eventCount'),
       };
     })
     .sort((a, b) => b.totalTokens - a.totalTokens);

--- a/agents-manage-ui/src/lib/api/signoz-stats.ts
+++ b/agents-manage-ui/src/lib/api/signoz-stats.ts
@@ -208,6 +208,115 @@ type Series = {
 const countFromSeries = (s: Series) => parseInt(s.values?.[0]?.value ?? '0', 10) || 0;
 const numberFromSeries = (s: Series) => Number(s.values?.[0]?.value ?? 0) || 0;
 
+const DAY_IN_SECONDS = 86400;
+
+const dateKeyFromMs = (ms: number) => {
+  const d = new Date(ms);
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`;
+};
+
+const timestampMsFromValue = (raw: unknown): number => {
+  if (raw == null) return 0;
+  if (typeof raw === 'number') {
+    if (raw > 1e15) return nsToMs(raw);
+    if (raw > 1e12) return raw;
+    if (raw > 0) return raw * 1000;
+    return 0;
+  }
+  if (typeof raw === 'string') {
+    const num = Number(raw);
+    if (!Number.isNaN(num)) return timestampMsFromValue(num);
+    const parsed = new Date(raw).getTime();
+    return Number.isNaN(parsed) ? 0 : parsed;
+  }
+  return 0;
+};
+
+const extractTimeSeriesBuckets = (resp: any, name: string): Map<string, number> => {
+  const buckets = new Map<string, number>();
+  const results = resp?.data?.data?.results ?? resp?.data?.results;
+  if (!Array.isArray(results)) return buckets;
+  const result = results.find((r: any) => r?.queryName === name);
+  if (!result) return buckets;
+
+  const seriesList: any[] = result.aggregations
+    ? result.aggregations.flatMap((agg: any) => agg.series ?? [])
+    : (result.series ?? []);
+
+  for (const s of seriesList) {
+    for (const v of s.values ?? []) {
+      const ms = timestampMsFromValue(v.timestamp ?? v.ts ?? v.time);
+      if (!ms) continue;
+      const cost = Number(v.value ?? 0) || 0;
+      const key = dateKeyFromMs(ms);
+      buckets.set(key, (buckets.get(key) ?? 0) + cost);
+    }
+  }
+  return buckets;
+};
+
+type UsageCostGroupBy = 'model' | 'agent' | 'generation_type' | 'conversation' | 'provider';
+
+interface UsageCostSummaryRow {
+  groupKey: string;
+  totalInputTokens: number;
+  totalOutputTokens: number;
+  totalTokens: number;
+  totalEstimatedCostUsd: number;
+  eventCount: number;
+}
+
+const USAGE_COST_AGGREGATION_EXPRESSIONS = {
+  inputTokens: `sum(${SPAN_KEYS.GEN_AI_USAGE_INPUT_TOKENS})`,
+  outputTokens: `sum(${SPAN_KEYS.GEN_AI_USAGE_OUTPUT_TOKENS})`,
+  cost: `sum(${SPAN_KEYS.GEN_AI_COST_ESTIMATED_USD})`,
+  eventCount: 'count()',
+} as const;
+
+const USAGE_COST_AGGREGATIONS = [
+  USAGE_COST_AGGREGATION_EXPRESSIONS.inputTokens,
+  USAGE_COST_AGGREGATION_EXPRESSIONS.outputTokens,
+  USAGE_COST_AGGREGATION_EXPRESSIONS.cost,
+  USAGE_COST_AGGREGATION_EXPRESSIONS.eventCount,
+] as const;
+
+const usageCostQueryName = (groupBy: UsageCostGroupBy): string => `usageCost_${groupBy}`;
+
+const usageCostGroupByKey = (groupBy: UsageCostGroupBy): string => {
+  switch (groupBy) {
+    case 'model':
+      return SPAN_KEYS.AI_MODEL_ID;
+    case 'agent':
+      return SPAN_KEYS.AGENT_ID;
+    case 'generation_type':
+      return SPAN_KEYS.AI_TELEMETRY_GENERATION_TYPE;
+    case 'conversation':
+      return SPAN_KEYS.CONVERSATION_ID;
+    case 'provider':
+      return SPAN_KEYS.GEN_AI_RESPONSE_PROVIDER;
+  }
+};
+
+const seriesToUsageSummaryRows = (series: Series[], groupByKey: string): UsageCostSummaryRow[] => {
+  return series
+    .map((s) => {
+      const values = s.values ?? [];
+      const inputTokens = Number(values[0]?.value ?? 0) || 0;
+      const outputTokens = Number(values[1]?.value ?? 0) || 0;
+      const cost = Number(values[2]?.value ?? 0) || 0;
+      const eventCount = parseInt(values[3]?.value ?? '0', 10) || 0;
+      return {
+        groupKey: s.labels?.[groupByKey] || UNKNOWN_VALUE,
+        totalInputTokens: inputTokens,
+        totalOutputTokens: outputTokens,
+        totalTokens: inputTokens + outputTokens,
+        totalEstimatedCostUsd: cost,
+        eventCount,
+      };
+    })
+    .sort((a, b) => b.totalTokens - a.totalTokens);
+};
+
 const datesRange = (startMs: number, endMs: number) => {
   const start = new Date(startMs);
   start.setHours(0, 0, 0, 0);
@@ -2589,89 +2698,40 @@ class SigNozStatsAPI {
   async getUsageCostSummary(
     startTime: number,
     endTime: number,
-    groupBy: 'model' | 'agent' | 'generation_type' | 'conversation' | 'provider',
+    groupBy: UsageCostGroupBy,
     projectId?: string
-  ): Promise<
-    Array<{
-      groupKey: string;
-      totalInputTokens: number;
-      totalOutputTokens: number;
-      totalTokens: number;
-      totalEstimatedCostUsd: number;
-      eventCount: number;
-    }>
-  > {
+  ): Promise<UsageCostSummaryRow[]> {
+    const result = await this.getUsageCostSummaries(startTime, endTime, [groupBy], projectId);
+    return result[groupBy];
+  }
+
+  async getUsageCostSummaries<G extends UsageCostGroupBy>(
+    startTime: number,
+    endTime: number,
+    groupings: readonly G[],
+    projectId?: string
+  ): Promise<Record<G, UsageCostSummaryRow[]>> {
+    const empty = Object.fromEntries(
+      groupings.map((g) => [g, [] as UsageCostSummaryRow[]])
+    ) as Record<G, UsageCostSummaryRow[]>;
+    if (groupings.length === 0) return empty;
+
     try {
       const resp = await this.makeRequest(
-        this.buildUsageCostPayload(startTime, endTime, groupBy, projectId),
+        this.buildUsageCostMultiGroupPayload(startTime, endTime, groupings, projectId),
         projectId
       );
 
-      const inputSeries = this.extractSeries(resp, 'inputTokens');
-      const outputSeries = this.extractSeries(resp, 'outputTokens');
-      const costSeries = this.extractSeries(resp, 'cost');
-      const countSeries = this.extractSeries(resp, 'eventCount');
-
-      const groupByKey =
-        groupBy === 'model'
-          ? SPAN_KEYS.AI_MODEL_ID
-          : groupBy === 'agent'
-            ? SPAN_KEYS.AGENT_ID
-            : groupBy === 'generation_type'
-              ? SPAN_KEYS.AI_TELEMETRY_GENERATION_TYPE
-              : groupBy === 'conversation'
-                ? SPAN_KEYS.CONVERSATION_ID
-                : groupBy === 'provider'
-                  ? SPAN_KEYS.GEN_AI_RESPONSE_PROVIDER
-                  : 'timestamp';
-
-      const stats = new Map<
-        string,
-        { inputTokens: number; outputTokens: number; cost: number; count: number }
-      >();
-
-      for (const s of inputSeries) {
-        const key = s.labels?.[groupByKey] || UNKNOWN_VALUE;
-        const val = numberFromSeries(s);
-        const existing = stats.get(key) || { inputTokens: 0, outputTokens: 0, cost: 0, count: 0 };
-        existing.inputTokens += val;
-        stats.set(key, existing);
+      const out = { ...empty };
+      for (const g of groupings) {
+        const series = this.extractSeries(resp, usageCostQueryName(g));
+        const groupByKey = usageCostGroupByKey(g);
+        out[g] = seriesToUsageSummaryRows(series, groupByKey);
       }
-      for (const s of outputSeries) {
-        const key = s.labels?.[groupByKey] || UNKNOWN_VALUE;
-        const val = numberFromSeries(s);
-        const existing = stats.get(key) || { inputTokens: 0, outputTokens: 0, cost: 0, count: 0 };
-        existing.outputTokens += val;
-        stats.set(key, existing);
-      }
-      for (const s of costSeries) {
-        const key = s.labels?.[groupByKey] || UNKNOWN_VALUE;
-        const val = numberFromSeries(s);
-        const existing = stats.get(key) || { inputTokens: 0, outputTokens: 0, cost: 0, count: 0 };
-        existing.cost += val;
-        stats.set(key, existing);
-      }
-      for (const s of countSeries) {
-        const key = s.labels?.[groupByKey] || UNKNOWN_VALUE;
-        const val = countFromSeries(s);
-        const existing = stats.get(key) || { inputTokens: 0, outputTokens: 0, cost: 0, count: 0 };
-        existing.count += val;
-        stats.set(key, existing);
-      }
-
-      return [...stats.entries()]
-        .map(([groupKey, data]) => ({
-          groupKey,
-          totalInputTokens: data.inputTokens,
-          totalOutputTokens: data.outputTokens,
-          totalTokens: data.inputTokens + data.outputTokens,
-          totalEstimatedCostUsd: data.cost,
-          eventCount: data.count,
-        }))
-        .sort((a, b) => b.totalTokens - a.totalTokens);
+      return out;
     } catch (e) {
-      console.error('getUsageCostSummary error:', e);
-      return [];
+      console.error('getUsageCostSummaries error:', e);
+      return empty;
     }
   }
 
@@ -2822,65 +2882,32 @@ class SigNozStatsAPI {
     try {
       const filterItems = buildScopedFilterItems('all-usage', projectId);
 
-      const traceIdGroupBy = [
-        {
-          name: SPAN_KEYS.TRACE_ID,
-          fieldDataType: FIELD_DATA_TYPES.STRING,
-          fieldContext: FIELD_CONTEXTS.SPAN,
-        },
-      ];
-
-      const makeQuery = (name: string, expression: string) => ({
-        type: QUERY_TYPES.BUILDER_QUERY,
-        spec: {
-          name,
-          signal: SIGNALS.TRACES,
-          aggregations: [{ expression }],
-          filter: { expression: buildFilterExpression(filterItems) },
-          groupBy: traceIdGroupBy,
-          order: [],
-          stepInterval: QUERY_DEFAULTS.STEP_INTERVAL,
-          limit: QUERY_DEFAULTS.LIMIT_UNLIMITED,
-          disabled: QUERY_DEFAULTS.DISABLED,
-        },
-      });
-
       const payload = {
         start: startTime,
         end: endTime,
-        requestType: REQUEST_TYPES.SCALAR,
+        requestType: REQUEST_TYPES.TIME_SERIES,
         ...(projectId && { projectId }),
         compositeQuery: {
           queries: [
-            makeQuery('costByTrace', `sum(${SPAN_KEYS.GEN_AI_COST_ESTIMATED_USD})`),
-            makeQuery('timestampByTrace', `min(${SPAN_KEYS.TIMESTAMP})`),
+            {
+              type: QUERY_TYPES.BUILDER_QUERY,
+              spec: {
+                name: 'costPerDay',
+                signal: SIGNALS.TRACES,
+                aggregations: [{ expression: `sum(${SPAN_KEYS.GEN_AI_COST_ESTIMATED_USD})` }],
+                filter: { expression: buildFilterExpression(filterItems) },
+                groupBy: [],
+                order: [],
+                stepInterval: DAY_IN_SECONDS,
+                disabled: QUERY_DEFAULTS.DISABLED,
+              },
+            },
           ],
         },
       };
 
       const resp = await this.makeRequest(payload, projectId);
-      const costSeries = this.extractSeries(resp, 'costByTrace');
-      const tsSeries = this.extractSeries(resp, 'timestampByTrace');
-
-      const tsByTraceId = new Map<string, number>();
-      for (const s of tsSeries) {
-        const id = s.labels?.[SPAN_KEYS.TRACE_ID];
-        if (!id) continue;
-        const ms = timestampMsFromSeries(s);
-        if (ms) tsByTraceId.set(id, ms);
-      }
-
-      const buckets = new Map<string, number>();
-      for (const s of costSeries) {
-        const id = s.labels?.[SPAN_KEYS.TRACE_ID];
-        if (!id) continue;
-        const ms = tsByTraceId.get(id);
-        if (!ms) continue;
-        const cost = numberFromSeries(s);
-        const d = new Date(ms);
-        const key = `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`;
-        buckets.set(key, (buckets.get(key) ?? 0) + cost);
-      }
+      const buckets = extractTimeSeriesBuckets(resp, 'costPerDay');
 
       return datesRange(startTime, endTime).map((date) => ({
         date,
@@ -2892,7 +2919,12 @@ class SigNozStatsAPI {
     }
   }
 
-  private buildUsageCostPayload(start: number, end: number, groupBy: string, projectId?: string) {
+  private buildUsageCostMultiGroupPayload(
+    start: number,
+    end: number,
+    groupings: readonly UsageCostGroupBy[],
+    projectId?: string
+  ) {
     const baseItems: Array<{ key: string; op: string; value: unknown }> = [
       {
         key: SPAN_KEYS.AI_OPERATION_ID,
@@ -2906,34 +2938,20 @@ class SigNozStatsAPI {
       },
       ...(projectId ? [{ key: SPAN_KEYS.PROJECT_ID, op: OPERATORS.EQUALS, value: projectId }] : []),
     ];
+    const filterExpression = buildFilterExpression(baseItems);
 
-    const groupByKey =
-      groupBy === 'model'
-        ? SPAN_KEYS.AI_MODEL_ID
-        : groupBy === 'agent'
-          ? SPAN_KEYS.AGENT_ID
-          : groupBy === 'generation_type'
-            ? SPAN_KEYS.AI_TELEMETRY_GENERATION_TYPE
-            : groupBy === 'conversation'
-              ? SPAN_KEYS.CONVERSATION_ID
-              : groupBy === 'provider'
-                ? SPAN_KEYS.GEN_AI_RESPONSE_PROVIDER
-                : SPAN_KEYS.TIMESTAMP;
-
-    const groupByFieldContext = FIELD_CONTEXTS.ATTRIBUTE;
-
-    const makeAggQuery = (queryName: string, aggregateKey: string) => ({
+    const queries = groupings.map((g) => ({
       type: QUERY_TYPES.BUILDER_QUERY,
       spec: {
-        name: queryName,
+        name: usageCostQueryName(g),
         signal: SIGNALS.TRACES,
-        aggregations: [{ expression: `sum(${aggregateKey})` }],
-        filter: { expression: buildFilterExpression(baseItems) },
+        aggregations: USAGE_COST_AGGREGATIONS.map((expression) => ({ expression })),
+        filter: { expression: filterExpression },
         groupBy: [
           {
-            name: groupByKey,
+            name: usageCostGroupByKey(g),
             fieldDataType: FIELD_DATA_TYPES.STRING,
-            fieldContext: groupByFieldContext,
+            fieldContext: FIELD_CONTEXTS.ATTRIBUTE,
           },
         ],
         order: [],
@@ -2941,42 +2959,14 @@ class SigNozStatsAPI {
         limit: QUERY_DEFAULTS.LIMIT_UNLIMITED,
         disabled: QUERY_DEFAULTS.DISABLED,
       },
-    });
-
-    const makeCountQuery = (queryName: string) => ({
-      type: QUERY_TYPES.BUILDER_QUERY,
-      spec: {
-        name: queryName,
-        signal: SIGNALS.TRACES,
-        aggregations: [{ expression: 'count()' }],
-        filter: { expression: buildFilterExpression(baseItems) },
-        groupBy: [
-          {
-            name: groupByKey,
-            fieldDataType: FIELD_DATA_TYPES.STRING,
-            fieldContext: groupByFieldContext,
-          },
-        ],
-        order: [],
-        stepInterval: QUERY_DEFAULTS.STEP_INTERVAL,
-        limit: QUERY_DEFAULTS.LIMIT_UNLIMITED,
-        disabled: QUERY_DEFAULTS.DISABLED,
-      },
-    });
+    }));
 
     return {
       start,
       end,
       requestType: REQUEST_TYPES.SCALAR,
       ...(projectId && { projectId }),
-      compositeQuery: {
-        queries: [
-          makeAggQuery('inputTokens', SPAN_KEYS.GEN_AI_USAGE_INPUT_TOKENS),
-          makeAggQuery('outputTokens', SPAN_KEYS.GEN_AI_USAGE_OUTPUT_TOKENS),
-          makeAggQuery('cost', SPAN_KEYS.GEN_AI_COST_ESTIMATED_USD),
-          makeCountQuery('eventCount'),
-        ],
-      },
+      compositeQuery: { queries },
     };
   }
 


### PR DESCRIPTION
## Summary

The cost dashboard was timing out because it pushed aggregation work to the client and fanned out into many independent ClickHouse scans. This PR moves that work to the database.

- **`getUsageCostPerDay`**: was grouping by `traceID` with `LIMIT_UNLIMITED = 10000` and reducing per-trace rows into day buckets in JS. Now a single `TIME_SERIES` query with `stepInterval: 86400` returns one row per day directly from ClickHouse.
- **`getUsageCostSummary`**: the per-grouping payload was 4 separate builder queries (`sum(input)`, `sum(output)`, `sum(cost)`, `count()`), and the dashboard fired 4 of those in parallel — 16 ClickHouse scans + 4 HTTP round trips. New `getUsageCostSummaries(groupings)` collapses all four aggregations into one builder query per grouping and runs all groupings in a single composite request. Net: **4 scans + 1 round trip**.
- **`cost-dashboard.tsx`**: swapped 4 parallel `getUsageCostSummary` calls for one `getUsageCostSummaries` call.

## Test plan

- [ ] Load the cost page on a tenant with substantial usage — confirm it no longer times out and renders in normal time
- [ ] Verify stat cards, all four breakdown tables (model / agent / provider / generation type), and the "Cost Over Time" chart show correct numbers
- [ ] Cross-check a few rows against the previous implementation on a small date range to confirm the positional mapping of aggregations (`[input, output, cost, count]`) matches the SigNoz response
- [ ] Sanity-check the Cost Events table still populates
- [ ] Spot-check with and without a `projectId`

🤖 Generated with [Claude Code](https://claude.com/claude-code)