### PR TITLE
fix(agents-mcp): include bin/ in published npm package

### DIFF
--- a/packages/agents-mcp/package.json
+++ b/packages/agents-mcp/package.json
@@ -4,6 +4,7 @@
   "author": "Speakeasy",
   "type": "module",
   "sideEffects": false,
+  "files": ["esm/", "bin/"],
   "bin": {
     "@inkeep/agents-mcp": "bin/mcp-server.js",
     "mcp": "bin/mcp-server.js"


### PR DESCRIPTION
## Problem
The @inkeep/agents-mcp package declares bin entries pointing to bin/mcp-server.js but the published tarball omits this file.

## Root Cause
packages/agents-mcp/.gitignore excludes /bin. The package.json lacks a files field, so npm uses .gitignore during publish.

## Fix
Added files field ["esm/", "bin/"] to explicitly include these directories.

Closes charles-openclaw/charles-microbounties#585