### PR TITLE
feat: add support_copilot app type with OAuth 2.1 JWT auth

### DIFF
--- a/.changeset/promising-azure-tyrannosaurus.md
+++ b/.changeset/promising-azure-tyrannosaurus.md
@@ -1,0 +1,7 @@
+---
+"@inkeep/agents-core": patch
+"@inkeep/agents-api": patch
+"@inkeep/agents-manage-ui": patch
+---
+
+Add support_copilot app type with OAuth 2.1 JWT auth, tenant-level app discovery endpoint, and apps UI for configuring support copilot apps with credentials

--- a/.env.example
+++ b/.env.example
@@ -88,6 +88,9 @@ SPICEDB_PRESHARED_KEY=dev-secret-key
 # API bypass secret for local development and testing (skips auth)
 INKEEP_AGENTS_MANAGE_API_BYPASS_SECRET=test-bypass-secret-for-ci
 
+# OAuth 2.1 client ID for the Support Copilot app (set after running `pnpm setup-oauth-client`)
+# COPILOT_OAUTH_CLIENT_ID=
+
 # ========== SERVICE TOKENS ================
 # INKEEP_AGENTS_JWT_SIGNING_SECRET=
 

--- a/agents-api/__snapshots__/openapi.json
+++ b/agents-api/__snapshots__/openapi.json
@@ -1140,6 +1140,7 @@
         "discriminator": {
           "mapping": {
             "api": "#/components/schemas/ApiConfig",
+            "support_copilot": "#/components/schemas/SupportCopilotConfig",
             "web_client": "#/components/schemas/WebClientConfig"
           },
           "propertyName": "type"
@@ -1150,6 +1151,9 @@
           },
           {
             "$ref": "#/components/schemas/ApiConfig"
+          },
+          {
+            "$ref": "#/components/schemas/SupportCopilotConfig"
           }
         ]
       },
@@ -1157,6 +1161,7 @@
         "discriminator": {
           "mapping": {
             "api": "#/components/schemas/ApiConfig",
+            "support_copilot": "#/components/schemas/SupportCopilotConfig",
             "web_client": "#/components/schemas/WebClientConfigResponse"
           },
           "propertyName": "type"
@@ -1167,6 +1172,9 @@
           },
           {
             "$ref": "#/components/schemas/ApiConfig"
+          },
+          {
+            "$ref": "#/components/schemas/SupportCopilotConfig"
           }
         ]
       },
@@ -1217,7 +1225,8 @@
           "type": {
             "enum": [
               "web_client",
-              "api"
+              "api",
+              "support_copilot"
             ],
             "type": "string"
           },
@@ -9655,6 +9664,33 @@
         },
         "type": "object"
       },
+      "SupportCopilotConfig": {
+        "properties": {
+          "supportCopilot": {
+            "properties": {
+              "credentialReferenceIds": {
+                "default": [],
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              }
+            },
+            "type": "object"
+          },
+          "type": {
+            "enum": [
+              "support_copilot"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "supportCopilot"
+        ],
+        "type": "object"
+      },
       "TeamAgent": {
         "properties": {
           "description": {
@@ -12366,6 +12402,93 @@
         "tags": [
           "OAuth"
         ]
+      }
+    },
+    "/manage/tenants/{tenantId}/apps": {
+      "get": {
+        "description": "List all apps for a tenant across all projects, optionally filtered by type",
+        "operationId": "list-tenant-apps",
+        "parameters": [
+          {
+            "description": "Tenant identifier",
+            "in": "path",
+            "name": "tenantId",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/TenantIdPathParam"
+            }
+          },
+          {
+            "in": "query",
+            "name": "page",
+            "required": false,
+            "schema": {
+              "$ref": "#/components/schemas/PaginationPageQueryParam"
+            }
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "$ref": "#/components/schemas/PaginationLimitQueryParam"
+            }
+          },
+          {
+            "description": "Filter by app type",
+            "in": "query",
+            "name": "type",
+            "required": false,
+            "schema": {
+              "description": "Filter by app type",
+              "enum": [
+                "web_client",
+                "api",
+                "support_copilot"
+              ],
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AppListResponse"
+                }
+              }
+            },
+            "description": "List of apps retrieved successfully"
+          }
+        },
+        "summary": "List Tenant Apps",
+        "tags": [
+          "Apps"
+        ],
+        "x-authz": {
+          "description": "Requires organization membership. Auth is enforced by the manageBearerOrSessionAuth middleware in createApp.ts.",
+          "permission": "member",
+          "resource": "organization"
+        },
+        "x-speakeasy-pagination": {
+          "inputs": [
+            {
+              "in": "parameters",
+              "name": "page",
+              "type": "page"
+            },
+            {
+              "in": "parameters",
+              "name": "limit",
+              "type": "limit"
+            }
+          ],
+          "outputs": {
+            "numPages": "$.pagination.pages"
+          },
+          "type": "offsetLimit"
+        }
       }
     },
     "/manage/tenants/{tenantId}/entitlements": {
@@ -27552,7 +27675,8 @@
               "description": "Filter by app type",
               "enum": [
                 "web_client",
-                "api"
+                "api",
+                "support_copilot"
               ],
               "type": "string"
             }

--- a/agents-api/__snapshots__/openapi.json
+++ b/agents-api/__snapshots__/openapi.json
@@ -12460,6 +12460,66 @@
               }
             },
             "description": "List of apps retrieved successfully"
+          },
+          "400": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BadRequest"
+                }
+              }
+            },
+            "description": "Bad Request"
+          },
+          "401": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Unauthorized"
+                }
+              }
+            },
+            "description": "Unauthorized"
+          },
+          "403": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Forbidden"
+                }
+              }
+            },
+            "description": "Forbidden"
+          },
+          "404": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NotFound"
+                }
+              }
+            },
+            "description": "Not Found"
+          },
+          "422": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UnprocessableEntity"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InternalServerError"
+                }
+              }
+            },
+            "description": "Internal Server Error"
           }
         },
         "summary": "List Tenant Apps",

--- a/agents-api/src/__tests__/manage/middleware/manage-auth-api-key-rejection.test.ts
+++ b/agents-api/src/__tests__/manage/middleware/manage-auth-api-key-rejection.test.ts
@@ -14,12 +14,19 @@ vi.mock('@inkeep/agents-core', () => ({
   isInternalServiceToken: isInternalServiceTokenMock,
   verifyInternalServiceAuthHeader: vi.fn(),
   verifySlackUserToken: vi.fn(),
+  getInProcessFetch: () => vi.fn(),
   getLogger: () => ({
     debug: vi.fn(),
     error: vi.fn(),
     info: vi.fn(),
     warn: vi.fn(),
   }),
+}));
+
+vi.mock('jose', () => ({
+  createRemoteJWKSet: vi.fn(() => vi.fn()),
+  customFetch: Symbol('customFetch'),
+  jwtVerify: vi.fn().mockRejectedValue(new Error('not mocked')),
 }));
 
 vi.mock('@inkeep/agents-core/middleware', () => ({

--- a/agents-api/src/__tests__/manage/middleware/manage-auth-oauth-jwt.test.ts
+++ b/agents-api/src/__tests__/manage/middleware/manage-auth-oauth-jwt.test.ts
@@ -1,0 +1,162 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { jwtVerifyMock } = vi.hoisted(() => ({
+  jwtVerifyMock: vi.fn(),
+}));
+
+vi.mock('@inkeep/agents-core', () => ({
+  validateAndGetApiKey: vi.fn(),
+  isSlackUserToken: vi.fn().mockReturnValue(false),
+  isInternalServiceToken: vi.fn().mockReturnValue(false),
+  verifyInternalServiceAuthHeader: vi.fn(),
+  verifySlackUserToken: vi.fn(),
+  getInProcessFetch: () => vi.fn(),
+  getLogger: () => ({
+    debug: vi.fn(),
+    error: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+  }),
+}));
+
+vi.mock('@inkeep/agents-core/middleware', () => ({
+  registerAuthzMeta: vi.fn(),
+}));
+
+vi.mock('jose', () => ({
+  createRemoteJWKSet: vi.fn(() => vi.fn()),
+  customFetch: Symbol('customFetch'),
+  jwtVerify: jwtVerifyMock,
+}));
+
+vi.mock('../../../env.js', () => ({
+  env: {
+    ENVIRONMENT: 'production',
+    INKEEP_AGENTS_MANAGE_API_BYPASS_SECRET: undefined,
+    INKEEP_AGENTS_API_URL: 'http://localhost:3002',
+    COPILOT_OAUTH_CLIENT_ID: 'copilot-client-id',
+  },
+}));
+
+vi.mock('../../../data/db/runDbClient.js', () => ({ default: {} }));
+
+vi.mock('../../../middleware/sessionAuth', () => ({
+  sessionAuth: () =>
+    vi.fn(async (_c: unknown, _next: unknown) => {
+      throw new Error('session auth not mocked');
+    }),
+}));
+
+import { Hono } from 'hono';
+import { manageBearerAuth } from '../../../middleware/manageAuth';
+
+const VALID_JWT = 'eyJhbGciOiJFZERTQSJ9.payload.signature';
+
+describe('Manage Auth - OAuth JWT', () => {
+  let app: Hono;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    app = new Hono();
+    app.use('*', async (c, next) => {
+      c.set('auth' as never, {
+        api: { getSession: vi.fn().mockResolvedValue(null) },
+      });
+      await next();
+    });
+  });
+
+  it('should authenticate with valid OAuth JWT and set context claims', async () => {
+    jwtVerifyMock.mockResolvedValue({
+      payload: {
+        sub: 'user-123',
+        azp: 'copilot-client-id',
+        'https://inkeep.com/tenantId': 'tenant_1',
+        'https://inkeep.com/email': 'user@example.com',
+      },
+    });
+
+    app.use('*', manageBearerAuth());
+    app.get('/', (c) =>
+      c.json({
+        userId: (c as any).get('userId'),
+        userEmail: (c as any).get('userEmail'),
+        tenantId: (c as any).get('tenantId'),
+      })
+    );
+
+    const res = await app.request('/', {
+      headers: { Authorization: `Bearer ${VALID_JWT}` },
+    });
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toEqual({
+      userId: 'user-123',
+      userEmail: 'user@example.com',
+      tenantId: 'tenant_1',
+    });
+  });
+
+  it('should reject when azp does not match COPILOT_OAUTH_CLIENT_ID', async () => {
+    jwtVerifyMock.mockResolvedValue({
+      payload: {
+        sub: 'user-123',
+        azp: 'wrong-client-id',
+        'https://inkeep.com/tenantId': 'tenant_1',
+      },
+    });
+
+    app.use('*', manageBearerAuth());
+    app.get('/', (c) => c.text('OK'));
+
+    const res = await app.request('/', {
+      headers: { Authorization: `Bearer ${VALID_JWT}` },
+    });
+
+    expect(res.status).toBe(401);
+  });
+
+  it('should skip OAuth path for non-JWT tokens (falls through to other auth)', async () => {
+    app.use('*', manageBearerAuth());
+    app.get('/', (c) => c.text('OK'));
+
+    const res = await app.request('/', {
+      headers: { Authorization: 'Bearer plain-opaque-token' },
+    });
+
+    expect(res.status).toBe(401);
+    expect(jwtVerifyMock).not.toHaveBeenCalled();
+  });
+
+  it('should fall through when JWT signature verification fails', async () => {
+    jwtVerifyMock.mockRejectedValue(new Error('signature invalid'));
+
+    app.use('*', manageBearerAuth());
+    app.get('/', (c) => c.text('OK'));
+
+    const res = await app.request('/', {
+      headers: { Authorization: `Bearer ${VALID_JWT}` },
+    });
+
+    expect(res.status).toBe(401);
+  });
+
+  it('should fall through when JWT missing sub claim', async () => {
+    jwtVerifyMock.mockResolvedValue({
+      payload: {
+        azp: 'copilot-client-id',
+        'https://inkeep.com/tenantId': 'tenant_1',
+      },
+    });
+
+    app.use('*', manageBearerAuth());
+    app.get('/', (c) => c.text('OK'));
+
+    const res = await app.request('/', {
+      headers: { Authorization: `Bearer ${VALID_JWT}` },
+    });
+
+    expect(res.status).toBe(401);
+  });
+});

--- a/agents-api/src/__tests__/manage/middleware/manage-auth-oauth-jwt.test.ts
+++ b/agents-api/src/__tests__/manage/middleware/manage-auth-oauth-jwt.test.ts
@@ -34,7 +34,7 @@ vi.mock('../../../env.js', () => ({
     ENVIRONMENT: 'production',
     INKEEP_AGENTS_MANAGE_API_BYPASS_SECRET: undefined,
     INKEEP_AGENTS_API_URL: 'http://localhost:3002',
-    COPILOT_OAUTH_CLIENT_ID: 'copilot-client-id',
+    COPILOT_OAUTH_CLIENT_ID: 'copilot-client-id' as string | undefined,
   },
 }));
 
