### PR TITLE
fix(agents-api): prevent double content in streamed response finalization

### DIFF
--- a/.changeset/motionless-emerald-crawdad.md
+++ b/.changeset/motionless-emerald-crawdad.md
@@ -1,0 +1,5 @@
+---
+"@inkeep/agents-api": patch
+---
+
+Fix duplicate content in streamed responses caused by double-push in finalize

--- a/agents-api/src/domains/run/stream/IncrementalStreamParser.ts
+++ b/agents-api/src/domains/run/stream/IncrementalStreamParser.ts
@@ -489,29 +489,28 @@ export class IncrementalStreamParser {
     }
 
     if (this.buffer) {
-      const part: StreamPart = {
-        kind: 'text',
-        text: this.buffer,
-      };
-      await this.streamPart(part);
+      this.pendingTextBuffer += this.buffer;
+      this.buffer = '';
     }
 
     if (this.pendingTextBuffer) {
       const cleanedText = this.pendingTextBuffer
-        .replace(/<\/?artifact:ref(?:\s[^>]*)?>\/?>/g, '') // Remove artifact:ref tags safely
-        .replace(/<\/?artifact(?:\s[^>]*)?>\/?>/g, '') // Remove artifact tags safely
-        .replace(/<\/artifact:ref>/g, '') // Remove closing artifact:ref tags
-        .replace(/<\/(?:\w+:)?artifact>/g, ''); // Remove closing artifact tags safely
+        .replace(/<\/?artifact:ref(?:\s[^>]*)?>\/?>/g, '')
+        .replace(/<\/?artifact(?:\s[^>]*)?>\/?>/g, '')
+        .replace(/<\/artifact:ref>/g, '')
+        .replace(/<\/(?:\w+:)?artifact>/g, '');
 
       if (cleanedText) {
+        if (!this.hasStartedRole) {
+          await this.streamHelper.writeRole('assistant');
+          this.hasStartedRole = true;
+        }
         const textPart: StreamPart = {
           kind: 'text',
           text: cleanedText,
         };
         this.collectedParts.push(textPart);
-
         this.allStreamedContent.push(textPart);
-
         await this.streamHelper.streamText(cleanedText, 0);
       }
       this.pendingTextBuffer = '';

--- a/agents-api/src/domains/run/stream/__tests__/IncrementalStreamParser.test.ts
+++ b/agents-api/src/domains/run/stream/__tests__/IncrementalStreamParser.test.ts
@@ -703,6 +703,66 @@ describe('IncrementalStreamParser', () => {
     });
   });
 
+  describe('finalize', () => {
+    it('does not duplicate collected parts when buffer has content alongside pendingTextBuffer', async () => {
+      (parser as any).buffer = ' more text';
+      (parser as any).pendingTextBuffer = 'initial';
+      (parser as any).hasStartedRole = true;
+
+      await parser.finalize();
+
+      const collected = parser.getCollectedParts();
+      const textParts = collected.filter((p) => p.kind === 'text');
+      const allText = textParts.map((p) => p.text).join('');
+
+      expect(allText).toBe('initial more text');
+      expect(textParts).toHaveLength(1);
+    });
+
+    it('removes complete artifact tags from buffer+pendingTextBuffer at finalize', async () => {
+      (parser as any).buffer = ' after tag';
+      (parser as any).pendingTextBuffer = 'before </artifact:ref>';
+      (parser as any).hasStartedRole = true;
+
+      await parser.finalize();
+
+      const collected = parser.getCollectedParts();
+      const textParts = collected.filter((p) => p.kind === 'text');
+      const allText = textParts.map((p) => p.text).join('');
+
+      expect(allText).toBe('before  after tag');
+      expect(textParts).toHaveLength(1);
+
+      const streamCalls = (mockStreamHelper.streamText as ReturnType<typeof vi.fn>).mock.calls;
+      expect(streamCalls).toHaveLength(1);
+      expect(streamCalls[0][0]).toBe('before  after tag');
+    });
+
+    it('writes role before streaming if not yet started', async () => {
+      (parser as any).buffer = 'hello';
+      (parser as any).hasStartedRole = false;
+
+      await parser.finalize();
+
+      expect(mockStreamHelper.writeRole).toHaveBeenCalledWith('assistant');
+      expect(mockStreamHelper.streamText).toHaveBeenCalledWith('hello', 0);
+    });
+
+    it('flushes remaining non-Text data components at finalization', async () => {
+      await parser.processObjectDelta({
+        dataComponents: [{ id: 'card1', name: 'Card', props: { title: 'Test Card' } }],
+      });
+
+      await parser.finalize();
+
+      expect(mockArtifactParser.parseObject).toHaveBeenCalledWith(
+        { dataComponents: [{ id: 'card1', name: 'Card', props: { title: 'Test Card' } }] },
+        expect.any(Map),
+        expect.any(String)
+      );
+    });
+  });
+
   describe('internal tool_result artifact suppression (live SSE)', () => {
     it('does not stream an internal tool_result artifact to the end user', async () => {
       const internalArtifactPart = {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes a bug in `IncrementalStreamParser.finalize()` that caused text content to be pushed to `collectedParts` twice when the buffer contained incomplete artifact markers at stream end. This resulted in persisted messages having duplicate text parts, which caused "double content" when conversations were replayed in the widget.

## Problem

In `finalize()`:
1. `streamPart()` was called with the remaining buffer text, unconditionally pushing it to `collectedParts`
2. If `hasIncompleteArtifact` returned `true`, `streamPart` would NOT flush `pendingTextBuffer` (buffering it for later)
3. The subsequent `pendingTextBuffer` cleanup block would then push the (cleaned) text to `collectedParts` **again**

This meant the same text appeared twice in the response parts array that gets persisted to the database, and then appeared doubled when the conversation was replayed via the widget.

## Fix

Instead of routing the remaining buffer through `streamPart()` (which has the unconditional push + conditional flush split), merge it directly into `pendingTextBuffer`. The combined text is then cleaned of artifact tags and pushed to `collectedParts` exactly once.

## Testing

- Added 3 new tests covering the finalize behavior:
  - Verifies no duplicate parts when buffer has content alongside pendingTextBuffer
  - Verifies artifact tags are properly stripped from combined buffer+pendingTextBuffer
  - Verifies role is written if not yet started
- All existing streaming tests continue to pass

## Changeset

`@inkeep/agents-api` patch — "Fix duplicate content in streamed responses caused by double-push in finalize"

Resolves PRD-7514
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [PRD-7514](https://linear.app/inkeep/issue/PRD-7514/i-was-viewing-serafins-blog-post-and-seeing-the-double-content-ok-bug)

<div><a href="https://cursor.com/agents/bc-5eb701e8-0a0b-42d2-bb4a-57a788dd70db"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5eb701e8-0a0b-42d2-bb4a-57a788dd70db"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

