### PR TITLE
docs: replace broken Cloud waitlist link

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Agents can also be used for **AI Workflow Automation** like:
 
 For a full overview, see the [Concepts](https://docs.inkeep.com/concepts) guide.
 
-Interested in a managed platform? Sign up for the [Inkeep Cloud waitlist](https://inkeep.com/cloud-waitlist) or learn about [Inkeep Enterprise](https://inkeep.com/enterprise).
+Interested in a managed platform? Request a [demo](https://inkeep.com/demo) or learn about [Inkeep Enterprise](https://inkeep.com/enterprise).
 
 ## Architecture
 


### PR DESCRIPTION
## Summary

- Replace the broken Inkeep Cloud waitlist link in `README.md` with the current demo URL.
- Keep the existing Enterprise link alongside the demo entry point.

Fixes #3429

## Verification

- Confirmed `https://inkeep.com/demo` returns HTTP 200.
- Confirmed `https://inkeep.com/enterprise` returns HTTP 200.
- Ran `git diff-tree --check` against the base and tip commits.