@@ -48,6 +48,7 @@ vi.mock('../../../middleware/sessionAuth', () => ({
 }));
 
 import { Hono } from 'hono';
+import { env } from '../../../env';
 import { manageBearerAuth } from '../../../middleware/manageAuth';
 
 const VALID_JWT = 'eyJhbGciOiJFZERTQSJ9.payload.signature';
@@ -158,5 +159,25 @@ describe('Manage Auth - OAuth JWT', () => {
     });
 
     expect(res.status).toBe(401);
+  });
+
+  it('should skip OAuth JWT path entirely when COPILOT_OAUTH_CLIENT_ID is not configured', async () => {
+    const original = env.COPILOT_OAUTH_CLIENT_ID;
+    env.COPILOT_OAUTH_CLIENT_ID = undefined;
+    try {
+      app.use('*', manageBearerAuth());
+      app.get('/', (c) => c.text('OK'));
+
+      const res = await app.request('/', {
+        headers: { Authorization: `Bearer ${VALID_JWT}` },
+      });
+
+      expect(res.status).toBe(401);
+      // Critical: must not even attempt JWT verification when unconfigured,
+      // so that JWTs issued to other OAuth clients cannot authenticate.
+      expect(jwtVerifyMock).not.toHaveBeenCalled();
+    } finally {
+      env.COPILOT_OAUTH_CLIENT_ID = original;
+    }
   });
 });

--- a/agents-api/src/__tests__/manage/routes/tenantApps.test.ts
+++ b/agents-api/src/__tests__/manage/routes/tenantApps.test.ts
@@ -1,0 +1,116 @@
+import { createTestProject } from '@inkeep/agents-core/db/test-manage-client';
+import { describe, expect, it } from 'vitest';
+import manageDbClient from '../../../data/db/manageDbClient';
+import { makeRequest } from '../../utils/testRequest';
+import { createTestTenantWithOrg } from '../../utils/testTenant';
+
+describe('Tenant Apps Routes - Integration Tests', () => {
+  const createApp = async ({
+    tenantId,
+    projectId,
+    type,
+    name,
+  }: {
+    tenantId: string;
+    projectId: string;
+    type: 'web_client' | 'api' | 'support_copilot';
+    name: string;
+  }) => {
+    const body: Record<string, unknown> = {
+      name,
+      type,
+      defaultAgentId: 'agent-1',
+      config:
+        type === 'web_client'
+          ? {
+              type: 'web_client',
+              webClient: { allowedDomains: ['help.customer.com'] },
+            }
+          : type === 'api'
+            ? { type: 'api', api: {} }
+            : {
+                type: 'support_copilot',
+                supportCopilot: { credentialReferenceIds: [] },
+              },
+    };
+
+    const res = await makeRequest(`/manage/tenants/${tenantId}/projects/${projectId}/apps`, {
+      method: 'POST',
+      body: JSON.stringify(body),
+    });
+    expect(res.status).toBe(201);
+    const respBody = await res.json();
+    return respBody.data.app;
+  };
+
+  describe('GET /manage/tenants/:tenantId/apps', () => {
+    it('should list apps across all projects in the tenant', async () => {
+      const tenantId = await createTestTenantWithOrg('tenant-apps-list');
+      const projectA = 'project-a';
+      const projectB = 'project-b';
+      await createTestProject(manageDbClient, tenantId, projectA);
+      await createTestProject(manageDbClient, tenantId, projectB);
+
+      await createApp({ tenantId, projectId: projectA, type: 'web_client', name: 'A Web' });
+      await createApp({ tenantId, projectId: projectB, type: 'api', name: 'B API' });
+
+      const res = await makeRequest(`/manage/tenants/${tenantId}/apps?page=1&limit=10`);
+      expect(res.status).toBe(200);
+
+      const body = await res.json();
+      expect(body.data).toHaveLength(2);
+      expect(body.pagination.total).toBe(2);
+      const projectIds = body.data.map(
+        (app: { defaultProjectId: string | null }) => app.defaultProjectId
+      );
+      expect(projectIds).toContain(projectA);
+      expect(projectIds).toContain(projectB);
+    });
+
+    it('should filter by type=support_copilot across projects', async () => {
+      const tenantId = await createTestTenantWithOrg('tenant-apps-filter-copilot');
+      const projectA = 'project-a';
+      const projectB = 'project-b';
+      await createTestProject(manageDbClient, tenantId, projectA);
+      await createTestProject(manageDbClient, tenantId, projectB);
+
+      await createApp({
+        tenantId,
+        projectId: projectA,
+        type: 'support_copilot',
+        name: 'A Copilot',
+      });
+      await createApp({
+        tenantId,
+        projectId: projectB,
+        type: 'support_copilot',
+        name: 'B Copilot',
+      });
+      await createApp({ tenantId, projectId: projectA, type: 'web_client', name: 'A Web' });
+
+      const res = await makeRequest(
+        `/manage/tenants/${tenantId}/apps?type=support_copilot&limit=10`
+      );
+      expect(res.status).toBe(200);
+
+      const body = await res.json();
+      expect(body.data).toHaveLength(2);
+      for (const app of body.data) {
+        expect(app.type).toBe('support_copilot');
+      }
+    });
+
+    it('should return empty list for tenant with no apps', async () => {
+      const tenantId = await createTestTenantWithOrg('tenant-apps-empty');
+      const projectId = 'default-project';
+      await createTestProject(manageDbClient, tenantId, projectId);
+
+      const res = await makeRequest(`/manage/tenants/${tenantId}/apps?limit=10`);
+      expect(res.status).toBe(200);
+
+      const body = await res.json();
+      expect(body.data).toHaveLength(0);
+      expect(body.pagination.total).toBe(0);
+    });
+  });
+});

