### PR TITLE
feat(core): add Requesty as an OpenAI-compatible provider

### DIFF
--- a/.changeset/add-requesty-provider.md
+++ b/.changeset/add-requesty-provider.md
@@ -1,0 +1,5 @@
+---
+"@inkeep/agents-core": patch
+---
+
+Add Requesty as an OpenAI-compatible provider in the model factory

--- a/agents-docs/content/typescript-sdk/models.mdx
+++ b/agents-docs/content/typescript-sdk/models.mdx
@@ -73,6 +73,7 @@ Each model type inherits independently through the project → agent → sub age
 | **Azure OpenAI** | `azure/my-gpt4-deployment`<br/>`azure/my-gpt35-deployment` | `AZURE_API_KEY` |
 | **Google** | `google/gemini-3.1-pro-preview`<br/>`google/gemini-3.5-flash`<br/>`google/gemini-3.1-flash-lite`<br/>`google/gemini-2.5-pro`<br/>`google/gemini-2.5-flash`<br/>`google/gemini-2.5-flash-lite` | `GOOGLE_GENERATIVE_AI_API_KEY` |
 | **OpenRouter** | `openrouter/anthropic/claude-sonnet-4-0`<br/>`openrouter/meta-llama/llama-3.1-405b` | `OPENROUTER_API_KEY` |
+| **Requesty** | `requesty/openai/gpt-4o-mini`<br/>`requesty/anthropic/claude-sonnet-4-5` | `REQUESTY_API_KEY` |
 | **Gateway** | `gateway/openai/gpt-4.1-mini` | `AI_GATEWAY_API_KEY` |
 | **NVIDIA NIM** | `nim/nvidia/llama-3.3-nemotron-super-49b-v1.5`<br/>`nim/nvidia/nemotron-4-340b-instruct` | `NIM_API_KEY` |
 | **Custom OpenAI-compatible** | `custom/my-custom-model`<br/>`custom/llama-3-custom` | `CUSTOM_LLM_API_KEY` |

--- a/packages/agents-core/package.json
+++ b/packages/agents-core/package.json
@@ -211,6 +211,7 @@
     "@nangohq/node": "^0.69.41",
     "@nangohq/types": "^0.69.41",
     "@openrouter/ai-sdk-provider": "^2.1.0",
+    "@requesty/ai-sdk": "^3.4.0",
     "@opentelemetry/api": "^1.9.0",
     "@vercel/functions": "^3.5.1",
     "ai": "6.0.191",

--- a/packages/agents-core/src/utils/model-factory.ts
+++ b/packages/agents-core/src/utils/model-factory.ts
@@ -6,6 +6,7 @@ import { createOpenAI, openai } from '@ai-sdk/openai';
 import { createOpenAICompatible } from '@ai-sdk/openai-compatible';
 import type { JSONObject } from '@ai-sdk/provider';
 import { createOpenRouter, openrouter } from '@openrouter/ai-sdk-provider';
+import { createRequesty } from '@requesty/ai-sdk';
 import type { LanguageModel } from 'ai';
 import { wrapLanguageModel } from 'ai';
 
@@ -65,6 +66,10 @@ export class ModelFactory {
         return createGoogleGenerativeAI(config);
       case 'openrouter':
         return createOpenRouter(config);
+      case 'requesty':
+        return createRequesty(config) as unknown as {
+          languageModel: (modelId: string) => LanguageModel;
+        };
       case 'gateway':
         return createGateway(config);
       case 'nim': {


### PR DESCRIPTION
This adds a dedicated `requesty` provider to the model factory, mirroring the existing OpenRouter provider as closely as possible.

Changes:
* `packages/agents-core/src/utils/model-factory.ts`: import `createRequesty` from `@requesty/ai-sdk` and add a `case 'requesty'` to `createProvider`, mirroring the `openrouter` case.
* `packages/agents-core/package.json`: add the `@requesty/ai-sdk` dependency.
* `agents-docs/content/typescript-sdk/models.mdx`: add Requesty to the supported providers table (`REQUESTY_API_KEY`).
* `.changeset/add-requesty-provider.md`: patch changeset for `@inkeep/agents-core`.

Requesty is an OpenAI-compatible LLM gateway and uses the same `provider/model` naming as OpenRouter (for example `requesty/openai/gpt-4o-mini`), so the existing `provider/model` split and factory dispatch handle it unchanged. `createRequesty` is the env-aware factory from the official `@requesty/ai-sdk` package, analogous to `createOpenRouter`.

Verification: I tested the endpoint live before opening this. `GET https://router.requesty.ai/v1/models` returned 200 (578 models), and a chat completion with `openai/gpt-4o-mini` against `https://router.requesty.ai/v1/chat/completions` returned 200. I did not run the full monorepo build locally (the dep needs an install), so the lockfile is not included.

Docs: https://requesty.ai , https://app.requesty.ai/api-keys

I work at Requesty. This mirrors the existing OpenRouter provider as closely as possible. Happy to adjust or close it if it's not a fit.
