### PR TITLE
fix(docker): pin doltgresql image to 0.56.7 across template and dev c…

### DIFF
--- a/.changeset/pin-doltgres-image-tag.md
+++ b/.changeset/pin-doltgres-image-tag.md
@@ -1,0 +1,5 @@
+---
+'create-agents': patch
+---
+
+Pin Doltgres database Docker image to stable `0.56.7` tag across template compose files to prevent unpinned `:latest` image regressions.

--- a/create-agents-template/docker-compose.db.yml
+++ b/create-agents-template/docker-compose.db.yml
@@ -1,7 +1,6 @@
 services:
   doltgres-db:
-    image: dolthub/doltgresql:latest
-    pull_policy: always
+    image: dolthub/doltgresql:0.56.7
     restart: unless-stopped
     environment:
       DOLTGRES_USER: appuser

--- a/create-agents-template/docker-compose.yml
+++ b/create-agents-template/docker-compose.yml
@@ -83,7 +83,7 @@ services:
         condition: service_healthy
     restart: "no"
   inkeep-agents-doltgres-db:
-    image: dolthub/doltgresql:latest
+    image: dolthub/doltgresql:0.56.7
     restart: unless-stopped
     environment:
       DOLTGRES_USER: appuser

--- a/docker-compose.dbs.yml
+++ b/docker-compose.dbs.yml
@@ -1,7 +1,6 @@
 services:
   doltgres-db:
-    image: dolthub/doltgresql:latest
-    pull_policy: always
+    image: dolthub/doltgresql:0.56.7
     restart: unless-stopped
     environment:
       DOLTGRES_USER: appuser

--- a/docker-compose.isolated.yml
+++ b/docker-compose.isolated.yml
@@ -14,8 +14,7 @@
 
 services:
   doltgres-db:
-    image: dolthub/doltgresql:latest
-    pull_policy: always
+    image: dolthub/doltgresql:0.56.7
     restart: unless-stopped
     environment:
       DOLTGRES_USER: appuser


### PR DESCRIPTION
## Summary

Fixes #3465 where running `npx @inkeep/create-agents` or `pnpm setup-dev` failed during project seeding / `inkeep push` with HTTP 500 (`SELECT * FROM dolt_tags` caused by `error: role "appuser" does not exist`).

### Root Cause
While root `docker-compose.yml` explicitly pinned `dolthub/doltgresql:0.56.7`, template and local development docker-compose files used unpinned `dolthub/doltgresql:latest` with `pull_policy: always`. Recent upstream builds of `dolthub/doltgresql:latest` introduced a wire-protocol session authorization regression when queried over host-port forwarding proxies (e.g. `localhost:5432` on Docker Desktop), breaking `dolt_tags` / `dolt_branches` queries for host-bound Node services.

### Changes
1. **Pinned Doltgres Docker Image**:
   - `create-agents-template/docker-compose.db.yml`
   - `create-agents-template/docker-compose.yml`
   - `docker-compose.dbs.yml`
   - `docker-compose.isolated.yml`
   Updated image from `dolthub/doltgresql:latest` to `dolthub/doltgresql:0.56.7` and removed `pull_policy: always`.

2. **Added Changeset**:
   - Added patch changeset for `@inkeep/create-agents` in `.changeset/pin-doltgres-image-tag.md`.

## Verification
- Verified that all compose files now consistently reference `dolthub/doltgresql:0.56.7` matching root `docker-compose.yml`.
- Verified changeset resolution for published template package.