--- a/agents-api/src/__tests__/run/middleware/api-key-auth.test.ts
+++ b/agents-api/src/__tests__/run/middleware/api-key-auth.test.ts
@@ -46,6 +46,7 @@ vi.mock('@inkeep/agents-core', () => ({
   getAppById: vi.fn(() => vi.fn().mockResolvedValue(null)),
   validateOrigin: vi.fn().mockReturnValue(false),
   updateAppLastUsed: vi.fn(() => vi.fn().mockResolvedValue(undefined)),
+  getInProcessFetch: () => vi.fn(),
   getLogger: () => ({
     debug: vi.fn(),
     error: vi.fn(),
@@ -56,6 +57,8 @@ vi.mock('@inkeep/agents-core', () => ({
 
 vi.mock('jose', () => ({
   jwtVerify: vi.fn().mockRejectedValue(new Error('not mocked')),
+  createRemoteJWKSet: vi.fn(() => vi.fn()),
+  customFetch: Symbol('customFetch'),
 }));
 
 vi.mock('../../../domains/run/routes/auth', () => ({

--- a/agents-api/src/__tests__/run/middleware/app-credential-auth.test.ts
+++ b/agents-api/src/__tests__/run/middleware/app-credential-auth.test.ts
@@ -89,11 +89,12 @@ vi.mock('../../../env.js', () => ({
   env: {
     INKEEP_AGENTS_RUN_API_BYPASS_SECRET: undefined as string | undefined,
     INKEEP_AGENTS_API_URL: 'http://localhost:3002',
-    COPILOT_OAUTH_CLIENT_ID: 'copilot-client-id',
+    COPILOT_OAUTH_CLIENT_ID: 'copilot-client-id' as string | undefined,
   },
 }));
 
 import { Hono } from 'hono';
+import { env } from '../../../env';
 import { runApiKeyAuth as apiKeyAuth } from '../../../middleware/runAuth';
 
 function makeSupportCopilotApp(overrides: Record<string, unknown> = {}) {
@@ -731,6 +732,48 @@ describe('App Credential Authentication', () => {
       });
 
       expect(res.status).toBe(401);
+    });
+
+    it('should reject when JWT missing tenantId claim', async () => {
+      getAppByIdMock.mockReturnValue(vi.fn().mockResolvedValue(makeSupportCopilotApp()));
+      jwtVerifyMock.mockResolvedValue({
+        payload: {
+          sub: 'user-123',
+          azp: 'copilot-client-id',
+        },
+      });
+
+      const res = await app.request('/', {
+        headers: {
+          Authorization: `Bearer ${VALID_OAUTH_JWT}`,
+          'x-inkeep-app-id': 'app-copilot-1',
+        },
+      });
+
+      expect(res.status).toBe(401);
+      expect(jwtVerifyMock).toHaveBeenCalled();
+      expect(canUseProjectStrictMock).not.toHaveBeenCalled();
+    });
+
+    it('should reject when COPILOT_OAUTH_CLIENT_ID is not configured', async () => {
+      const original = env.COPILOT_OAUTH_CLIENT_ID;
+      env.COPILOT_OAUTH_CLIENT_ID = undefined;
+      try {
+        getAppByIdMock.mockReturnValue(vi.fn().mockResolvedValue(makeSupportCopilotApp()));
+
+        const res = await app.request('/', {
+          headers: {
+            Authorization: `Bearer ${VALID_OAUTH_JWT}`,
+            'x-inkeep-app-id': 'app-copilot-1',
+          },
+        });
+
+        expect(res.status).toBe(401);
+        // Critical: must not even attempt JWT verification when unconfigured.
+        expect(jwtVerifyMock).not.toHaveBeenCalled();
+      } finally {
+        env.COPILOT_OAUTH_CLIENT_ID = original;
+      }
     });
   });
 });

--- a/agents-api/src/__tests__/run/middleware/app-credential-auth.test.ts
+++ b/agents-api/src/__tests__/run/middleware/app-credential-auth.test.ts
@@ -49,6 +49,7 @@ vi.mock('@inkeep/agents-core', async () => {
     canUseProjectStrict: canUseProjectStrictMock,
     validateTargetAgent: validateTargetAgentMock,
     verifyPoW: verifyPoWMock,
+    getInProcessFetch: () => vi.fn(),
     getPoWErrorMessage: (error: string) => {
       const messages: Record<string, string> = {
         pow_expired: 'Proof-of-work challenge has expired. Please request a new challenge.',
@@ -68,6 +69,8 @@ vi.mock('@inkeep/agents-core', async () => {
 
 vi.mock('jose', () => ({
   jwtVerify: jwtVerifyMock,
+  createRemoteJWKSet: vi.fn(() => vi.fn()),
+  customFetch: Symbol('customFetch'),
   errors: {
     JWTExpired: class JWTExpired extends Error {},
     JWSSignatureVerificationFailed: class JWSSignatureVerificationFailed extends Error {},
@@ -86,11 +89,28 @@ vi.mock('../../../env.js', () => ({
   env: {
     INKEEP_AGENTS_RUN_API_BYPASS_SECRET: undefined as string | undefined,
     INKEEP_AGENTS_API_URL: 'http://localhost:3002',
+    COPILOT_OAUTH_CLIENT_ID: 'copilot-client-id',
   },
 }));
 
 import { Hono } from 'hono';
 import { runApiKeyAuth as apiKeyAuth } from '../../../middleware/runAuth';
+
+function makeSupportCopilotApp(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'app-copilot-1',
+    tenantId: 'tenant_1',
+    projectId: 'project_1',
+    type: 'support_copilot',
+    enabled: true,
+    defaultAgentId: 'agent-1',
+    config: {
+      type: 'support_copilot',
+      supportCopilot: { credentialReferenceIds: [] },
+    },
+    ...overrides,
+  };
+}
 
 function makeWebClientApp(overrides: Record<string, unknown> = {}) {
   return {
@@ -561,6 +581,156 @@ describe('App Credential Authentication', () => {
       });
 
       expect(res.status).toBe(200);
+    });
+  });
+
+  describe('support_copilot app with OAuth JWT', () => {
+    const VALID_OAUTH_JWT = 'eyJhbGciOiJFZERTQSJ9.oauth-payload.oauth-signature';
+
+    beforeEach(() => {
+      app.use('*', apiKeyAuth());
+      app.get('/', (c) => c.json({ success: true }));
+    });
+
+    it('should authenticate successfully with valid OAuth JWT', async () => {
+      getAppByIdMock.mockReturnValue(vi.fn().mockResolvedValue(makeSupportCopilotApp()));
+      canUseProjectStrictMock.mockResolvedValue(true);
+      jwtVerifyMock.mockResolvedValue({
+        payload: {
+          sub: 'user-123',
+          azp: 'copilot-client-id',
+          'https://inkeep.com/tenantId': 'tenant_1',
+        },
+      });
+
+      const res = await app.request('/', {
+        headers: {
+          Authorization: `Bearer ${VALID_OAUTH_JWT}`,
+          'x-inkeep-app-id': 'app-copilot-1',
+        },
+      });
+
+      expect(res.status).toBe(200);
+      expect(canUseProjectStrictMock).toHaveBeenCalledWith({
+        userId: 'user-123',
+        tenantId: 'tenant_1',
+        projectId: 'project_1',
+      });
+    });
+
+    it('should reject when JWT verification fails', async () => {
+      getAppByIdMock.mockReturnValue(vi.fn().mockResolvedValue(makeSupportCopilotApp()));
+      jwtVerifyMock.mockRejectedValue(new Error('signature invalid'));
+
+      const res = await app.request('/', {
+        headers: {
+          Authorization: `Bearer ${VALID_OAUTH_JWT}`,
+          'x-inkeep-app-id': 'app-copilot-1',
+        },
+      });
+
+      expect(res.status).toBe(401);
+    });
+
+    it('should reject when azp does not match COPILOT_OAUTH_CLIENT_ID', async () => {
+      getAppByIdMock.mockReturnValue(vi.fn().mockResolvedValue(makeSupportCopilotApp()));
+      jwtVerifyMock.mockResolvedValue({
+        payload: {
+          sub: 'user-123',
+          azp: 'wrong-client-id',
+          'https://inkeep.com/tenantId': 'tenant_1',
+        },
+      });
+
+      const res = await app.request('/', {
+        headers: {
+          Authorization: `Bearer ${VALID_OAUTH_JWT}`,
+          'x-inkeep-app-id': 'app-copilot-1',
+        },
+      });
+
+      expect(res.status).toBe(401);
+    });
+
+    it('should reject when JWT tenant does not match app tenant', async () => {
+      getAppByIdMock.mockReturnValue(vi.fn().mockResolvedValue(makeSupportCopilotApp()));
+      jwtVerifyMock.mockResolvedValue({
+        payload: {
+          sub: 'user-123',
+          azp: 'copilot-client-id',
+          'https://inkeep.com/tenantId': 'different-tenant',
+        },
+      });
+
+      const res = await app.request('/', {
+        headers: {
+          Authorization: `Bearer ${VALID_OAUTH_JWT}`,
+          'x-inkeep-app-id': 'app-copilot-1',
+        },
+      });
+
+      expect(res.status).toBe(403);
+    });
+
+    it('should reject when user lacks project permission (canUseProjectStrict = false)', async () => {
+      getAppByIdMock.mockReturnValue(vi.fn().mockResolvedValue(makeSupportCopilotApp()));
+      canUseProjectStrictMock.mockResolvedValue(false);
+      jwtVerifyMock.mockResolvedValue({
+        payload: {
+          sub: 'user-123',
+          azp: 'copilot-client-id',
+          'https://inkeep.com/tenantId': 'tenant_1',
+        },
+      });
+
+      const res = await app.request('/', {
+        headers: {
+          Authorization: `Bearer ${VALID_OAUTH_JWT}`,
+          'x-inkeep-app-id': 'app-copilot-1',
+        },
+      });
+
+      expect(res.status).toBe(403);
+    });
+
+    it('should return 503 when SpiceDB is unavailable', async () => {
+      getAppByIdMock.mockReturnValue(vi.fn().mockResolvedValue(makeSupportCopilotApp()));
+      canUseProjectStrictMock.mockRejectedValue(new Error('SpiceDB unreachable'));
+      jwtVerifyMock.mockResolvedValue({
+        payload: {
+          sub: 'user-123',
+          azp: 'copilot-client-id',
+          'https://inkeep.com/tenantId': 'tenant_1',
+        },
+      });
+
+      const res = await app.request('/', {
+        headers: {
+          Authorization: `Bearer ${VALID_OAUTH_JWT}`,
+          'x-inkeep-app-id': 'app-copilot-1',
+        },
+      });
+
+      expect(res.status).toBe(503);
+    });
+
+    it('should reject when JWT missing sub claim', async () => {
+      getAppByIdMock.mockReturnValue(vi.fn().mockResolvedValue(makeSupportCopilotApp()));
+      jwtVerifyMock.mockResolvedValue({
+        payload: {
+          azp: 'copilot-client-id',
+          'https://inkeep.com/tenantId': 'tenant_1',
+        },
+      });
+
+      const res = await app.request('/', {
+        headers: {
+          Authorization: `Bearer ${VALID_OAUTH_JWT}`,
+          'x-inkeep-app-id': 'app-copilot-1',
+        },
+      });
+
+      expect(res.status).toBe(401);
     });
   });
 });

--- a/agents-api/src/__tests__/run/middleware/runAuth-appPrompt.test.ts
+++ b/agents-api/src/__tests__/run/middleware/runAuth-appPrompt.test.ts
@@ -46,6 +46,7 @@ vi.mock('@inkeep/agents-core', () => ({
   canUseProjectStrict: canUseProjectStrictMock,
   validateTargetAgent: validateTargetAgentMock,
   verifyPoW: verifyPoWMock,
+  getInProcessFetch: () => vi.fn(),
   getPoWErrorMessage: (error: string) => {
     const messages: Record<string, string> = {
       pow_expired: 'Proof-of-work challenge has expired.',
@@ -64,6 +65,8 @@ vi.mock('@inkeep/agents-core', () => ({
 
 vi.mock('jose', () => ({
   jwtVerify: jwtVerifyMock,
+  createRemoteJWKSet: vi.fn(() => vi.fn()),
+  customFetch: Symbol('customFetch'),
   errors: {
     JWTExpired: class JWTExpired extends Error {},
     JWSSignatureVerificationFailed: class JWSSignatureVerificationFailed extends Error {},

--- a/agents-api/src/domains/manage/index.ts
+++ b/agents-api/src/domains/manage/index.ts
@@ -17,6 +17,7 @@ import playgroundTokenRoutes from './routes/playgroundToken';
 import projectFullRoutes from './routes/projectFull';
 import projectGitHubAccessRoutes from './routes/projectGithubAccess';
 import signozRoutes from './routes/signoz';
+import tenantAppsRoutes from './routes/tenantApps';
 import userProfileRoutes from './routes/userProfile';
 import userProjectMembershipsRoutes from './routes/userProjectMemberships';
 import usersRoutes from './routes/users';
@@ -73,6 +74,9 @@ export function createManageRoutes() {
 
   // Mount feedback routes under tenant/project
   app.route('/tenants/:tenantId/projects/:projectId/feedback', feedbackRoutes);
+
+  // Mount tenant-level apps listing (cross-project, e.g. for support_copilot discovery)
+  app.route('/tenants/:tenantId/apps', tenantAppsRoutes);
 
   // Mount full project routes directly under tenant
   app.route('/tenants/:tenantId', projectFullRoutes);

--- a/agents-api/src/domains/manage/routes/apps.ts
+++ b/agents-api/src/domains/manage/routes/apps.ts
@@ -44,7 +44,10 @@ app.openapi(
     request: {
       params: TenantProjectParamsSchema,
       query: PaginationQueryParamsSchema.extend({
-        type: z.enum(['web_client', 'api']).optional().describe('Filter by app type'),
+        type: z
+          .enum(['web_client', 'api', 'support_copilot'])
+          .optional()
+          .describe('Filter by app type'),
       }),
     },
     responses: {

--- a/agents-api/src/domains/manage/routes/apps.ts
+++ b/agents-api/src/domains/manage/routes/apps.ts
@@ -67,7 +67,7 @@ app.openapi(
     const { tenantId, projectId } = c.req.valid('param');
     const page = Number(c.req.query('page')) || 1;
     const limit = Math.min(Number(c.req.query('limit')) || 10, 100);
-    const type = c.req.query('type') as 'web_client' | 'api' | undefined;
+    const type = c.req.query('type') as 'web_client' | 'api' | 'support_copilot' | undefined;
 
     const result = await listAppsPaginated(runDbClient)({
       scopes: { tenantId, projectId },

--- a/agents-api/src/domains/manage/routes/tenantApps.ts
+++ b/agents-api/src/domains/manage/routes/tenantApps.ts
@@ -1,0 +1,67 @@
+import { OpenAPIHono, z } from '@hono/zod-openapi';
+import {
+  AppListResponse,
+  listAppsPaginated,
+  PaginationQueryParamsSchema,
+  sanitizeAppConfig,
+  TenantParamsSchema,
+} from '@inkeep/agents-core';
+import { createProtectedRoute, inheritedManageTenantAuth } from '@inkeep/agents-core/middleware';
+import runDbClient from '../../../data/db/runDbClient';
+import type { ManageAppVariables } from '../../../types/app';
+import { speakeasyOffsetLimitPagination } from '../../../utils/speakeasy';
+
+const app = new OpenAPIHono<{ Variables: ManageAppVariables }>();
+
+app.openapi(
+  createProtectedRoute({
+    method: 'get',
+    path: '/',
+    summary: 'List Tenant Apps',
+    description: 'List all apps for a tenant across all projects, optionally filtered by type',
+    operationId: 'list-tenant-apps',
+    tags: ['Apps'],
+    permission: inheritedManageTenantAuth(),
+    request: {
+      params: TenantParamsSchema,
+      query: PaginationQueryParamsSchema.extend({
+        type: z
+          .enum(['web_client', 'api', 'support_copilot'])
+          .optional()
+          .describe('Filter by app type'),
+      }),
+    },
+    responses: {
+      200: {
+        description: 'List of apps retrieved successfully',
+        content: {
+          'application/json': {
+            schema: AppListResponse,
+          },
+        },
+      },
+    },
+    ...speakeasyOffsetLimitPagination,
+  }),
+  async (c) => {
+    const { tenantId } = c.req.valid('param');
+    const page = Number(c.req.query('page')) || 1;
+    const limit = Math.min(Number(c.req.query('limit')) || 10, 100);
+    const type = c.req.query('type') as 'web_client' | 'api' | 'support_copilot' | undefined;
+
+    const result = await listAppsPaginated(runDbClient)({
+      scopes: { tenantId },
+      pagination: { page, limit },
+      type,
+    });
+
+    const sanitizedData = result.data.map((app) => sanitizeAppConfig(app));
+
+    return c.json({
+      data: sanitizedData,
+      pagination: result.pagination,
+    });
+  }
+);
+
+export default app;

--- a/agents-api/src/domains/manage/routes/tenantApps.ts
+++ b/agents-api/src/domains/manage/routes/tenantApps.ts
@@ -1,6 +1,7 @@
 import { OpenAPIHono, z } from '@hono/zod-openapi';
 import {
   AppListResponse,
+  commonGetErrorResponses,
   listAppsPaginated,
   PaginationQueryParamsSchema,
   sanitizeAppConfig,
@@ -40,6 +41,7 @@ app.openapi(
           },
         },
       },
+      ...commonGetErrorResponses,
     },
     ...speakeasyOffsetLimitPagination,
   }),

--- a/agents-api/src/env.ts
+++ b/agents-api/src/env.ts
@@ -67,6 +67,14 @@ const envSchema = z
       })
       .describe('Admin password for management UI login (min 8 characters)'),
 
+    // OAuth 2.1 Support Copilot
+    COPILOT_OAUTH_CLIENT_ID: z
+      .string()
+      .optional()
+      .describe(
+        'OAuth 2.1 client ID for the Support Copilot app (created by pnpm setup-oauth-client)'
+      ),
+
     // API Bypass Secrets (for local development and testing, skips auth)
     INKEEP_AGENTS_API_BYPASS_SECRET: z
       .string()

--- a/agents-api/src/middleware/manageAuth.ts
+++ b/agents-api/src/middleware/manageAuth.ts
@@ -1,5 +1,6 @@
 import {
   type BaseExecutionContext,
+  getInProcessFetch,
   getLogger,
   isInternalServiceToken,
   isSlackUserToken,
@@ -11,9 +12,15 @@ import type { createAuth } from '@inkeep/agents-core/auth';
 import { registerAuthzMeta } from '@inkeep/agents-core/middleware';
 import { createMiddleware } from 'hono/factory';
 import { HTTPException } from 'hono/http-exception';
+import { createRemoteJWKSet, customFetch, jwtVerify } from 'jose';
 import runDbClient from '../data/db/runDbClient';
 import { env } from '../env';
 import { sessionAuth } from './sessionAuth';
+
+const jwksUrl = new URL('/api/auth/jwks', env.INKEEP_AGENTS_API_URL || 'http://localhost:3002');
+const JWKS = createRemoteJWKSet(jwksUrl, {
+  [customFetch]: getInProcessFetch(),
+});
 
 /**
  * Legacy exception: allow database API keys on GET /manage/tenants/:t/projects/:p/conversations/:id
@@ -39,8 +46,9 @@ const logger = getLogger('env-key-auth');
  * Authentication priority:
  * 1. Bypass secret (INKEEP_AGENTS_MANAGE_API_BYPASS_SECRET)
  * 2. Better-auth session token (from device authorization flow)
- * 3. Slack user JWT token (for Slack work app delegation)
- * 4. Internal service token
+ * 3. OAuth access token (JWT or opaque, from oauthProvider plugin)
+ * 4. Slack user JWT token (for Slack work app delegation)
+ * 5. Internal service token
  *
  * NOTE: Database API keys are intentionally NOT accepted on manage endpoints,
  * EXCEPT for the legacy exception on GET /manage/tenants/:t/projects/:p/conversations/:id
@@ -119,7 +127,34 @@ export const manageBearerAuth = () =>
       logger.debug({ error }, 'Better-auth session validation failed, trying other auth methods');
     }
 
-    // 3. Validate as a Slack user JWT token (for Slack work app delegation)
+    // 3. Validate as an OAuth JWT access token (from oauthProvider plugin)
+    // Only JWT tokens are handled here — opaque tokens are not issued by the copilot flow.
+    if (token.split('.').length === 3) {
+      try {
+        const { payload } = await jwtVerify(token, JWKS);
+        const azp = payload.azp as string | undefined;
+        if (env.COPILOT_OAUTH_CLIENT_ID && azp !== env.COPILOT_OAUTH_CLIENT_ID) {
+          throw new HTTPException(401, { message: 'Invalid OAuth client' });
+        }
+        const sub = payload.sub;
+        const tenantId = payload['https://inkeep.com/tenantId'] as string | undefined;
+        const email = payload['https://inkeep.com/email'] as string | undefined;
+        if (sub) {
+          logger.info({ userId: sub, tenantId }, 'OAuth JWT authenticated successfully');
+          c.set('userId', sub);
+          if (email) c.set('userEmail', email);
+          if (tenantId) c.set('tenantId', tenantId);
+          if (azp) c.set('oauthClientId' as any, azp);
+          await next();
+          return;
+        }
+      } catch (error) {
+        if (error instanceof HTTPException) throw error;
+        logger.debug({ error }, 'OAuth JWT validation failed, trying other auth methods');
+      }
+    }
+
+    // 4. Validate as a Slack user JWT token (for Slack work app delegation)
     if (isSlackUserToken(token)) {
       const result = await verifySlackUserToken(token);
 
@@ -149,7 +184,7 @@ export const manageBearerAuth = () =>
       return;
     }
 
-    // 4. Validate as an internal service token if not already authenticated
+    // 5. Validate as an internal service token if not already authenticated
     if (isInternalServiceToken(token)) {
       const result = await verifyInternalServiceAuthHeader(authHeader);
       if (!result.valid || !result.payload) {
@@ -180,7 +215,7 @@ export const manageBearerAuth = () =>
       return;
     }
 
-    // 5. Legacy exception: allow database API keys on the get-conversation-by-ID endpoint only
+    // 6. Legacy exception: allow database API keys on the get-conversation-by-ID endpoint only
     if (isLegacyApiKeyAllowedRoute(c.req.method, c.req.path)) {
       try {
         const apiKeyRecord = await validateAndGetApiKey(token, runDbClient);

--- a/agents-api/src/middleware/manageAuth.ts
+++ b/agents-api/src/middleware/manageAuth.ts
@@ -1,6 +1,5 @@
 import {
   type BaseExecutionContext,
-  getInProcessFetch,
   getLogger,
   isInternalServiceToken,
   isSlackUserToken,
@@ -12,15 +11,11 @@ import type { createAuth } from '@inkeep/agents-core/auth';
 import { registerAuthzMeta } from '@inkeep/agents-core/middleware';
 import { createMiddleware } from 'hono/factory';
 import { HTTPException } from 'hono/http-exception';
-import { createRemoteJWKSet, customFetch, jwtVerify } from 'jose';
+import { jwtVerify } from 'jose';
 import runDbClient from '../data/db/runDbClient';
 import { env } from '../env';
+import { getOAuthIssuer, getOAuthJwks } from '../utils/oauthJwks';
 import { sessionAuth } from './sessionAuth';
-
-const jwksUrl = new URL('/api/auth/jwks', env.INKEEP_AGENTS_API_URL || 'http://localhost:3002');
-const JWKS = createRemoteJWKSet(jwksUrl, {
-  [customFetch]: getInProcessFetch(),
-});
 
 /**
  * Legacy exception: allow database API keys on GET /manage/tenants/:t/projects/:p/conversations/:id
@@ -129,11 +124,16 @@ export const manageBearerAuth = () =>
 
     // 3. Validate as an OAuth JWT access token (from oauthProvider plugin)
     // Only JWT tokens are handled here — opaque tokens are not issued by the copilot flow.
-    if (token.split('.').length === 3) {
+    // OAuth JWT auth is disabled entirely when COPILOT_OAUTH_CLIENT_ID is unset, so an
+    // unconfigured deployment cannot be tricked into accepting a JWT intended for a different
+    // OAuth client on the same provider.
+    if (env.COPILOT_OAUTH_CLIENT_ID && token.split('.').length === 3) {
       try {
-        const { payload } = await jwtVerify(token, JWKS);
+        const { payload } = await jwtVerify(token, getOAuthJwks(), {
+          issuer: getOAuthIssuer(),
+        });
         const azp = payload.azp as string | undefined;
-        if (env.COPILOT_OAUTH_CLIENT_ID && azp !== env.COPILOT_OAUTH_CLIENT_ID) {
+        if (azp !== env.COPILOT_OAUTH_CLIENT_ID) {
           throw new HTTPException(401, { message: 'Invalid OAuth client' });
         }
         const sub = payload.sub;
@@ -144,7 +144,7 @@ export const manageBearerAuth = () =>
           c.set('userId', sub);
           if (email) c.set('userEmail', email);
           if (tenantId) c.set('tenantId', tenantId);
-          if (azp) c.set('oauthClientId' as any, azp);
+          c.set('oauthClientId' as any, azp);
           await next();
           return;
         }

--- a/agents-api/src/middleware/runAuth.ts
+++ b/agents-api/src/middleware/runAuth.ts
@@ -3,6 +3,7 @@ import {
   canUseProjectStrict,
   createApiError,
   getAppById,
+  getInProcessFetch,
   getPoWErrorMessage,
   isSlackUserToken,
   type PublicKeyConfig,
@@ -18,7 +19,14 @@ import {
 import { trace } from '@opentelemetry/api';
 import { createMiddleware } from 'hono/factory';
 import { HTTPException } from 'hono/http-exception';
-import { decodeProtectedHeader, errors, importSPKI, jwtVerify } from 'jose';
+import {
+  createRemoteJWKSet,
+  customFetch,
+  decodeProtectedHeader,
+  errors,
+  importSPKI,
+  jwtVerify,
+} from 'jose';
 import runDbClient from '../data/db/runDbClient';
 import { getAnonJwtSecret } from '../domains/run/routes/auth';
 import { env } from '../env';
@@ -26,6 +34,11 @@ import { getLogger } from '../logger';
 import { createBaseExecutionContext } from '../types/runExecutionContext';
 
 const logger = getLogger('env-key-auth');
+
+const jwksUrl = new URL('/api/auth/jwks', env.INKEEP_AGENTS_API_URL || 'http://localhost:3002');
+const JWKS = createRemoteJWKSet(jwksUrl, {
+  [customFetch]: getInProcessFetch(),
+});
 
 // ============================================================================
 // Supported auth strategies
@@ -402,6 +415,101 @@ function tryBypassAuth(apiKey: string, reqData: RequestData): AuthAttempt {
   };
 }
 
+async function tryOAuthSupportCopilotAuth(
+  app: NonNullable<Awaited<ReturnType<ReturnType<typeof getAppById>>>>,
+  reqData: RequestData
+): Promise<AuthAttempt> {
+  const { apiKey: bearerToken, agentId: requestedAgentId } = reqData;
+
+  if (!bearerToken) {
+    return { authResult: null, failureMessage: 'Bearer token required for support_copilot app' };
+  }
+
+  let payload: Record<string, unknown>;
+  try {
+    const result = await jwtVerify(bearerToken, JWKS);
+    payload = result.payload as Record<string, unknown>;
+  } catch (err) {
+    logger.debug(
+      { error: err, appId: app.id },
+      'OAuth JWT verification failed for support_copilot'
+    );
+    return { authResult: null, failureMessage: 'Invalid or expired OAuth JWT' };
+  }
+
+  const sub = payload.sub as string | undefined;
+  const azp = payload.azp as string | undefined;
+  const jwtTenantId = payload['https://inkeep.com/tenantId'] as string | undefined;
+
+  if (!sub) {
+    return { authResult: null, failureMessage: 'OAuth JWT missing sub claim' };
+  }
+
+  if (env.COPILOT_OAUTH_CLIENT_ID && azp !== env.COPILOT_OAUTH_CLIENT_ID) {
+    logger.warn({ azp, appId: app.id }, 'OAuth JWT azp mismatch');
+    throw new HTTPException(401, { message: 'Invalid OAuth client' });
+  }
+
+  if (app.tenantId && jwtTenantId && app.tenantId !== jwtTenantId) {
+    logger.warn(
+      { appTenantId: app.tenantId, jwtTenantId, appId: app.id },
+      'OAuth JWT tenant mismatch'
+    );
+    throw new HTTPException(403, { message: 'Tenant mismatch' });
+  }
+
+  if (!app.projectId) {
+    logger.error({ appId: app.id }, 'support_copilot app missing projectId');
+    throw createApiError({ code: 'internal_server_error', message: 'App configuration error' });
+  }
+
+  try {
+    const canUse = await canUseProjectStrict({
+      userId: sub,
+      tenantId: app.tenantId || '',
+      projectId: app.projectId,
+    });
+    if (!canUse) {
+      logger.warn(
+        { userId: sub, tenantId: app.tenantId, projectId: app.projectId },
+        'OAuth JWT: user does not have access to requested project'
+      );
+      throw new HTTPException(403, { message: 'Access denied: insufficient permissions' });
+    }
+  } catch (error) {
+    if (error instanceof HTTPException) throw error;
+    logger.error(
+      { error, userId: sub, projectId: app.projectId },
+      'SpiceDB permission check failed for OAuth JWT'
+    );
+    throw new HTTPException(503, { message: 'Authorization service temporarily unavailable' });
+  }
+
+  if (Math.random() < 0.1) {
+    updateAppLastUsed(runDbClient)(app.id).catch((err) => {
+      logger.error({ error: err, appId: app.id }, 'Failed to update app lastUsedAt');
+    });
+  }
+
+  logger.info({ appId: app.id, userId: sub }, 'OAuth support_copilot authenticated successfully');
+
+  return {
+    authResult: {
+      apiKey: bearerToken,
+      tenantId: app.tenantId || '',
+      projectId: app.projectId,
+      agentId: requestedAgentId || app.defaultAgentId || '',
+      apiKeyId: `app:${app.id}`,
+      metadata: {
+        endUserId: sub,
+        initiatedBy: { type: 'user' as const, id: sub },
+        authMethod: 'app_credential_support_copilot',
+        appId: app.id,
+      },
+    },
+  };
+}
+
 /**
  * Authenticate using an app credential (X-Inkeep-App-Id header).
  * Supports web_client (end-user JWT) and api (app secret) types.
@@ -738,6 +846,8 @@ async function tryAppCredentialAuth(reqData: RequestData): Promise<AuthAttempt> 
       }
       return { authResult: null, failureMessage: 'Invalid end-user JWT' };
     }
+  } else if (app.type === 'support_copilot') {
+    return tryOAuthSupportCopilotAuth(app, reqData);
   } else {
     return { authResult: null, failureMessage: 'Unsupported app type' };
   }

--- a/agents-api/src/middleware/runAuth.ts
+++ b/agents-api/src/middleware/runAuth.ts
@@ -3,7 +3,6 @@ import {
   canUseProjectStrict,
   createApiError,
   getAppById,
-  getInProcessFetch,
   getPoWErrorMessage,
   isSlackUserToken,
   type PublicKeyConfig,
@@ -19,26 +18,15 @@ import {
 import { trace } from '@opentelemetry/api';
 import { createMiddleware } from 'hono/factory';
 import { HTTPException } from 'hono/http-exception';
-import {
-  createRemoteJWKSet,
-  customFetch,
-  decodeProtectedHeader,
-  errors,
-  importSPKI,
-  jwtVerify,
-} from 'jose';
+import { decodeProtectedHeader, errors, importSPKI, jwtVerify } from 'jose';
 import runDbClient from '../data/db/runDbClient';
 import { getAnonJwtSecret } from '../domains/run/routes/auth';
 import { env } from '../env';
 import { getLogger } from '../logger';
 import { createBaseExecutionContext } from '../types/runExecutionContext';
+import { getOAuthIssuer, getOAuthJwks } from '../utils/oauthJwks';
 
 const logger = getLogger('env-key-auth');
-
-const jwksUrl = new URL('/api/auth/jwks', env.INKEEP_AGENTS_API_URL || 'http://localhost:3002');
-const JWKS = createRemoteJWKSet(jwksUrl, {
-  [customFetch]: getInProcessFetch(),
-});
 
 // ============================================================================
 // Supported auth strategies
@@ -425,9 +413,22 @@ async function tryOAuthSupportCopilotAuth(
     return { authResult: null, failureMessage: 'Bearer token required for support_copilot app' };
   }
 
+  // OAuth JWT auth is disabled entirely when COPILOT_OAUTH_CLIENT_ID is unset so an
+  // unconfigured deployment cannot be tricked into accepting a JWT intended for a
+  // different OAuth client on the same provider.
+  if (!env.COPILOT_OAUTH_CLIENT_ID) {
+    logger.warn(
+      { appId: app.id },
+      'support_copilot app credential auth attempted but COPILOT_OAUTH_CLIENT_ID is not configured'
+    );
+    return { authResult: null, failureMessage: 'OAuth is not configured for support_copilot' };
+  }
+
   let payload: Record<string, unknown>;
   try {
-    const result = await jwtVerify(bearerToken, JWKS);
+    const result = await jwtVerify(bearerToken, getOAuthJwks(), {
+      issuer: getOAuthIssuer(),
+    });
     payload = result.payload as Record<string, unknown>;
   } catch (err) {
     logger.debug(
@@ -445,12 +446,17 @@ async function tryOAuthSupportCopilotAuth(
     return { authResult: null, failureMessage: 'OAuth JWT missing sub claim' };
   }
 
-  if (env.COPILOT_OAUTH_CLIENT_ID && azp !== env.COPILOT_OAUTH_CLIENT_ID) {
+  if (!jwtTenantId) {
+    logger.warn({ appId: app.id, userId: sub }, 'OAuth JWT missing tenantId claim');
+    return { authResult: null, failureMessage: 'OAuth JWT missing tenantId claim' };
+  }
+
+  if (azp !== env.COPILOT_OAUTH_CLIENT_ID) {
     logger.warn({ azp, appId: app.id }, 'OAuth JWT azp mismatch');
     throw new HTTPException(401, { message: 'Invalid OAuth client' });
   }
 
-  if (app.tenantId && jwtTenantId && app.tenantId !== jwtTenantId) {
+  if (app.tenantId && app.tenantId !== jwtTenantId) {
     logger.warn(
       { appTenantId: app.tenantId, jwtTenantId, appId: app.id },
       'OAuth JWT tenant mismatch'

--- a/agents-api/src/utils/oauthJwks.ts
+++ b/agents-api/src/utils/oauthJwks.ts
@@ -1,0 +1,28 @@
+import { getInProcessFetch } from '@inkeep/agents-core';
+import { createRemoteJWKSet, customFetch } from 'jose';
+import { env } from '../env';
+
+let cachedJwks: ReturnType<typeof createRemoteJWKSet> | null = null;
+
+/**
+ * Shared JWKS singleton for verifying OAuth JWTs issued by the local
+ * oauthProvider plugin. Lazy-initialized so module imports don't depend
+ * on env values at load time.
+ */
+export function getOAuthJwks(): ReturnType<typeof createRemoteJWKSet> {
+  if (!cachedJwks) {
+    const jwksUrl = new URL('/api/auth/jwks', env.INKEEP_AGENTS_API_URL || 'http://localhost:3002');
+    cachedJwks = createRemoteJWKSet(jwksUrl, {
+      [customFetch]: getInProcessFetch(),
+    });
+  }
+  return cachedJwks;
+}
+
+/**
+ * Issuer value that the oauthProvider plugin sets on JWTs it issues.
+ * Used for defense-in-depth `iss` claim validation in `jwtVerify({ issuer })`.
+ */
+export function getOAuthIssuer(): string {
+  return `${env.INKEEP_AGENTS_API_URL || 'http://localhost:3002'}/api/auth`;
+}

--- a/agents-manage-ui/src/app/[tenantId]/projects/[projectId]/apps/page.tsx
+++ b/agents-manage-ui/src/app/[tenantId]/projects/[projectId]/apps/page.tsx
@@ -7,6 +7,8 @@ import { PageHeader } from '@/components/layout/page-header';
 import { STATIC_LABELS } from '@/constants/theme';
 import { fetchAgents } from '@/lib/api/agent-full-client';
 import { fetchApps } from '@/lib/api/apps';
+import { fetchCredentials } from '@/lib/api/credentials';
+import { fetchEntitlements } from '@/lib/api/entitlements';
 import { fetchProjectPermissions } from '@/lib/api/projects';
 import type { Agent } from '@/lib/types/agent-full';
 import { createLookup } from '@/lib/utils';
@@ -31,21 +33,43 @@ async function AppsPage({ params }: PageProps<'/[tenantId]/projects/[projectId]/
   const { tenantId, projectId } = await params;
 
   try {
-    const [apps, agents, { canUse }] = await Promise.all([
+    const [apps, agents, credentials, entitlements, { canUse }] = await Promise.all([
       fetchApps(tenantId, projectId),
       fetchAgents(tenantId, projectId),
+      fetchCredentials(tenantId, projectId),
+      fetchEntitlements(tenantId),
       fetchProjectPermissions(tenantId, projectId),
     ]);
     const agentLookup = createLookup(agents.data);
     const agentOptions = createAgentOptions(agents.data);
+    const credentialOptions: SelectOption[] = credentials.map((c) => ({
+      value: c.id,
+      label: c.name || c.id,
+    }));
+    const hasSupportCopilotEntitlement = entitlements.some(
+      (e) => e.resourceType === 'feature:support_copilot' && e.maxValue > 0
+    );
     return (
       <>
         <PageHeader
           title={metadata.title}
           description={metadata.description}
-          action={canUse ? <NewAppDialog agentOptions={agentOptions} /> : undefined}
+          action={
+            canUse ? (
+              <NewAppDialog
+                agentOptions={agentOptions}
+                credentialOptions={credentialOptions}
+                hasSupportCopilotEntitlement={hasSupportCopilotEntitlement}
+              />
+            ) : undefined
+          }
         />
-        <AppsTable apps={apps.data} agentLookup={agentLookup} agentOptions={agentOptions} />
+        <AppsTable
+          apps={apps.data}
+          agentLookup={agentLookup}
+          agentOptions={agentOptions}
+          credentialOptions={credentialOptions}
+        />
       </>
     );
   } catch (error) {

--- a/agents-manage-ui/src/components/apps/app-item-menu.tsx
+++ b/agents-manage-ui/src/components/apps/app-item-menu.tsx
@@ -17,11 +17,12 @@ import { UpdateAppDialog } from './update-app-dialog';
 interface AppItemMenuProps {
   app: App;
   agentOptions: SelectOption[];
+  credentialOptions: SelectOption[];
 }
 
 type DialogType = 'delete' | 'update' | null;
 
-export function AppItemMenu({ app, agentOptions }: AppItemMenuProps) {
+export function AppItemMenu({ app, agentOptions, credentialOptions }: AppItemMenuProps) {
   const [openDialog, setOpenDialog] = useState<DialogType>(null);
 
   const handleDialogClose = () => {
@@ -54,7 +55,12 @@ export function AppItemMenu({ app, agentOptions }: AppItemMenuProps) {
       )}
 
       {openDialog === 'update' && (
-        <UpdateAppDialog app={app} agentOptions={agentOptions} setIsOpen={handleDialogClose} />
+        <UpdateAppDialog
+          app={app}
+          agentOptions={agentOptions}
+          credentialOptions={credentialOptions}
+          setIsOpen={handleDialogClose}
+        />
       )}
     </>
   );

--- a/agents-manage-ui/src/components/apps/apps-table.tsx
+++ b/agents-manage-ui/src/components/apps/apps-table.tsx
@@ -19,16 +19,19 @@ interface AppsTableProps {
   apps: App[];
   agentLookup: Record<string, Agent>;
   agentOptions: SelectOption[];
+  credentialOptions: SelectOption[];
 }
 
 const TYPE_LABELS: Record<string, string> = {
   web_client: 'Web Client',
   api: 'API',
+  support_copilot: 'Support Copilot',
 };
 
-const TYPE_BADGE_VARIANT: Record<string, 'sky' | 'violet'> = {
+const TYPE_BADGE_VARIANT: Record<string, 'sky' | 'violet' | 'orange'> = {
   web_client: 'sky',
   api: 'violet',
+  support_copilot: 'orange',
 };
 
 function AppIdCell({ appId }: { appId: string }) {
@@ -52,7 +55,7 @@ function AppIdCell({ appId }: { appId: string }) {
   );
 }
 
-export function AppsTable({ apps, agentLookup, agentOptions }: AppsTableProps) {
+export function AppsTable({ apps, agentLookup, agentOptions, credentialOptions }: AppsTableProps) {
   const { tenantId } = useParams<{ tenantId: string }>();
   const {
     data: { canUse },
@@ -133,7 +136,14 @@ export function AppsTable({ apps, agentLookup, agentOptions }: AppsTableProps) {
       header: '',
       enableSorting: false,
       meta: { className: 'w-12' },
-      cell: ({ row }) => canUse && <AppItemMenu app={row.original} agentOptions={agentOptions} />,
+      cell: ({ row }) =>
+        canUse && (
+          <AppItemMenu
+            app={row.original}
+            agentOptions={agentOptions}
+            credentialOptions={credentialOptions}
+          />
+        ),
     },
   ];
 

--- a/agents-manage-ui/src/components/apps/form/app-create-form.tsx
+++ b/agents-manage-ui/src/components/apps/form/app-create-form.tsx
@@ -20,15 +20,22 @@ import { Separator } from '@/components/ui/separator';
 import { addAppAuthKeyAction } from '@/lib/actions/app-auth-keys';
 import { createAppAction } from '@/lib/actions/apps';
 import type { AppCreateResponse } from '@/lib/api/apps';
+import { CredentialMultiSelect } from './credential-multi-select';
 import { type AppCreateFormInput, AppCreateFormSchema } from './validation';
 
 interface AppCreateFormProps {
-  appType: 'web_client' | 'api';
+  appType: 'web_client' | 'api' | 'support_copilot';
   agentOptions: SelectOption[];
+  credentialOptions: SelectOption[];
   onAppCreated: (result: AppCreateResponse) => void;
 }
 
-export function AppCreateForm({ appType, agentOptions, onAppCreated }: AppCreateFormProps) {
+export function AppCreateForm({
+  appType,
+  agentOptions,
+  credentialOptions,
+  onAppCreated,
+}: AppCreateFormProps) {
   const { tenantId, projectId } = useParams<{ tenantId: string; projectId: string }>();
 
   const [pendingKeysToAdd, setPendingKeysToAdd] = useState<PendingKey[]>([]);
@@ -44,6 +51,7 @@ export function AppCreateForm({ appType, agentOptions, onAppCreated }: AppCreate
       prompt: '',
       allowedDomains: appType === 'web_client' ? '' : undefined,
       audience: '',
+      credentialReferenceIds: [],
     },
     mode: 'onChange',
   });
@@ -79,7 +87,14 @@ export function AppCreateForm({ appType, agentOptions, onAppCreated }: AppCreate
                   ...authConfig,
                 },
               }
-            : { type: 'api', api: {} },
+            : appType === 'support_copilot'
+              ? {
+                  type: 'support_copilot',
+                  supportCopilot: {
+                    credentialReferenceIds: data.credentialReferenceIds ?? [],
+                  },
+                }
+              : { type: 'api', api: {} },
       };
 
       const result = await createAppAction(tenantId, projectId, payload);
@@ -157,6 +172,18 @@ export function AppCreateForm({ appType, agentOptions, onAppCreated }: AppCreate
           rows={4}
           className="max-h-96"
         />
+
+        {appType === 'support_copilot' && credentialOptions.length > 0 && (
+          <CredentialMultiSelect
+            control={form.control}
+            name="credentialReferenceIds"
+            label="Credentials"
+            description="Optional. Grant this app access to stored credentials for connecting to external services."
+            options={credentialOptions}
+            placeholder="Select credentials..."
+            searchPlaceholder="Search credentials..."
+          />
+        )}
 
         {appType === 'web_client' && (
           <>

--- a/agents-manage-ui/src/components/apps/form/app-update-form.tsx
+++ b/agents-manage-ui/src/components/apps/form/app-update-form.tsx
@@ -24,6 +24,7 @@ import {
 } from '@/lib/actions/app-auth-keys';
 import { updateAppAction } from '@/lib/actions/apps';
 import type { App } from '@/lib/api/apps';
+import { CredentialMultiSelect } from './credential-multi-select';
 import { type AppUpdateFormInput, AppUpdateFormSchema } from './validation';
 
 interface AppUpdateFormProps {
@@ -31,6 +32,7 @@ interface AppUpdateFormProps {
   projectId: string;
   app: App;
   agentOptions: SelectOption[];
+  credentialOptions: SelectOption[];
   onAppUpdated: () => void;
 }
 
@@ -45,11 +47,19 @@ export function AppUpdateForm({
   projectId,
   app,
   agentOptions,
+  credentialOptions,
   onAppUpdated,
 }: AppUpdateFormProps) {
   const webConfig: WebClientConfigShape | null =
     app.type === 'web_client'
       ? (((app.config as Record<string, unknown>)?.webClient as WebClientConfigShape) ?? null)
+      : null;
+
+  const supportCopilotConfig =
+    app.type === 'support_copilot'
+      ? ((app.config as Record<string, unknown>)?.supportCopilot as
+          | { credentialReferenceIds?: string[] }
+          | undefined)
       : null;
 
   const [serverKeys, setServerKeys] = useState<PublicKeyDisplay[]>([]);
@@ -84,6 +94,7 @@ export function AppUpdateForm({
             audience: webConfig?.audience ?? '',
           }
         : {}),
+      credentialReferenceIds: supportCopilotConfig?.credentialReferenceIds ?? [],
     },
     mode: 'onChange',
   });
@@ -116,6 +127,13 @@ export function AppUpdateForm({
         payload.config = {
           type: 'web_client',
           webClient: webClientConfig,
+        };
+      } else if (app.type === 'support_copilot') {
+        payload.config = {
+          type: 'support_copilot',
+          supportCopilot: {
+            credentialReferenceIds: data.credentialReferenceIds ?? [],
+          },
         };
       }
 
@@ -215,6 +233,18 @@ export function AppUpdateForm({
           rows={4}
           className="max-h-96"
         />
+
+        {app.type === 'support_copilot' && credentialOptions.length > 0 && (
+          <CredentialMultiSelect
+            control={form.control}
+            name="credentialReferenceIds"
+            label="Credentials"
+            description="Optional. Grant this app access to stored credentials for connecting to external services."
+            options={credentialOptions}
+            placeholder="Select credentials..."
+            searchPlaceholder="Search credentials..."
+          />
+        )}
 
         {app.type === 'web_client' && !isLoadingKeys && (
           <>

--- a/agents-manage-ui/src/components/apps/form/credential-multi-select.tsx
+++ b/agents-manage-ui/src/components/apps/form/credential-multi-select.tsx
@@ -1,0 +1,143 @@
+'use client';
+
+import { Check, ChevronsUpDown, X } from 'lucide-react';
+import { useState } from 'react';
+import type { Control, FieldPath, FieldValues } from 'react-hook-form';
+import type { SelectOption } from '@/components/form/generic-select';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from '@/components/ui/command';
+import {
+  FormControl,
+  FormDescription,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from '@/components/ui/form';
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
+import { cn } from '@/lib/utils';
+
+interface CredentialMultiSelectProps<FV extends FieldValues> {
+  control: Control<FV>;
+  name: FieldPath<FV>;
+  label: string;
+  description?: string;
+  options: SelectOption[];
+  placeholder?: string;
+  searchPlaceholder?: string;
+}
+
+export function CredentialMultiSelect<TFieldValues extends FieldValues>({
+  control,
+  name,
+  label,
+  description,
+  options,
+  placeholder = 'Select credentials...',
+  searchPlaceholder = 'Search credentials...',
+}: CredentialMultiSelectProps<TFieldValues>) {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <FormField
+      control={control}
+      name={name}
+      render={({ field }) => {
+        const selected: string[] = field.value ?? [];
+
+        const toggleValue = (value: string) => {
+          const next = selected.includes(value)
+            ? selected.filter((v) => v !== value)
+            : [...selected, value];
+          field.onChange(next);
+        };
+
+        const removeValue = (value: string) => {
+          field.onChange(selected.filter((v) => v !== value));
+        };
+
+        return (
+          <FormItem>
+            <FormLabel>{label}</FormLabel>
+            <Popover open={open} onOpenChange={setOpen}>
+              <FormControl>
+                <PopoverTrigger asChild>
+                  <Button
+                    variant="outline"
+                    role="combobox"
+                    aria-expanded={open}
+                    className="w-full justify-between font-normal"
+                  >
+                    {selected.length > 0 ? (
+                      <span className="text-muted-foreground">
+                        {selected.length} credential{selected.length !== 1 ? 's' : ''} selected
+                      </span>
+                    ) : (
+                      <span className="text-muted-foreground">{placeholder}</span>
+                    )}
+                    <ChevronsUpDown className="opacity-50 text-muted-foreground" />
+                  </Button>
+                </PopoverTrigger>
+              </FormControl>
+              <PopoverContent className="p-0 w-(--radix-popover-trigger-width)">
+                <Command>
+                  <CommandInput placeholder={searchPlaceholder} className="h-9" />
+                  <CommandList>
+                    <CommandEmpty>No credentials found.</CommandEmpty>
+                    <CommandGroup>
+                      {options.map((option) => (
+                        <CommandItem
+                          key={option.value}
+                          value={option.value}
+                          onSelect={() => toggleValue(option.value)}
+                        >
+                          {option.label}
+                          <Check
+                            className={cn(
+                              'ml-auto',
+                              selected.includes(option.value) ? 'opacity-100' : 'opacity-0'
+                            )}
+                          />
+                        </CommandItem>
+                      ))}
+                    </CommandGroup>
+                  </CommandList>
+                </Command>
+              </PopoverContent>
+            </Popover>
+            {selected.length > 0 && (
+              <div className="flex flex-wrap gap-1 pt-1">
+                {selected.map((id) => {
+                  const opt = options.find((o) => o.value === id);
+                  return (
+                    <Badge key={id} variant="secondary" className="gap-1">
+                      {opt?.label ?? id}
+                      <button
+                        type="button"
+                        className="rounded-full hover:bg-muted-foreground/20"
+                        onClick={() => removeValue(id)}
+                        aria-label={`Remove ${opt?.label ?? id}`}
+                      >
+                        <X className="size-3" />
+                      </button>
+                    </Badge>
+                  );
+                })}
+              </div>
+            )}
+            {description && <FormDescription>{description}</FormDescription>}
+            <FormMessage />
+          </FormItem>
+        );
+      }}
+    />
+  );
+}

--- a/agents-manage-ui/src/components/apps/form/credential-multi-select.tsx
+++ b/agents-manage-ui/src/components/apps/form/credential-multi-select.tsx
@@ -83,7 +83,7 @@ export function CredentialMultiSelect<TFieldValues extends FieldValues>({
                     ) : (
                       <span className="text-muted-foreground">{placeholder}</span>
                     )}
-                    <ChevronsUpDown className="opacity-50 text-muted-foreground" />
+                    <ChevronsUpDown aria-hidden className="opacity-50 text-muted-foreground" />
                   </Button>
                 </PopoverTrigger>
               </FormControl>
@@ -101,6 +101,7 @@ export function CredentialMultiSelect<TFieldValues extends FieldValues>({
                         >
                           {option.label}
                           <Check
+                            aria-hidden
                             className={cn(
                               'ml-auto',
                               selected.includes(option.value) ? 'opacity-100' : 'opacity-0'
@@ -126,7 +127,7 @@ export function CredentialMultiSelect<TFieldValues extends FieldValues>({
                         onClick={() => removeValue(id)}
                         aria-label={`Remove ${opt?.label ?? id}`}
                       >
-                        <X className="size-3" />
+                        <X aria-hidden className="size-3" />
                       </button>
                     </Badge>
                   );

--- a/agents-manage-ui/src/components/apps/form/validation.ts
+++ b/agents-manage-ui/src/components/apps/form/validation.ts
@@ -12,6 +12,11 @@ export const APP_TYPE_OPTIONS = [
     label: 'API',
     description: 'For server-to-server API access',
   },
+  {
+    value: 'support_copilot' as const,
+    label: 'Support Copilot',
+    description: 'For deploying agents across external tools and support platforms',
+  },
 ] as const;
 
 function validateDomainList(val: string | undefined) {
@@ -35,12 +40,17 @@ const webClientFields = {
   audience: z.string().optional(),
 };
 
+const supportCopilotFields = {
+  credentialReferenceIds: z.array(z.string()).optional(),
+};
+
 export const AppCreateFormSchema = z.object({
   name: z.string().min(1, 'Name is required'),
   description: z.string().optional(),
   defaultAgentId: z.string().min(1, 'Default agent is required'),
   prompt: z.string().optional(),
   ...webClientFields,
+  ...supportCopilotFields,
 });
 
 export const AppUpdateFormSchema = z.object({
@@ -50,6 +60,7 @@ export const AppUpdateFormSchema = z.object({
   prompt: z.string().optional(),
   enabled: z.boolean(),
   ...webClientFields,
+  ...supportCopilotFields,
 });
 
 export type AppCreateFormInput = z.infer<typeof AppCreateFormSchema>;

--- a/agents-manage-ui/src/components/apps/new-app-dialog.tsx
+++ b/agents-manage-ui/src/components/apps/new-app-dialog.tsx
@@ -3,6 +3,7 @@
 import { ChevronDown, Plus } from 'lucide-react';
 import { useState } from 'react';
 import type { SelectOption } from '@/components/form/generic-select';
+import { useRuntimeConfig } from '@/contexts/runtime-config';
 import type { AppCreateResponse } from '@/lib/api/apps';
 import { Button } from '../ui/button';
 import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from '../ui/dialog';
@@ -18,11 +19,24 @@ import { APP_TYPE_OPTIONS } from './form/validation';
 
 interface NewAppDialogProps {
   agentOptions: SelectOption[];
+  credentialOptions: SelectOption[];
+  hasSupportCopilotEntitlement: boolean;
 }
 
-type AppType = 'web_client' | 'api';
+type AppType = 'web_client' | 'api' | 'support_copilot';
 
-export function NewAppDialog({ agentOptions }: NewAppDialogProps) {
+export function NewAppDialog({
+  agentOptions,
+  credentialOptions,
+  hasSupportCopilotEntitlement,
+}: NewAppDialogProps) {
+  const { PUBLIC_IS_INKEEP_CLOUD_DEPLOYMENT } = useRuntimeConfig();
+  const isCloudDeployment = PUBLIC_IS_INKEEP_CLOUD_DEPLOYMENT === 'true';
+  const supportCopilotEnabled = isCloudDeployment && hasSupportCopilotEntitlement;
+  const appTypeOptions = APP_TYPE_OPTIONS.filter(
+    (opt) => opt.value !== 'support_copilot' || supportCopilotEnabled
+  );
+
   const [isOpen, setIsOpen] = useState(false);
   const [selectedType, setSelectedType] = useState<AppType | null>(null);
   const [createdApp, setCreatedApp] = useState<AppCreateResponse | null>(null);
@@ -58,7 +72,7 @@ export function NewAppDialog({ agentOptions }: NewAppDialogProps) {
           </Button>
         </DropdownMenuTrigger>
         <DropdownMenuContent align="end" className="w-56">
-          {APP_TYPE_OPTIONS.map((opt) => (
+          {appTypeOptions.map((opt) => (
             <DropdownMenuItem
               key={opt.value}
               className="flex flex-col items-start gap-0.5 py-2"
@@ -84,6 +98,7 @@ export function NewAppDialog({ agentOptions }: NewAppDialogProps) {
               <AppCreateForm
                 appType={selectedType}
                 agentOptions={agentOptions}
+                credentialOptions={credentialOptions}
                 onAppCreated={handleAppCreated}
               />
             )}

--- a/agents-manage-ui/src/components/apps/update-app-dialog.tsx
+++ b/agents-manage-ui/src/components/apps/update-app-dialog.tsx
@@ -10,10 +10,16 @@ import { APP_TYPE_OPTIONS } from './form/validation';
 interface UpdateAppDialogProps {
   app: App;
   agentOptions: SelectOption[];
+  credentialOptions: SelectOption[];
   setIsOpen: (isOpen: boolean) => void;
 }
 
-export function UpdateAppDialog({ app, agentOptions, setIsOpen }: UpdateAppDialogProps) {
+export function UpdateAppDialog({
+  app,
+  agentOptions,
+  credentialOptions,
+  setIsOpen,
+}: UpdateAppDialogProps) {
   const { tenantId, projectId } = useParams<{
     tenantId: string;
     projectId: string;
@@ -34,6 +40,7 @@ export function UpdateAppDialog({ app, agentOptions, setIsOpen }: UpdateAppDialo
             projectId={projectId}
             app={app}
             agentOptions={agentOptions}
+            credentialOptions={credentialOptions}
             onAppUpdated={() => setIsOpen(false)}
           />
         </div>

--- a/package.json
+++ b/package.json
@@ -85,7 +85,8 @@
     "check:dal-boundary": "bash scripts/lint-data-access-boundary.sh",
     "check:env-descriptions": "node scripts/check-env-descriptions.mjs",
     "check:route-handler-patterns": "node scripts/check-route-handler-patterns.mjs",
-    "setup-slack-dev": "tsx scripts/setup-slack-dev.ts"
+    "setup-slack-dev": "tsx scripts/setup-slack-dev.ts",
+    "setup-oauth-client": "tsx scripts/setup-oauth-client.ts"
   },
   "version": "0.1.0",
   "dependencies": {

--- a/packages/agents-core/src/types/utility.ts
+++ b/packages/agents-core/src/types/utility.ts
@@ -13,6 +13,7 @@ import type {
   PublicKeyConfigSchema,
   StatusComponentSchema,
   StatusUpdateSchema,
+  SupportCopilotConfigSchema,
   WebClientConfigSchema,
   WorkAppGitHubAccountTypeSchema,
   WorkAppGitHubInstallationStatusSchema,
@@ -326,7 +327,8 @@ export interface BaseExecutionContext {
     authMethod?:
       | 'app_credential_web_client'
       | 'app_credential_api'
-      | 'app_credential_web_client_authenticated';
+      | 'app_credential_web_client_authenticated'
+      | 'app_credential_support_copilot';
     appId?: string;
     appPrompt?: string;
   };
@@ -443,12 +445,14 @@ export type WorkAppGitHubAccountType = z.infer<typeof WorkAppGitHubAccountTypeSc
 export type ChannelAccessMode = z.infer<typeof ChannelAccessModeSchema>;
 export type ChannelIds = z.infer<typeof ChannelIdsSchema>;
 
-export type AppType = 'web_client' | 'api';
+export type AppType = 'web_client' | 'api' | 'support_copilot';
 
 export type PublicKeyAlgorithm = z.infer<typeof PublicKeyAlgorithmSchema>;
 export type PublicKeyConfig = z.infer<typeof PublicKeyConfigSchema>;
 export type WebClientConfig = z.infer<typeof WebClientConfigSchema>;
 
 export type ApiConfig = z.infer<typeof ApiConfigSchema>;
+
+export type SupportCopilotConfig = z.infer<typeof SupportCopilotConfigSchema>;
 
 export type AppConfig = z.infer<typeof AppConfigSchema>;

--- a/packages/agents-core/src/validation/schemas.ts
+++ b/packages/agents-core/src/validation/schemas.ts
@@ -1898,8 +1898,17 @@ export const ApiConfigSchema = z
   })
   .openapi('ApiConfig');
 
+export const SupportCopilotConfigSchema = z
+  .object({
+    type: z.literal('support_copilot'),
+    supportCopilot: z.object({
+      credentialReferenceIds: z.array(z.string()).default([]),
+    }),
+  })
+  .openapi('SupportCopilotConfig');
+
 export const AppConfigSchema = z
-  .discriminatedUnion('type', [WebClientConfigSchema, ApiConfigSchema])
+  .discriminatedUnion('type', [WebClientConfigSchema, ApiConfigSchema, SupportCopilotConfigSchema])
   .openapi('AppConfig');
 
 export const AddPublicKeyRequestSchema = z
@@ -1935,7 +1944,11 @@ export const WebClientConfigResponseSchema = z
   .openapi('WebClientConfigResponse');
 
 export const AppConfigResponseSchema = z
-  .discriminatedUnion('type', [WebClientConfigResponseSchema, ApiConfigSchema])
+  .discriminatedUnion('type', [
+    WebClientConfigResponseSchema,
+    ApiConfigSchema,
+    SupportCopilotConfigSchema,
+  ])
   .openapi('AppConfigResponse');
 
 export const AppSelectSchema = createSelectSchema(apps);
@@ -1943,7 +1956,7 @@ export const AppSelectSchema = createSelectSchema(apps);
 export const AppInsertSchema = createInsertSchema(apps).extend({
   id: ResourceIdSchema,
   name: z.string().trim().nonempty('Please enter a name.').max(256),
-  type: z.enum(['web_client', 'api']),
+  type: z.enum(['web_client', 'api', 'support_copilot']),
   defaultAgentId: z.string().min(1).nullish(),
   config: AppConfigSchema,
 });

--- a/scripts/setup-oauth-client.ts
+++ b/scripts/setup-oauth-client.ts
@@ -1,0 +1,143 @@
+#!/usr/bin/env tsx
+
+/**
+ * OAuth Client Setup
+ *
+ * Creates an OAuth 2.1 client for the copilot Chrome extension.
+ * Persists client_id and client_secret to .env so re-runs are idempotent.
+ *
+ * Usage: pnpm setup-oauth-client
+ */
+
+import { appendFileSync, existsSync, readFileSync, writeFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const ROOT_DIR = join(__dirname, '..');
+const ENV_PATH = join(ROOT_DIR, '.env');
+
+function getEnvVar(key: string): string | undefined {
+  if (!existsSync(ENV_PATH)) return undefined;
+  const content = readFileSync(ENV_PATH, 'utf-8');
+  const match = content.match(new RegExp(`^${key}=(.*)$`, 'm'));
+  return match?.[1]?.trim();
+}
+
+function setEnvVar(key: string, value: string): void {
+  if (!existsSync(ENV_PATH)) {
+    writeFileSync(ENV_PATH, `${key}=${value}\n`);
+    return;
+  }
+
+  const content = readFileSync(ENV_PATH, 'utf-8');
+  const regex = new RegExp(`^#?\\s*${key}=.*$`, 'm');
+
+  if (regex.test(content)) {
+    writeFileSync(ENV_PATH, content.replace(regex, `${key}=${value}`));
+  } else {
+    appendFileSync(ENV_PATH, `\n${key}=${value}`);
+  }
+}
+
+async function main() {
+  const printOnly = process.argv.includes('--print-only');
+
+  console.log('\n=== OAuth Client Setup ===\n');
+
+  if (printOnly) {
+    console.log('⚠️  --print-only: values will be printed to stdout, not written to .env.');
+    console.log('   Each run creates a NEW OAuth client — save the output.\n');
+  } else {
+    const existingClientId = getEnvVar('COPILOT_OAUTH_CLIENT_ID');
+    const existingClientSecret = getEnvVar('COPILOT_OAUTH_CLIENT_SECRET');
+
+    if (existingClientId && existingClientSecret) {
+      console.log(`ℹ️  OAuth client already configured:`);
+      console.log(`   client_id: ${existingClientId}`);
+      console.log(`   client_secret: ${existingClientSecret.slice(0, 8)}...`);
+      console.log(
+        `\n   To recreate, remove COPILOT_OAUTH_CLIENT_ID and COPILOT_OAUTH_CLIENT_SECRET from .env\n`
+      );
+      process.exit(0);
+    }
+  }
+
+  const { loadEnvironmentFiles } = await import('../packages/agents-core/src/env');
+  loadEnvironmentFiles();
+
+  const { createAgentsRunDatabaseClient } = await import(
+    '../packages/agents-core/src/db/runtime/runtime-client'
+  );
+  const { createAuth } = await import('../packages/agents-core/src/auth/auth');
+
+  const dbClient = createAgentsRunDatabaseClient();
+  const apiUrl = process.env.INKEEP_AGENTS_API_URL || 'http://localhost:3002';
+  const authSecret = process.env.BETTER_AUTH_SECRET;
+
+  if (!authSecret) {
+    console.error('❌ BETTER_AUTH_SECRET is required in .env');
+    process.exit(1);
+  }
+
+  const auth = createAuth({
+    baseURL: apiUrl,
+    secret: authSecret,
+    dbClient,
+  });
+
+  console.log('📦 Creating OAuth client...');
+
+  const redirectUris = [
+    'http://localhost:3100/auth/callback',
+    'https://copilot.inkeep.com/auth/callback',
+  ];
+
+  const client = await auth.api.adminCreateOAuthClient({
+    headers: new Headers(),
+    body: {
+      redirect_uris: redirectUris,
+      client_secret_expires_at: 0,
+      skip_consent: true,
+      enable_end_session: true,
+    },
+  });
+
+  const clientId = (client as Record<string, string>).client_id;
+  const clientSecret = (client as Record<string, string>).client_secret;
+
+  if (!clientId || !clientSecret) {
+    console.error('❌ Failed to create OAuth client — no client_id/client_secret returned');
+    console.error('   Response:', JSON.stringify(client, null, 2));
+    process.exit(1);
+  }
+
+  if (printOnly) {
+    console.log('   ✅ OAuth client created');
+    console.log(`   redirect_uris: ${redirectUris.join(', ')}`);
+    console.log(`   skip_consent:  true\n`);
+    console.log('   COPILOT_OAUTH_CLIENT_ID and COPILOT_OAUTH_CLIENT_SECRET:\n');
+    console.log(`   COPILOT_OAUTH_CLIENT_ID=${clientId}`);
+    console.log(`   COPILOT_OAUTH_CLIENT_SECRET=${clientSecret}`);
+    console.log(`\n   Store these in your secret manager. They are shown only once.\n`);
+    process.exit(0);
+  }
+
+  setEnvVar('COPILOT_OAUTH_CLIENT_ID', clientId);
+  setEnvVar('COPILOT_OAUTH_CLIENT_SECRET', clientSecret);
+
+  console.log('   ✅ OAuth client created');
+  console.log(`   client_id:     ${clientId}`);
+  console.log(`   client_secret: ${clientSecret.slice(0, 8)}...`);
+  console.log(`   redirect_uris: ${redirectUris.join(', ')}`);
+  console.log(`   skip_consent:  true`);
+  console.log(`\n   Saved to .env as COPILOT_OAUTH_CLIENT_ID and COPILOT_OAUTH_CLIENT_SECRET`);
+  console.log('   Use these values in your Chrome extension config.\n');
+
+  process.exit(0);
+}
+
+main().catch((error) => {
+  console.error('\n❌ Setup failed:', error);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

Adds a new `support_copilot` app type for deploying agents across external tools and support platforms (browser extensions, helpdesks, etc.). End-users authenticate via the existing OAuth 2.1 provider ([#3103](https://github.com/inkeep/agents/pull/3103)) using asymmetric JWTs verified via JWKS.

## What's included

**Backend (`agents-api`, `agents-core`):**
- New `SupportCopilotConfig` schema with `credentialReferenceIds`
- `tryOAuthSupportCopilotAuth()` — JWKS-verified JWT flow with `azp`, tenant-match, and SpiceDB `canUseProjectStrict` checks
- OAuth JWT path added to `manageAuth` at priority #3 (JWT-only — opaque tokens are not issued by this flow)
- `GET /manage/tenants/:tenantId/apps` — cross-project app discovery (used by the copilot BFF to resolve its `app_id` per tenant)
- `COPILOT_OAUTH_CLIENT_ID` env var for `azp` validation

**UI (`agents-manage-ui`):**
- "Support Copilot" option in the New App dropdown (double-gated: `PUBLIC_IS_INKEEP_CLOUD_DEPLOYMENT=true` AND org has `feature:support_copilot` entitlement with `maxValue > 0`)
- `CredentialMultiSelect` component for picking credential references
- Default agent + credential pickers in create/update forms
- Orange badge for `support_copilot` in the apps table

**Tooling:**
- `scripts/setup-oauth-client.ts` — creates the OAuth client for the copilot BFF
- `--print-only` flag for prod bootstrap (no `.env` write, values go to stdout for copy into secret manager)

## Gating (per-org opt-in on cloud only)

The Support Copilot option requires **both**:
1. `PUBLIC_IS_INKEEP_CLOUD_DEPLOYMENT=true` (deployment-level flag)
2. A row in `org_entitlement` with `resource_type = 'feature:support_copilot'` and `max_value > 0` for that org

To enable for a customer:
```sql
INSERT INTO org_entitlement (id, organization_id, resource_type, max_value)
VALUES ('<uuid>', '<tenant-id>', 'feature:support_copilot', 1);
```

## Production setup

1. `pnpm setup-oauth-client --print-only` (pointed at prod DB) → copy `COPILOT_OAUTH_CLIENT_ID` + `COPILOT_OAUTH_CLIENT_SECRET` into secret manager
2. Set `COPILOT_OAUTH_CLIENT_ID` on the `agents-api` deployment (validates `azp` on incoming JWTs)
3. Set both `COPILOT_OAUTH_CLIENT_ID` and `COPILOT_OAUTH_CLIENT_SECRET` on the copilot BFF deployment (needs the secret to exchange auth codes)
4. Insert the `feature:support_copilot` entitlement row for any cloud tenant that should see the dropdown option

## Test plan

- [x] Full `agents-api` test suite passes (2362 passed, 15 new)
- [x] Typecheck, lint, format clean across monorepo
- [x] Create `support_copilot` app via UI in a cloud-flagged, entitled tenant
- [x] Edit existing `support_copilot` app (credentials + default agent persist)
- [x] Verify option is hidden when deployment flag or entitlement is missing
- [x] Verify `GET /manage/tenants/:tenantId/apps?type=support_copilot` returns cross-project results
- [ ] Manual prod bootstrap: `pnpm setup-oauth-client --print-only` against prod DB
- [ ] Chrome extension → copilot BFF → agents-api end-to-end with real OAuth flow

## Known gaps / follow-ups

- **No API-side entitlement gate.** Intentional — the OAuth auth path silently rejects any JWT when `COPILOT_OAUTH_CLIENT_ID` is unset, so an OSS or un-entitled tenant can't actually use a `support_copilot` app even if they create one via curl. Consider adding an API gate if we want stricter defense-in-depth.
- **No self-service OAuth client management UI.** Clients are created via the bootstrap script today. Future: a "Developer apps" page in the manage UI.
- **No customer-facing docs.** Skipped per product call — this is cloud-only and ops-provisioned for now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)