### PR TITLE
feat(agents-cli): add recent-projects management with stale entry detection and pruning

### DIFF
--- a/.changeset/sunny-green-flyingfish.md
+++ b/.changeset/sunny-green-flyingfish.md
@@ -1,0 +1,5 @@
+---
+"@inkeep/agents-cli": patch
+---
+
+Add recent-projects management with stale entry detection, removal, and auto-pruning

--- a/agents-cli/src/commands/recent-projects.ts
+++ b/agents-cli/src/commands/recent-projects.ts
@@ -1,0 +1,66 @@
+import chalk from 'chalk';
+import {
+  getRecentProjects,
+  pruneStaleProjects,
+  removeRecentProject,
+  validateRecentProjects,
+} from '../utils/recent-projects';
+
+export async function recentProjectsListCommand(): Promise<void> {
+  const projects = getRecentProjects();
+
+  if (projects.length === 0) {
+    console.log(chalk.gray('No recent projects.'));
+    return;
+  }
+
+  const stale = validateRecentProjects();
+  const stalePaths = new Set(stale.map((s) => s.project.path));
+
+  console.log(chalk.bold('Recent projects:\n'));
+
+  for (const project of projects) {
+    const isMissing = stalePaths.has(project.path);
+    const name = isMissing ? chalk.strikethrough.red(project.name) : chalk.cyan(project.name);
+    const path = isMissing
+      ? chalk.red(project.path) + chalk.red(' (directory missing)')
+      : chalk.gray(project.path);
+    const date = chalk.gray(new Date(project.lastOpenedAt).toLocaleDateString());
+
+    console.log(`  ${name}  ${date}`);
+    console.log(`  ${path}`);
+    console.log();
+  }
+
+  if (stale.length > 0) {
+    console.log(
+      chalk.yellow(
+        `${stale.length} project(s) have missing directories. Run ${chalk.bold('inkeep recent-projects prune')} to remove them.`
+      )
+    );
+  }
+}
+
+export async function recentProjectsRemoveCommand(projectPath: string): Promise<void> {
+  const removed = removeRecentProject(projectPath);
+
+  if (removed) {
+    console.log(chalk.green('✓'), `Removed ${chalk.cyan(projectPath)} from recent projects`);
+  } else {
+    console.log(chalk.yellow('⚠'), `No recent project found with path: ${projectPath}`);
+  }
+}
+
+export async function recentProjectsPruneCommand(): Promise<void> {
+  const pruned = pruneStaleProjects();
+
+  if (pruned.length === 0) {
+    console.log(chalk.green('✓'), 'All recent project paths are valid. Nothing to prune.');
+    return;
+  }
+
+  console.log(chalk.green('✓'), `Pruned ${pruned.length} stale project(s):\n`);
+  for (const project of pruned) {
+    console.log(`  ${chalk.strikethrough(project.name)} ${chalk.gray(project.path)}`);
+  }
+}

--- a/agents-cli/src/program.ts
+++ b/agents-cli/src/program.ts
@@ -15,6 +15,11 @@ import {
 } from './commands/profile';
 import { pullV4Command } from './commands/pull-v4/introspect';
 import { pushCommand } from './commands/push';
+import {
+  recentProjectsListCommand,
+  recentProjectsPruneCommand,
+  recentProjectsRemoveCommand,
+} from './commands/recent-projects';
 import { statusCommand } from './commands/status';
 import { updateCommand } from './commands/update';
 import { whoamiCommand } from './commands/whoami';
@@ -231,6 +236,25 @@ export function createProgram(): Command {
     .command('remove <name>')
     .description('Remove a profile')
     .action(profileRemoveCommand);
+
+  const recentProjectsCommand = program
+    .command('recent-projects')
+    .description('Manage recent project history');
+
+  recentProjectsCommand
+    .command('list')
+    .description('List recent projects and flag missing directories')
+    .action(recentProjectsListCommand);
+
+  recentProjectsCommand
+    .command('remove <path>')
+    .description('Remove a project from recent history by its directory path')
+    .action(recentProjectsRemoveCommand);
+
+  recentProjectsCommand
+    .command('prune')
+    .description('Remove all recent projects whose directories no longer exist')
+    .action(recentProjectsPruneCommand);
 
   return program;
 }

