### PR TITLE
feat: add LiteLLM as an OpenAI-compatible model provider

### DIFF
--- a/.changeset/add-litellm-provider.md
+++ b/.changeset/add-litellm-provider.md
@@ -1,0 +1,6 @@
+---
+"@inkeep/agents-core": patch
+"@inkeep/agents-manage-ui": patch
+---
+
+Add LiteLLM as a built-in OpenAI-compatible model provider. Use the `litellm/` prefix (e.g. `litellm/anthropic/claude-sonnet-4-5`) to route through a LiteLLM proxy; the base URL resolves from `providerOptions.baseURL`, then `LITELLM_API_BASE`, then `http://localhost:4000/v1`, and `LITELLM_API_KEY` is sent as a bearer token when set.

--- a/agents-api/src/__tests__/run/agents/ModelFactory.test.ts
+++ b/agents-api/src/__tests__/run/agents/ModelFactory.test.ts
@@ -839,6 +839,14 @@ describe('ModelFactory', () => {
         });
       });
 
+      test('should support litellm provider', () => {
+        const result = ModelFactory.parseModelString('litellm/anthropic/claude-sonnet-4-5');
+        expect(result).toEqual({
+          provider: 'litellm',
+          modelName: 'anthropic/claude-sonnet-4-5',
+        });
+      });
+
       test('should support custom provider', () => {
         const result = ModelFactory.parseModelString('custom/my-custom-model');
         expect(result).toEqual({
@@ -898,6 +906,36 @@ describe('ModelFactory', () => {
         expect(model).toBeDefined();
         expect(model).toHaveProperty('modelId');
       }
+    });
+
+    test('should create LiteLLM models without provider options', () => {
+      // LiteLLM proxy exposes any provider model via an OpenAI-compatible API
+      const litellmModels = [
+        'litellm/anthropic/claude-sonnet-4-5',
+        'litellm/gpt-4o',
+        'litellm/bedrock/anthropic.claude-3-5-sonnet',
+        'litellm/my-team-alias',
+      ];
+
+      for (const modelString of litellmModels) {
+        const config: ModelSettings = { model: modelString };
+        const model = ModelFactory.createModel(config);
+        expect(model).toBeDefined();
+        expect(model).toHaveProperty('modelId');
+      }
+    });
+
+    test('should create LiteLLM model with a custom base URL override', () => {
+      const config: ModelSettings = {
+        model: 'litellm/my-team-alias',
+        providerOptions: {
+          baseURL: 'https://litellm.internal.example.com/v1',
+        },
+      };
+
+      const model = ModelFactory.createModel(config);
+      expect(model).toBeDefined();
+      expect(model).toHaveProperty('modelId', 'my-team-alias');
     });
 
     test('should create Custom models with provider options', () => {

--- a/agents-docs/content/typescript-sdk/models.mdx
+++ b/agents-docs/content/typescript-sdk/models.mdx
@@ -75,6 +75,7 @@ Each model type inherits independently through the project → agent → sub age
 | **OpenRouter** | `openrouter/anthropic/claude-sonnet-4-0`<br/>`openrouter/meta-llama/llama-3.1-405b` | `OPENROUTER_API_KEY` |
 | **Gateway** | `gateway/openai/gpt-4.1-mini` | `AI_GATEWAY_API_KEY` |
 | **NVIDIA NIM** | `nim/nvidia/llama-3.3-nemotron-super-49b-v1.5`<br/>`nim/nvidia/nemotron-4-340b-instruct` | `NIM_API_KEY` |
+| **LiteLLM** | `litellm/anthropic/claude-sonnet-4-5`<br/>`litellm/gpt-4o` | `LITELLM_API_KEY` |
 | **Custom OpenAI-compatible** | `custom/my-custom-model`<br/>`custom/llama-3-custom` | `CUSTOM_LLM_API_KEY` |
 | **Mock** | `mock/default` | None required |
 
@@ -307,6 +308,39 @@ models: {
 
 <Note>
 Azure OpenAI **requires** either `resourceName` (for standard Azure OpenAI deployments) or `baseURL` (for custom endpoints) in `providerOptions`. The `AZURE_API_KEY` environment variable must be set for authentication. Note that only one Azure OpenAI resource can be used at a time since authentication is handled via a single environment variable.
+</Note>
+
+**LiteLLM provider:**
+
+[LiteLLM](https://docs.litellm.ai/docs/simple_proxy) exposes 100+ providers (OpenAI, Anthropic, Bedrock, Vertex, Azure, and more) behind a single OpenAI-compatible proxy. Use the `litellm/` prefix with any model name or alias configured on your proxy.
+
+<Tabs>
+<Tab title="TypeScript">
+```typescript
+models: {
+  base: {
+    model: "litellm/anthropic/claude-sonnet-4-5",
+    providerOptions: {
+      // Optional: overrides LITELLM_API_BASE (defaults to http://localhost:4000/v1)
+      baseURL: "https://my-litellm-proxy.example.com/v1",
+      temperature: 0.7
+    }
+  }
+}
+```
+</Tab>
+<Tab title="JSON">
+```json
+{
+  "baseUrl": "https://my-litellm-proxy.example.com/v1",
+  "temperature": 0.7
+}
+```
+</Tab>
+</Tabs>
+
+<Note>
+The LiteLLM provider points at your LiteLLM proxy. The base URL resolves from `providerOptions.baseURL`, then the `LITELLM_API_BASE` environment variable, then `http://localhost:4000/v1`. Set `LITELLM_API_KEY` to your proxy's virtual/master key; it is sent as a bearer token when present. Model names after the `litellm/` prefix are passed through to the proxy, so any provider model string or configured alias works.
 </Note>
 
 **Custom OpenAI-compatible provider:**

--- a/agents-manage-ui/src/components/agent/sidepane/nodes/model-selector.tsx
+++ b/agents-manage-ui/src/components/agent/sidepane/nodes/model-selector.tsx
@@ -57,7 +57,7 @@ export const ModelSelector: FC<ModelSelectorProps> = ({
   const [open, setOpen] = useState(defaultOpen);
 
   const [showCustomInput, setShowCustomInput] = useState<
-    'openrouter' | 'gateway' | 'nim' | 'custom' | 'azure' | null
+    'openrouter' | 'gateway' | 'nim' | 'litellm' | 'custom' | 'azure' | null
   >(null);
   const [azureDeploymentName, setAzureDeploymentName] = useState('');
   const [azureResourceName, setAzureResourceName] = useState('');
@@ -89,6 +89,10 @@ export const ModelSelector: FC<ModelSelectorProps> = ({
     if (value.startsWith('nim/')) {
       const modelName = value.replace('nim/', '');
       return { value, label: modelName, prefix: 'nim/' };
+    }
+    if (value.startsWith('litellm/')) {
+      const modelName = value.replace('litellm/', '');
+      return { value, label: modelName, prefix: 'litellm/' };
     }
     if (value.startsWith('custom/')) {
       const modelName = value.replace('custom/', '');
@@ -203,6 +207,7 @@ export const ModelSelector: FC<ModelSelectorProps> = ({
                               !modelValue.startsWith('openrouter/') &&
                               !modelValue.startsWith('gateway/') &&
                               !modelValue.startsWith('nim/') &&
+                              !modelValue.startsWith('litellm/') &&
                               !modelValue.startsWith('custom/')
                             ) {
                               // Could be openrouter format, let user decide or add logic here
@@ -312,6 +317,18 @@ export const ModelSelector: FC<ModelSelectorProps> = ({
                   </CommandItem>
                   <CommandItem
                     className="flex items-center justify-between cursor-pointer text-foreground"
+                    value="__litellm__"
+                    onSelect={() => {
+                      setShowCustomInput('litellm');
+                      setOpen(false);
+                      setCustomModelInput('');
+                      onValueChange('litellm/...');
+                    }}
+                  >
+                    LiteLLM ...
+                  </CommandItem>
+                  <CommandItem
+                    className="flex items-center justify-between cursor-pointer text-foreground"
                     value="__azure__"
                     onSelect={() => {
                       setShowCustomInput('azure');
@@ -338,6 +355,7 @@ export const ModelSelector: FC<ModelSelectorProps> = ({
               openrouter: 'OpenRouter Model ID',
               gateway: 'Vercel AI Gateway Model ID',
               nim: 'NVIDIA NIM Model ID',
+              litellm: 'LiteLLM Model ID',
               custom: '',
             }[showCustomInput] || 'Custom Model ID'}
           </div>
@@ -347,6 +365,8 @@ export const ModelSelector: FC<ModelSelectorProps> = ({
                 'Examples: anthropic/claude-3-5-sonnet, meta-llama/llama-3.1-405b-instruct',
               gateway: 'Examples: openai/gpt-4o, anthropic/claude-3-5-sonnet',
               nim: 'Examples: nvidia/llama-3.3-nemotron-super-49b-v1.5, nvidia/nemotron-4-340b-instruct',
+              litellm:
+                'Examples: anthropic/claude-sonnet-4-5, gpt-4o, or a model alias configured on your LiteLLM proxy',
               custom: '',
             }[showCustomInput] || 'Examples: my-custom-model, llama-3-custom, custom-finetuned'}
           </div>
@@ -357,6 +377,7 @@ export const ModelSelector: FC<ModelSelectorProps> = ({
                   openrouter: 'anthropic/claude-3-5-sonnet',
                   gateway: 'openai/gpt-4o',
                   nim: 'nvidia/llama-3.3-nemotron-super-49b-v1.5',
+                  litellm: 'anthropic/claude-sonnet-4-5',
                   custom: '',
                 }[showCustomInput] || 'my-custom-model'
               }
@@ -371,7 +392,9 @@ export const ModelSelector: FC<ModelSelectorProps> = ({
                         ? 'gateway/'
                         : showCustomInput === 'nim'
                           ? 'nim/'
-                          : 'custom/';
+                          : showCustomInput === 'litellm'
+                            ? 'litellm/'
+                            : 'custom/';
                   onValueChange(`${prefix}${customModelInput.trim()}`);
                   setShowCustomInput(null);
                   setCustomModelInput('');
@@ -394,7 +417,9 @@ export const ModelSelector: FC<ModelSelectorProps> = ({
                         ? 'gateway/'
                         : showCustomInput === 'nim'
                           ? 'nim/'
-                          : 'custom/';
+                          : showCustomInput === 'litellm'
+                            ? 'litellm/'
+                            : 'custom/';
                   onValueChange(`${prefix}${customModelInput.trim()}`);
                   setShowCustomInput(null);
                   setCustomModelInput('');

--- a/agents-manage-ui/src/features/agent/state/use-agent-store.ts
+++ b/agents-manage-ui/src/features/agent/state/use-agent-store.ts
@@ -22,7 +22,7 @@ interface AgentStateData {
   isSidebarSessionOpen: boolean;
   variableSuggestions: string[];
   /**
-   * Tracks if any model configuration modal is currently open (azure, openrouter, gateway, nim).
+   * Tracks if any model configuration modal is currently open (azure, openrouter, gateway, nim, litellm).
    * Used to disable save button while configuration is in progress.
    */
   hasOpenModelConfig: boolean;

--- a/packages/agents-core/src/__tests__/utils/model-factory.test.ts
+++ b/packages/agents-core/src/__tests__/utils/model-factory.test.ts
@@ -75,6 +75,14 @@ describe('ModelFactory', () => {
       });
     });
 
+    test('should parse litellm model string', () => {
+      const result = ModelFactory.parseModelString('litellm/anthropic/claude-sonnet-4-5');
+      expect(result).toEqual({
+        provider: 'litellm',
+        modelName: 'anthropic/claude-sonnet-4-5',
+      });
+    });
+
     test('should parse custom model string', () => {
       const result = ModelFactory.parseModelString('custom/my-custom-model');
       expect(result).toEqual({

--- a/packages/agents-core/src/utils/model-factory.ts
+++ b/packages/agents-core/src/utils/model-factory.ts
@@ -27,6 +27,20 @@ const nimDefault = createOpenAICompatible({
   },
 });
 
+// LiteLLM proxy default endpoint (LiteLLM's documented default proxy port)
+const LITELLM_DEFAULT_BASE_URL = 'http://localhost:4000/v1';
+
+// LiteLLM default provider instance
+const litellmDefault = createOpenAICompatible({
+  name: 'litellm',
+  baseURL: process.env.LITELLM_API_BASE || LITELLM_DEFAULT_BASE_URL,
+  headers: {
+    ...(process.env.LITELLM_API_KEY && {
+      Authorization: `Bearer ${process.env.LITELLM_API_KEY}`,
+    }),
+  },
+});
+
 /**
  * Factory for creating AI SDK language models from configuration
  * Supports multiple providers and AI Gateway integration
@@ -77,6 +91,19 @@ export class ModelFactory {
           ...config,
         };
         return createOpenAICompatible(nimConfig);
+      }
+      case 'litellm': {
+        const litellmConfig = {
+          name: 'litellm',
+          baseURL: process.env.LITELLM_API_BASE || LITELLM_DEFAULT_BASE_URL,
+          headers: {
+            ...(process.env.LITELLM_API_KEY && {
+              Authorization: `Bearer ${process.env.LITELLM_API_KEY}`,
+            }),
+          },
+          ...config,
+        };
+        return createOpenAICompatible(litellmConfig);
       }
       case 'custom': {
         if (!config.baseURL && !config.baseUrl) {
@@ -261,6 +288,9 @@ export class ModelFactory {
         case 'nim':
           model = nimDefault(modelName);
           break;
+        case 'litellm':
+          model = litellmDefault(modelName);
+          break;
         case 'mock':
           return createMockModel(modelName) as unknown as LanguageModel;
         case 'custom':
@@ -271,7 +301,7 @@ export class ModelFactory {
           throw new Error(
             `Unsupported provider: ${provider}. ` +
               `Supported providers are: ${ModelFactory.BUILT_IN_PROVIDERS.join(', ')}. ` +
-              `To access other models, use OpenRouter (openrouter/model-id), Vercel AI Gateway (gateway/model-id), NVIDIA NIM (nim/model-id), or Custom OpenAI-compatible (custom/model-id).`
+              `To access other models, use OpenRouter (openrouter/model-id), Vercel AI Gateway (gateway/model-id), NVIDIA NIM (nim/model-id), LiteLLM (litellm/model-id), or Custom OpenAI-compatible (custom/model-id).`
           );
       }
     }
@@ -293,6 +323,7 @@ export class ModelFactory {
     'openrouter',
     'gateway',
     'nim',
+    'litellm',
     'custom',
     'mock',
   ] as const;


### PR DESCRIPTION
## Summary

- Adds **LiteLLM** as a first-class model provider, alongside the existing `openrouter`, `nim`, and `custom` OpenAI-compatible providers.
- Use the `litellm/` prefix (e.g. `litellm/anthropic/claude-sonnet-4-5`, `litellm/gpt-4o`, or any alias configured on your proxy) to route through a [LiteLLM proxy](https://docs.litellm.ai/docs/simple_proxy), which fronts 100+ providers (OpenAI, Anthropic, Bedrock, Vertex, Azure, Gemini, Groq, and more) behind one OpenAI-compatible endpoint.
- Implemented by mirroring the existing `nim` provider pattern exactly (a named `createOpenAICompatible` default instance + a configurable case), so it is additive and low-risk.

## Motivation

Teams that already run a LiteLLM proxy for centralized key management, spend tracking, routing, and rate limiting currently have to use the generic `custom/` provider and hand-set `providerOptions.baseURL` on every model. That works, but it is undiscoverable and easy to get wrong. This mirrors why the repo already ships named `nim` and `openrouter` conveniences on top of the generic `custom` path: a first-class `litellm/` provider gives a documented default base URL (`http://localhost:4000/v1`, LiteLLM's standard proxy port), env-based configuration, and UI discoverability.

## Changes

- `packages/agents-core/src/utils/model-factory.ts` — new `litellmDefault` provider instance; `litellm` case in `createProvider` (custom-config path) and in the default-instance switch; `litellm` added to `BUILT_IN_PROVIDERS`; provider-enumeration error messages updated.
- `packages/agents-core/src/__tests__/utils/model-factory.test.ts` — `parseModelString` coverage for `litellm/`.
- `agents-api/src/__tests__/run/agents/ModelFactory.test.ts` — parse + create coverage (default and custom-base-URL).
- `agents-manage-ui/src/components/agent/sidepane/nodes/model-selector.tsx` — LiteLLM entry in the model picker (prefix display, selector item, labels/placeholder, prefix handling).
- `agents-manage-ui/src/features/agent/state/use-agent-store.ts` — doc comment update.
- `agents-docs/content/typescript-sdk/models.mdx` — provider table row + configuration section.
- `.changeset/add-litellm-provider.md` — patch changeset for `@inkeep/agents-core` and `@inkeep/agents-manage-ui`.

### Configuration

The base URL resolves from `providerOptions.baseURL`, then `LITELLM_API_BASE`, then `http://localhost:4000/v1`. Set `LITELLM_API_KEY` to your proxy's virtual/master key; it is sent as a bearer token only when present (so keyless local proxies work too).

```typescript
models: {
  base: {
    model: "litellm/anthropic/claude-sonnet-4-5",
    providerOptions: {
      baseURL: "https://my-litellm-proxy.example.com/v1", // optional; overrides LITELLM_API_BASE
    },
  },
}
```

## Tests

**1. Unit tests**

`agents-core` (`packages/agents-core`):
```
$ pnpm exec vitest run src/__tests__/utils/model-factory.test.ts
 ✓ src/__tests__/utils/model-factory.test.ts (49 tests) 2433ms
 Test Files  1 passed (1)
      Tests  49 passed (49)
```

`agents-api`:
```
$ pnpm exec vitest run src/__tests__/run/agents/ModelFactory.test.ts
 ✓ |@inkeep/agents-api| src/__tests__/run/agents/ModelFactory.test.ts (70 tests) 239ms
 Test Files  1 passed (1)
      Tests  70 passed (70)
```

**2. Format + lint (Biome)** — clean on all changed files:
```
$ pnpm exec biome check <changed files>
Checked 5 files in 17ms. No fixes applied.
```

**3. Typecheck** — `@inkeep/agents-core` and `@inkeep/agents-manage-ui` both pass `tsc --noEmit`.

**4. Live end-to-end through a real LiteLLM proxy**

A LiteLLM proxy was started with an alias `e2e-gpt` routed to a live Azure AI Foundry deployment, then driven through `ModelFactory.createModel('litellm/e2e-gpt')` using the AI SDK's `generateText` and `streamText`:

```
provider: litellm.chat | modelId: e2e-gpt
LITELLM_API_BASE: http://localhost:4141/v1

[generateText]
  text: "4"
  finishReason: stop
  usage: {"inputTokens":19,"outputTokens":5,"totalTokens":24, ...}

[streamText]
streaming ok
  streamed: "streaming ok"
  finishReason: stop
```

This exercises the full chain: `ModelFactory` → `createOpenAICompatible` (the new `litellm` provider) → LiteLLM proxy → upstream provider → response parsed back through the AI SDK, for both non-streaming and streaming.

## Risk / compatibility

- Additive only. No existing provider behavior changes.
- Same shape as the existing `nim` named OpenAI-compatible provider.
- No new dependencies (`@ai-sdk/openai-compatible` is already used by `nim`/`custom`).

## Example usage

```typescript
import { ModelFactory } from '@inkeep/agents-core';

// LITELLM_API_BASE=https://my-litellm-proxy/v1  LITELLM_API_KEY=sk-...
const model = ModelFactory.createModel({ model: 'litellm/anthropic/claude-sonnet-4-5' });
```
