### PR TITLE
docs: update Inkeep managed platform link

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Agents can also be used for **AI Workflow Automation** like:
 
 For a full overview, see the [Concepts](https://docs.inkeep.com/concepts) guide.
 
-Interested in a managed platform? Sign up for the [Inkeep Cloud waitlist](https://inkeep.com/cloud-waitlist) or learn about [Inkeep Enterprise](https://inkeep.com/enterprise).
+Interested in a managed platform? [Get started with Inkeep](https://inkeep.com/get-started) or learn about [Inkeep Enterprise](https://inkeep.com/enterprise).
 
 ## Architecture
 


### PR DESCRIPTION
Fixes #3429.

## Summary
- replace the stale Inkeep Cloud waitlist link in the README with the current Get started page
- keep the adjacent Enterprise link unchanged

## Verification
- `curl -L https://inkeep.com/cloud-waitlist` returns 404
- `curl -L https://inkeep.com/get-started` returns 200
- `curl -L https://inkeep.com/enterprise` returns 200 and redirects to `/cx-agents`
- `git diff --check HEAD~1..HEAD -- README.md`
