### PR TITLE
fix(ai-sdk-provider): fix tool call propagation and tool message formatting

### DIFF
--- a/.changeset/asleep-cyan-mink.md
+++ b/.changeset/asleep-cyan-mink.md
@@ -1,0 +1,5 @@
+---
+"@inkeep/ai-sdk-provider": patch
+---
+
+Fix tool call propagation and tool message formatting in AI SDK provider

--- a/packages/ai-sdk-provider/src/__tests__/convert-to-inkeep-messages.test.ts
+++ b/packages/ai-sdk-provider/src/__tests__/convert-to-inkeep-messages.test.ts
@@ -1,0 +1,210 @@
+import type { LanguageModelV2Prompt } from '@ai-sdk/provider';
+import { describe, expect, it } from 'vitest';
+import { convertToInkeepChatMessages } from '../convert-to-inkeep-messages';
+
+describe('convertToInkeepChatMessages', () => {
+  it('should convert system messages', () => {
+    const prompt: LanguageModelV2Prompt = [
+      {
+        role: 'system',
+        content: 'You are a helpful assistant.',
+      },
+    ];
+
+    const result = convertToInkeepChatMessages(prompt);
+
+    expect(result).toEqual([
+      {
+        role: 'system',
+        content: 'You are a helpful assistant.',
+      },
+    ]);
+  });
+
+  it('should convert single user text messages to string content', () => {
+    const prompt: LanguageModelV2Prompt = [
+      {
+        role: 'user',
+        content: [{ type: 'text', text: 'Hello!' }],
+      },
+    ];
+
+    const result = convertToInkeepChatMessages(prompt);
+
+    expect(result).toEqual([
+      {
+        role: 'user',
+        content: 'Hello!',
+      },
+    ]);
+  });
+
+  it('should convert assistant messages with text only', () => {
+    const prompt: LanguageModelV2Prompt = [
+      {
+        role: 'assistant',
+        content: [{ type: 'text', text: 'I can help with that.' }],
+      },
+    ];
+
+    const result = convertToInkeepChatMessages(prompt);
+
+    expect(result).toEqual([
+      {
+        role: 'assistant',
+        content: 'I can help with that.',
+      },
+    ]);
+  });
+
+  it('should preserve toolCalls on assistant messages', () => {
+    const prompt: LanguageModelV2Prompt = [
+      {
+        role: 'assistant',
+        content: [
+          { type: 'text', text: 'Let me look that up.' },
+          {
+            type: 'tool-call',
+            toolCallId: 'call-123',
+            toolName: 'search_docs',
+            input: { query: 'getting started' },
+          },
+        ],
+      },
+    ];
+
+    const result = convertToInkeepChatMessages(prompt);
+
+    expect(result).toEqual([
+      {
+        role: 'assistant',
+        content: 'Let me look that up.',
+        tool_calls: [
+          {
+            id: 'call-123',
+            type: 'function',
+            function: {
+              name: 'search_docs',
+              arguments: JSON.stringify({ query: 'getting started' }),
+            },
+          },
+        ],
+      },
+    ]);
+  });
+
+  it('should convert tool response messages with tool_call_id and stringified content', () => {
+    const prompt: LanguageModelV2Prompt = [
+      {
+        role: 'tool',
+        content: [
+          {
+            type: 'tool-result',
+            toolCallId: 'call-123',
+            toolName: 'search_docs',
+            output: { type: 'json', value: { results: ['Doc 1', 'Doc 2'] } },
+          },
+        ],
+      },
+    ];
+
+    const result = convertToInkeepChatMessages(prompt);
+
+    expect(result).toEqual([
+      {
+        role: 'tool',
+        content: JSON.stringify({ results: ['Doc 1', 'Doc 2'] }),
+        name: 'search_docs',
+        tool_call_id: 'call-123',
+      },
+    ]);
+  });
+
+  it('should handle tool response with text output', () => {
+    const prompt: LanguageModelV2Prompt = [
+      {
+        role: 'tool',
+        content: [
+          {
+            type: 'tool-result',
+            toolCallId: 'call-456',
+            toolName: 'get_weather',
+            output: { type: 'text', value: 'Sunny and 72F' },
+          },
+        ],
+      },
+    ];
+
+    const result = convertToInkeepChatMessages(prompt);
+
+    expect(result).toEqual([
+      {
+        role: 'tool',
+        content: 'Sunny and 72F',
+        name: 'get_weather',
+        tool_call_id: 'call-456',
+      },
+    ]);
+  });
+
+  it('should convert a full multi-turn conversation with tool calling', () => {
+    const prompt: LanguageModelV2Prompt = [
+      {
+        role: 'system',
+        content: 'System prompt',
+      },
+      {
+        role: 'user',
+        content: [{ type: 'text', text: 'Find info about API keys' }],
+      },
+      {
+        role: 'assistant',
+        content: [
+          {
+            type: 'tool-call',
+            toolCallId: 'call-789',
+            toolName: 'query_api',
+            input: { endpoint: '/keys' },
+          },
+        ],
+      },
+      {
+        role: 'tool',
+        content: [
+          {
+            type: 'tool-result',
+            toolCallId: 'call-789',
+            toolName: 'query_api',
+            output: { type: 'json', value: { status: 'active' } },
+          },
+        ],
+      },
+    ];
+
+    const result = convertToInkeepChatMessages(prompt);
+
+    expect(result).toHaveLength(4);
+    expect(result[0]).toEqual({ role: 'system', content: 'System prompt' });
+    expect(result[1]).toEqual({ role: 'user', content: 'Find info about API keys' });
+    expect(result[2]).toEqual({
+      role: 'assistant',
+      content: '',
+      tool_calls: [
+        {
+          id: 'call-789',
+          type: 'function',
+          function: {
+            name: 'query_api',
+            arguments: JSON.stringify({ endpoint: '/keys' }),
+          },
+        },
+      ],
+    });
+    expect(result[3]).toEqual({
+      role: 'tool',
+      content: JSON.stringify({ status: 'active' }),
+      name: 'query_api',
+      tool_call_id: 'call-789',
+    });
+  });
+});