--- a/agents-cli/src/utils/__tests__/recent-projects.test.ts
+++ b/agents-cli/src/utils/__tests__/recent-projects.test.ts
@@ -1,0 +1,288 @@
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+  addRecentProject,
+  getRecentProjects,
+  getRecentProjectsState,
+  pruneStaleProjects,
+  removeRecentProject,
+  validateRecentProjects,
+} from '../recent-projects';
+
+describe('recent-projects', () => {
+  let stateDir: string;
+  let existingDir: string;
+
+  beforeEach(() => {
+    stateDir = join(tmpdir(), `ok-test-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+    mkdirSync(stateDir, { recursive: true });
+    existingDir = join(tmpdir(), `ok-project-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+    mkdirSync(existingDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(stateDir, { recursive: true, force: true });
+    rmSync(existingDir, { recursive: true, force: true });
+  });
+
+  describe('getRecentProjects', () => {
+    it('returns empty array when no state file exists', () => {
+      const result = getRecentProjects({ stateDir });
+      expect(result).toEqual([]);
+    });
+
+    it('returns empty array for malformed JSON', () => {
+      writeFileSync(join(stateDir, 'state.json'), 'not json');
+      const result = getRecentProjects({ stateDir });
+      expect(result).toEqual([]);
+    });
+
+    it('returns recent projects from state file', () => {
+      writeFileSync(
+        join(stateDir, 'state.json'),
+        JSON.stringify({
+          recentProjects: [
+            { path: '/tmp/project-a', name: 'Project A', lastOpenedAt: '2026-01-01T00:00:00.000Z' },
+          ],
+        })
+      );
+
+      const result = getRecentProjects({ stateDir });
+      expect(result).toHaveLength(1);
+      expect(result[0]).toEqual({
+        path: '/tmp/project-a',
+        name: 'Project A',
+        lastOpenedAt: '2026-01-01T00:00:00.000Z',
+      });
+    });
+  });
+
+  describe('addRecentProject', () => {
+    it('creates state file and adds project', () => {
+      addRecentProject({ path: '/tmp/my-project', name: 'My Project' }, { stateDir });
+
+      const state = JSON.parse(readFileSync(join(stateDir, 'state.json'), 'utf-8'));
+      expect(state.recentProjects).toHaveLength(1);
+      expect(state.recentProjects[0].path).toBe('/tmp/my-project');
+      expect(state.recentProjects[0].name).toBe('My Project');
+      expect(state.recentProjects[0].lastOpenedAt).toBeDefined();
+      expect(state.lastOpenedProject).toBe('/tmp/my-project');
+    });
+
+    it('moves existing project to front of list', () => {
+      addRecentProject({ path: '/tmp/project-a', name: 'A' }, { stateDir });
+      addRecentProject({ path: '/tmp/project-b', name: 'B' }, { stateDir });
+      addRecentProject({ path: '/tmp/project-a', name: 'A' }, { stateDir });
+
+      const state = JSON.parse(readFileSync(join(stateDir, 'state.json'), 'utf-8'));
+      expect(state.recentProjects).toHaveLength(2);
+      expect(state.recentProjects[0].path).toBe('/tmp/project-a');
+      expect(state.recentProjects[1].path).toBe('/tmp/project-b');
+    });
+
+    it('updates lastOpenedProject', () => {
+      addRecentProject({ path: '/tmp/project-a', name: 'A' }, { stateDir });
+      addRecentProject({ path: '/tmp/project-b', name: 'B' }, { stateDir });
+
+      const state = JSON.parse(readFileSync(join(stateDir, 'state.json'), 'utf-8'));
+      expect(state.lastOpenedProject).toBe('/tmp/project-b');
+    });
+
+    it('creates state directory if needed', () => {
+      const nestedDir = join(stateDir, 'nested', 'deep');
+      addRecentProject({ path: '/tmp/p', name: 'P' }, { stateDir: nestedDir });
+      expect(existsSync(join(nestedDir, 'state.json'))).toBe(true);
+    });
+  });
+
+  describe('removeRecentProject', () => {
+    it('removes a project and cleans up associated entries', () => {
+      writeFileSync(
+        join(stateDir, 'state.json'),
+        JSON.stringify({
+          recentProjects: [
+            { path: '/tmp/project-a', name: 'A', lastOpenedAt: '2026-01-01T00:00:00.000Z' },
+            { path: '/tmp/project-b', name: 'B', lastOpenedAt: '2026-01-02T00:00:00.000Z' },
+          ],
+          projectSessions: {
+            '/tmp/project-a': { tab: 'editor' },
+            '/tmp/project-b': { tab: 'preview' },
+          },
+          projectWindowBounds: {
+            '/tmp/project-a': { x: 0, y: 0, width: 800, height: 600 },
+            '/tmp/project-b': { x: 100, y: 100, width: 1024, height: 768 },
+          },
+          lastOpenedProject: '/tmp/project-a',
+        })
+      );
+
+      const result = removeRecentProject('/tmp/project-a', { stateDir });
+      expect(result).toBe(true);
+
+      const state = JSON.parse(readFileSync(join(stateDir, 'state.json'), 'utf-8'));
+      expect(state.recentProjects).toHaveLength(1);
+      expect(state.recentProjects[0].path).toBe('/tmp/project-b');
+      expect(state.projectSessions['/tmp/project-a']).toBeUndefined();
+      expect(state.projectSessions['/tmp/project-b']).toEqual({ tab: 'preview' });
+      expect(state.projectWindowBounds['/tmp/project-a']).toBeUndefined();
+      expect(state.projectWindowBounds['/tmp/project-b']).toEqual({
+        x: 100,
+        y: 100,
+        width: 1024,
+        height: 768,
+      });
+      expect(state.lastOpenedProject).toBe('/tmp/project-b');
+    });
+
+    it('returns false when project not found', () => {
+      writeFileSync(
+        join(stateDir, 'state.json'),
+        JSON.stringify({ recentProjects: [], projectSessions: {}, projectWindowBounds: {} })
+      );
+
+      const result = removeRecentProject('/tmp/nonexistent', { stateDir });
+      expect(result).toBe(false);
+    });
+
+    it('clears lastOpenedProject when last project is removed', () => {
+      writeFileSync(
+        join(stateDir, 'state.json'),
+        JSON.stringify({
+          recentProjects: [
+            { path: '/tmp/only-project', name: 'Only', lastOpenedAt: '2026-01-01T00:00:00.000Z' },
+          ],
+          projectSessions: {},
+          projectWindowBounds: {},
+          lastOpenedProject: '/tmp/only-project',
+        })
+      );
+
+      removeRecentProject('/tmp/only-project', { stateDir });
+
+      const state = JSON.parse(readFileSync(join(stateDir, 'state.json'), 'utf-8'));
+      expect(state.recentProjects).toHaveLength(0);
+      expect(state.lastOpenedProject).toBeUndefined();
+    });
+  });
+
+  describe('validateRecentProjects', () => {
+    it('returns empty array when all paths exist', () => {
+      writeFileSync(
+        join(stateDir, 'state.json'),
+        JSON.stringify({
+          recentProjects: [
+            { path: existingDir, name: 'Existing', lastOpenedAt: '2026-01-01T00:00:00.000Z' },
+          ],
+          projectSessions: {},
+          projectWindowBounds: {},
+        })
+      );
+
+      const result = validateRecentProjects({ stateDir });
+      expect(result).toHaveLength(0);
+    });
+
+    it('flags projects with missing paths', () => {
+      writeFileSync(
+        join(stateDir, 'state.json'),
+        JSON.stringify({
+          recentProjects: [
+            { path: existingDir, name: 'Existing', lastOpenedAt: '2026-01-01T00:00:00.000Z' },
+            {
+              path: '/tmp/definitely-does-not-exist-xyz-123',
+              name: 'Missing',
+              lastOpenedAt: '2026-01-02T00:00:00.000Z',
+            },
+          ],
+          projectSessions: {},
+          projectWindowBounds: {},
+        })
+      );
+
+      const result = validateRecentProjects({ stateDir });
+      expect(result).toHaveLength(1);
+      expect(result[0].project.path).toBe('/tmp/definitely-does-not-exist-xyz-123');
+      expect(result[0].reason).toBe('path_missing');
+    });
+
+    it('returns empty array for no recent projects', () => {
+      const result = validateRecentProjects({ stateDir });
+      expect(result).toHaveLength(0);
+    });
+  });
+
+  describe('pruneStaleProjects', () => {
+    it('removes projects with missing paths and cleans up state', () => {
+      const missingPath = '/tmp/definitely-does-not-exist-xyz-456';
+      writeFileSync(
+        join(stateDir, 'state.json'),
+        JSON.stringify({
+          recentProjects: [
+            { path: existingDir, name: 'Valid', lastOpenedAt: '2026-01-01T00:00:00.000Z' },
+            { path: missingPath, name: 'Stale', lastOpenedAt: '2026-01-02T00:00:00.000Z' },
+          ],
+          projectSessions: {
+            [existingDir]: { tab: 'editor' },
+            [missingPath]: { tab: 'preview' },
+          },
+          projectWindowBounds: {
+            [existingDir]: { width: 800 },
+            [missingPath]: { width: 1024 },
+          },
+          lastOpenedProject: missingPath,
+        })
+      );
+
+      const pruned = pruneStaleProjects({ stateDir });
+      expect(pruned).toHaveLength(1);
+      expect(pruned[0].path).toBe(missingPath);
+
+      const state = JSON.parse(readFileSync(join(stateDir, 'state.json'), 'utf-8'));
+      expect(state.recentProjects).toHaveLength(1);
+      expect(state.recentProjects[0].path).toBe(existingDir);
+      expect(state.projectSessions[missingPath]).toBeUndefined();
+      expect(state.projectSessions[existingDir]).toEqual({ tab: 'editor' });
+      expect(state.projectWindowBounds[missingPath]).toBeUndefined();
+      expect(state.projectWindowBounds[existingDir]).toEqual({ width: 800 });
+      expect(state.lastOpenedProject).toBe(existingDir);
+    });
+
+    it('returns empty array when nothing to prune', () => {
+      writeFileSync(
+        join(stateDir, 'state.json'),
+        JSON.stringify({
+          recentProjects: [
+            { path: existingDir, name: 'Valid', lastOpenedAt: '2026-01-01T00:00:00.000Z' },
+          ],
+          projectSessions: {},
+          projectWindowBounds: {},
+        })
+      );
+
+      const pruned = pruneStaleProjects({ stateDir });
+      expect(pruned).toHaveLength(0);
+    });
+
+    it('handles empty state gracefully', () => {
+      const pruned = pruneStaleProjects({ stateDir });
+      expect(pruned).toHaveLength(0);
+    });
+  });
+
+  describe('getRecentProjectsState', () => {
+    it('returns full state with defaults for missing fields', () => {
+      writeFileSync(
+        join(stateDir, 'state.json'),
+        JSON.stringify({ recentProjects: [{ path: '/a', name: 'A', lastOpenedAt: '2026-01-01' }] })
+      );
+
+      const state = getRecentProjectsState({ stateDir });
+      expect(state.recentProjects).toHaveLength(1);
+      expect(state.projectSessions).toEqual({});
+      expect(state.projectWindowBounds).toEqual({});
+      expect(state.lastOpenedProject).toBeUndefined();
+    });
+  });
+});

--- a/agents-cli/src/utils/recent-projects.ts
+++ b/agents-cli/src/utils/recent-projects.ts
@@ -1,0 +1,186 @@
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+
+export interface RecentProject {
+  path: string;
+  name: string;
+  lastOpenedAt: string;
+}
+
+export interface ProjectSession {
+  [key: string]: unknown;
+}
+
+export interface ProjectWindowBounds {
+  x?: number;
+  y?: number;
+  width?: number;
+  height?: number;
+}
+
+export interface RecentProjectsState {
+  recentProjects: RecentProject[];
+  projectSessions: Record<string, ProjectSession>;
+  projectWindowBounds: Record<string, ProjectWindowBounds>;
+  lastOpenedProject?: string;
+}
+
+export interface RecentProjectsOptions {
+  stateDir?: string;
+}
+
+const STATE_FILE = 'state.json';
+
+function getDefaultStateDir(): string {
+  if (process.platform === 'darwin') {
+    return join(homedir(), 'Library', 'Application Support', 'OpenKnowledge');
+  }
+  if (process.platform === 'win32') {
+    return join(homedir(), 'AppData', 'Roaming', 'OpenKnowledge');
+  }
+  return join(homedir(), '.config', 'OpenKnowledge');
+}
+
+function getStatePath(stateDir: string): string {
+  return join(stateDir, STATE_FILE);
+}
+
+function readStateFile(stateDir: string): RecentProjectsState {
+  const statePath = getStatePath(stateDir);
+  const empty: RecentProjectsState = {
+    recentProjects: [],
+    projectSessions: {},
+    projectWindowBounds: {},
+  };
+
+  if (!existsSync(statePath)) {
+    return empty;
+  }
+
+  try {
+    const content = readFileSync(statePath, 'utf-8');
+    const parsed = JSON.parse(content);
+    return {
+      recentProjects: Array.isArray(parsed.recentProjects) ? parsed.recentProjects : [],
+      projectSessions:
+        parsed.projectSessions && typeof parsed.projectSessions === 'object'
+          ? parsed.projectSessions
+          : {},
+      projectWindowBounds:
+        parsed.projectWindowBounds && typeof parsed.projectWindowBounds === 'object'
+          ? parsed.projectWindowBounds
+          : {},
+      lastOpenedProject: parsed.lastOpenedProject,
+    };
+  } catch {
+    return empty;
+  }
+}
+
+function writeStateFile(stateDir: string, state: RecentProjectsState): void {
+  if (!existsSync(stateDir)) {
+    mkdirSync(stateDir, { recursive: true });
+  }
+  const statePath = getStatePath(stateDir);
+  writeFileSync(statePath, `${JSON.stringify(state, null, 2)}\n`, 'utf-8');
+}
+
+export function getRecentProjects(options?: RecentProjectsOptions): RecentProject[] {
+  const stateDir = options?.stateDir ?? getDefaultStateDir();
+  return readStateFile(stateDir).recentProjects;
+}
+
+export function addRecentProject(
+  project: { path: string; name: string },
+  options?: RecentProjectsOptions
+): void {
+  const stateDir = options?.stateDir ?? getDefaultStateDir();
+  const state = readStateFile(stateDir);
+
+  const existingIndex = state.recentProjects.findIndex((p) => p.path === project.path);
+  if (existingIndex !== -1) {
+    state.recentProjects.splice(existingIndex, 1);
+  }
+
+  state.recentProjects.unshift({
+    path: project.path,
+    name: project.name,
+    lastOpenedAt: new Date().toISOString(),
+  });
+
+  state.lastOpenedProject = project.path;
+  writeStateFile(stateDir, state);
+}
+
+export function removeRecentProject(projectPath: string, options?: RecentProjectsOptions): boolean {
+  const stateDir = options?.stateDir ?? getDefaultStateDir();
+  const state = readStateFile(stateDir);
+
+  const initialLength = state.recentProjects.length;
+  state.recentProjects = state.recentProjects.filter((p) => p.path !== projectPath);
+
+  if (state.recentProjects.length === initialLength) {
+    return false;
+  }
+
+  delete state.projectSessions[projectPath];
+  delete state.projectWindowBounds[projectPath];
+
+  if (state.lastOpenedProject === projectPath) {
+    state.lastOpenedProject = state.recentProjects[0]?.path;
+  }
+
+  writeStateFile(stateDir, state);
+  return true;
+}
+
+export interface StaleProjectEntry {
+  project: RecentProject;
+  reason: 'path_missing';
+}
+
+export function validateRecentProjects(options?: RecentProjectsOptions): StaleProjectEntry[] {
+  const stateDir = options?.stateDir ?? getDefaultStateDir();
+  const state = readStateFile(stateDir);
+  const stale: StaleProjectEntry[] = [];
+
+  for (const project of state.recentProjects) {
+    if (!existsSync(project.path)) {
+      stale.push({ project, reason: 'path_missing' });
+    }
+  }
+
+  return stale;
+}
+
+export function pruneStaleProjects(options?: RecentProjectsOptions): RecentProject[] {
+  const stateDir = options?.stateDir ?? getDefaultStateDir();
+  const stale = validateRecentProjects(options);
+
+  if (stale.length === 0) {
+    return [];
+  }
+
+  const stalePaths = new Set(stale.map((s) => s.project.path));
+  const state = readStateFile(stateDir);
+
+  state.recentProjects = state.recentProjects.filter((p) => !stalePaths.has(p.path));
+
+  for (const path of stalePaths) {
+    delete state.projectSessions[path];
+    delete state.projectWindowBounds[path];
+  }
+
+  if (state.lastOpenedProject && stalePaths.has(state.lastOpenedProject)) {
+    state.lastOpenedProject = state.recentProjects[0]?.path;
+  }
+
+  writeStateFile(stateDir, state);
+  return stale.map((s) => s.project);
+}
+
+export function getRecentProjectsState(options?: RecentProjectsOptions): RecentProjectsState {
+  const stateDir = options?.stateDir ?? getDefaultStateDir();
+  return readStateFile(stateDir);
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Resolves [PRD-7464] — Desktop: stale recent-project entries remain after project directory is deleted.

Adds a `recent-projects` state management module and CLI commands to the `agents-cli` package. This provides the core infrastructure for detecting, listing, and removing stale project entries whose filesystem paths no longer exist.

## What's included

### State management (`agents-cli/src/utils/recent-projects.ts`)

- **`getRecentProjects()`** — Read the recent projects list from `state.json`
- **`addRecentProject()`** — Add/move a project to the top of the recents list
- **`removeRecentProject()`** — Remove a project and clean up `projectSessions`, `projectWindowBounds`, and `lastOpenedProject`
- **`validateRecentProjects()`** — Check which entries have missing directory paths
- **`pruneStaleProjects()`** — Auto-remove all entries whose paths no longer exist on disk
- **`getRecentProjectsState()`** — Read the full state file

### CLI commands (`inkeep recent-projects`)

| Command | Description |
|---------|-------------|
| `inkeep recent-projects list` | List recent projects, flagging those with missing directories |
| `inkeep recent-projects remove <path>` | Remove a specific project from history by path |
| `inkeep recent-projects prune` | Remove all projects whose directories no longer exist |

### Platform-aware state directory

Follows the OS-native application data convention:
- **macOS**: `~/Library/Application Support/OpenKnowledge/state.json`
- **Windows**: `%APPDATA%/OpenKnowledge/state.json`
- **Linux**: `~/.config/OpenKnowledge/state.json`

### Cleanup scope

When removing a project entry, all associated keys are cleaned:
- `recentProjects` — the project entry itself
- `projectSessions` — any session data keyed by path
- `projectWindowBounds` — any window geometry data keyed by path
- `lastOpenedProject` — reset to the next most recent project (or cleared)

## Tests

17 unit tests covering all functions and edge cases (malformed JSON, empty state, nested directory creation, multi-project interactions, stale detection with real filesystem paths).

## Changeset

`patch` bump for `@inkeep/agents-cli`.
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [PRD-7464](https://linear.app/inkeep/issue/PRD-7464/desktop-stale-recent-project-entries-remain-after-project-directory-is)

<div><a href="https://cursor.com/agents/bc-44470b71-dca0-4130-9448-dd0d580bd822"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-44470b71-dca0-4130-9448-dd0d580bd822"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