--- a/packages/ai-sdk-provider/src/__tests__/inkeep-chat-language-model.test.ts
+++ b/packages/ai-sdk-provider/src/__tests__/inkeep-chat-language-model.test.ts
@@ -204,5 +204,59 @@ describe('InkeepChatLanguageModel', () => {
       expect(requestBody.messages).toBeDefined();
       expect(Array.isArray(requestBody.messages)).toBe(true);
     });
+
+    it('should extract tool calls in doGenerate', async () => {
+      const mockResponse = {
+        id: 'response-2',
+        object: 'chat.completion',
+        created: Date.now(),
+        choices: [
+          {
+            index: 0,
+            message: {
+              role: 'assistant',
+              content: null,
+              tool_calls: [
+                {
+                  id: 'call-abc',
+                  type: 'function',
+                  function: {
+                    name: 'calculator',
+                    arguments: JSON.stringify({ a: 1, b: 2 }),
+                  },
+                },
+              ],
+            },
+            finish_reason: 'tool_calls',
+          },
+        ],
+      };
+
+      mockFetch.mockResolvedValue({
+        ok: true,
+        status: 200,
+        headers: new Headers(),
+        json: async () => mockResponse,
+        text: async () => JSON.stringify(mockResponse),
+      });
+
+      const model = new InkeepChatLanguageModel({}, mockConfig);
+
+      const options: LanguageModelV2CallOptions = {
+        prompt: [{ role: 'user', content: [{ type: 'text', text: 'Calculate 1 + 2' }] }],
+      };
+
+      const result = await model.doGenerate(options);
+
+      expect(result.content).toEqual([
+        {
+          type: 'tool-call',
+          toolCallId: 'call-abc',
+          toolName: 'calculator',
+          input: JSON.stringify({ a: 1, b: 2 }),
+        },
+      ]);
+      expect(result.finishReason).toBe('tool-calls');
+    });
   });
 });

--- a/packages/ai-sdk-provider/src/convert-to-inkeep-messages.ts
+++ b/packages/ai-sdk-provider/src/convert-to-inkeep-messages.ts
@@ -90,20 +90,45 @@ export function convertToInkeepChatMessages(
           }
         }
 
-        messages.push({
+        const assistantMessage: InkeepChatMessage = {
           role: 'assistant',
           content: text || '',
-        });
+        };
+
+        if (toolCalls.length > 0) {
+          assistantMessage.tool_calls = toolCalls;
+        }
+
+        messages.push(assistantMessage);
 
         break;
       }
 
       case 'tool': {
         for (const toolResponse of content) {
+          let contentStr: string;
+          const output = toolResponse.output as any;
+
+          if (output && typeof output === 'object' && 'type' in output) {
+            if (output.type === 'text' || output.type === 'error-text') {
+              contentStr = String(output.value ?? '');
+            } else if (output.type === 'json' || output.type === 'error-json') {
+              contentStr =
+                typeof output.value === 'string' ? output.value : JSON.stringify(output.value);
+            } else {
+              contentStr = JSON.stringify(output);
+            }
+          } else if (typeof output === 'string') {
+            contentStr = output;
+          } else {
+            contentStr = JSON.stringify(output);
+          }
+
           messages.push({
             role: 'tool',
-            content: JSON.stringify(toolResponse.output),
+            content: contentStr,
             name: toolResponse.toolName,
+            tool_call_id: toolResponse.toolCallId,
           });
         }
         break;

--- a/packages/ai-sdk-provider/src/inkeep-chat-language-model.ts
+++ b/packages/ai-sdk-provider/src/inkeep-chat-language-model.ts
@@ -179,6 +179,17 @@ export class InkeepChatLanguageModel implements LanguageModelV2 {
       });
     }
 
+    if (choice.message.tool_calls) {
+      for (const toolCall of choice.message.tool_calls) {
+        content.push({
+          type: 'tool-call',
+          toolCallId: toolCall.id,
+          toolName: toolCall.function.name,
+          input: toolCall.function.arguments || '{}',
+        });
+      }
+    }
+
     return {
       content,
       finishReason: mapInkeepFinishReason(choice.finish_reason as InkeepFinishReason),
@@ -349,9 +360,21 @@ const inkeepChatCompletionSchema = z.object({
       index: z.number(),
       message: z.object({
         role: z.literal('assistant'),
-        content: z.string(),
+        content: z.string().nullable().optional(),
+        tool_calls: z
+          .array(
+            z.object({
+              id: z.string(),
+              type: z.literal('function'),
+              function: z.object({
+                name: z.string(),
+                arguments: z.string(),
+              }),
+            })
+          )
+          .optional(),
       }),
-      finish_reason: z.string(),
+      finish_reason: z.string().nullable().optional(),
     })
   ),
   usage: z

--- a/packages/ai-sdk-provider/src/inkeep-chat-prompt.ts
+++ b/packages/ai-sdk-provider/src/inkeep-chat-prompt.ts
@@ -7,6 +7,15 @@ export interface InkeepChatMessage {
         text?: string;
       }>;
   name?: string;
+  tool_call_id?: string;
+  tool_calls?: Array<{
+    id: string;
+    type: 'function';
+    function: {
+      name: string;
+      arguments: string;
+    };
+  }>;
 }
 
 export interface InkeepChatRequest {
@@ -65,7 +74,7 @@ export interface InkeepChatCompletion {
     index: number;
     message: {
       role: 'assistant';
-      content: string;
+      content?: string | null;
       tool_calls?: Array<{
         id: string;
         type: 'function';
@@ -75,7 +84,7 @@ export interface InkeepChatCompletion {
         };
       }>;
     };
-    finish_reason: string;
+    finish_reason?: string | null;
   }>;
   usage?: {
     prompt_tokens?: number;


### PR DESCRIPTION
## Summary
This PR fixes tool call handling and message serialization in \@inkeep/ai-sdk-provider\:
1. **Tool Message Format & Propagation**:
   - Added \	ool_call_id\ and \	ool_calls\ properties to \InkeepChatMessage\ interface in \inkeep-chat-prompt.ts\.
   - Updated \convertToInkeepChatMessages\ in \convert-to-inkeep-messages.ts\ so that \	ool\ role messages properly format their \	ool_call_id\ and content, and assistant tool calls are preserved.
2. **Schema & Model Output Handling**:
   - Updated \inkeepChatCompletionSchema\ in \inkeep-chat-language-model.ts\ to accept nullable content when \	ool_calls\ are present.
   - Fixed \doGenerate\ to emit tool-call generation objects and avoid discarding model-invoked tool calls.

## Verification
- \pnpm --filter @inkeep/ai-sdk-provider test\ passes (all unit tests pass).
- \pnpm --filter @inkeep/ai-sdk-provider typecheck\ passes with 0 errors.