### PR TITLE
fix(agents-core): fix subagent stepCountIs inheritance and project skills cleanup

### DIFF
--- a/.changeset/exact-tan-worm.md
+++ b/.changeset/exact-tan-worm.md
@@ -1,0 +1,5 @@
+---
+"@inkeep/agents-core": patch
+---
+
+Fix sub-agent stepCountIs inheritance and project skill cleanup

--- a/packages/agents-core/src/__tests__/data-access/agentFull.test.ts
+++ b/packages/agents-core/src/__tests__/data-access/agentFull.test.ts
@@ -652,5 +652,153 @@ describe('AgentFull Data Access - getFullAgentDefinition', () => {
       expect(result?.subAgents).not.toHaveProperty('non-existent-agent');
       expect(Object.keys(result?.subAgents || {})).toHaveLength(1);
     });
+
+    it('should properly propagate stepCountIs to subAgents from project stopWhen during createFullAgentServerSide', async () => {
+      const mockProject = {
+        id: testProjectId,
+        name: 'Test Project',
+        stopWhen: {
+          stepCountIs: 25,
+          transferCountIs: 5,
+        },
+      };
+
+      const mockAgent = {
+        id: testAgentId,
+        name: 'Test Agent',
+        defaultSubAgentId: 'agent-1',
+        tenantId: testTenantId,
+        projectId: testProjectId,
+        createdAt: '2024-01-01T00:00:00.000Z',
+        updatedAt: '2024-01-01T00:00:00.000Z',
+        description: null,
+        models: null,
+        contextConfigId: null,
+        stopWhen: {
+          transferCountIs: 5,
+        },
+      };
+
+      const mockSubAgent = {
+        id: 'agent-1',
+        name: 'Agent 1',
+        description: 'First agent',
+        prompt: 'Instructions 1',
+        models: null,
+        tenantId: testTenantId,
+        projectId: testProjectId,
+        agentId: testAgentId,
+        stopWhen: {
+          stepCountIs: 25,
+        },
+        createdAt: '2024-01-01T00:00:00.000Z',
+        updatedAt: '2024-01-01T00:00:00.000Z',
+      };
+
+      const mockQuery = {
+        projects: {
+          findFirst: vi.fn().mockResolvedValue(mockProject),
+        },
+        agents: {
+          findFirst: vi.fn().mockResolvedValue(mockAgent),
+        },
+        subAgents: {
+          findFirst: vi.fn().mockResolvedValue(mockSubAgent),
+          findMany: vi.fn().mockResolvedValue([mockSubAgent]),
+        },
+        subAgentRelations: {
+          findMany: vi.fn().mockResolvedValue([]),
+        },
+        subAgentExternalAgentRelations: {
+          findMany: vi.fn().mockResolvedValue([]),
+        },
+        subAgentTeamAgentRelations: {
+          findMany: vi.fn().mockResolvedValue([]),
+        },
+        subAgentDataComponents: {
+          findMany: vi.fn().mockResolvedValue([]),
+        },
+        subAgentArtifactComponents: {
+          findMany: vi.fn().mockResolvedValue([]),
+        },
+        dataComponents: {
+          findMany: vi.fn().mockResolvedValue([]),
+        },
+        artifactComponents: {
+          findMany: vi.fn().mockResolvedValue([]),
+        },
+      };
+
+      const mockDelete = vi.fn().mockReturnValue({
+        where: vi.fn().mockResolvedValue([]),
+      });
+
+      const mockUpdate = vi.fn().mockReturnValue({
+        set: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            returning: vi.fn().mockResolvedValue([mockAgent]),
+          }),
+        }),
+      });
+
+      const mockTx = {
+        query: mockQuery,
+        insert: vi.fn().mockReturnValue({
+          values: vi.fn().mockReturnValue({
+            returning: vi.fn().mockResolvedValue([
+              {
+                id: testAgentId,
+                name: 'Test Agent',
+                defaultSubAgentId: 'agent-1',
+                tenantId: testTenantId,
+                projectId: testProjectId,
+              },
+            ]),
+          }),
+        }),
+        update: mockUpdate,
+        delete: mockDelete,
+        select: vi.fn().mockReturnValue(createSelectMock([])),
+        selectDistinct: vi.fn().mockReturnValue(createSelectMock([])),
+      };
+
+      const mockDb = {
+        query: mockQuery,
+        insert: mockTx.insert,
+        update: mockUpdate,
+        delete: mockDelete,
+        select: mockTx.select,
+        selectDistinct: mockTx.selectDistinct,
+        transaction: vi.fn(async (cb) => cb(mockTx)),
+      } as any;
+
+      const agentData: any = {
+        id: testAgentId,
+        name: 'Test Agent',
+        defaultSubAgentId: 'agent-1',
+        subAgents: {
+          'agent-1': {
+            id: 'agent-1',
+            name: 'Agent 1',
+            description: 'First agent',
+            prompt: 'Instructions 1',
+            type: 'internal',
+            canDelegateTo: [],
+            canUse: [],
+            dataComponents: [],
+            artifactComponents: [],
+          },
+        },
+      };
+
+      const { createFullAgentServerSide } = await import('../../data-access/manage/agentFull');
+      const result = await createFullAgentServerSide(mockDb)(
+        { tenantId: testTenantId, projectId: testProjectId },
+        agentData
+      );
+
+      expect(result.stopWhen?.transferCountIs).toBe(5);
+      expect(result.subAgents['agent-1']?.stopWhen?.stepCountIs).toBe(25);
+    });
   });
 });

--- a/packages/agents-core/src/__tests__/data-access/projectFull.test.ts
+++ b/packages/agents-core/src/__tests__/data-access/projectFull.test.ts
@@ -7,6 +7,7 @@ import {
   getFullProject,
   updateFullProjectServerSide,
 } from '../../data-access/manage/projectFull';
+import { listSkills } from '../../data-access/manage/skills';
 import type { AgentsManageDatabaseClient } from '../../db/manage/manage-client';
 import type { AgentsRunDatabaseClient } from '../../db/runtime/runtime-client';
 import { createTestOrganization } from '../../db/runtime/test-runtime-client';
@@ -893,6 +894,71 @@ Always check alerts.`,
       expect(Object.keys(result?.artifactComponents || {})).toHaveLength(1);
       expect(result?.artifactComponents?.[artifact1Id]).toBeDefined();
       expect(result?.artifactComponents?.[artifact2Id]).toBeUndefined();
+    });
+
+    it('should delete orphaned skills when removed from project', async () => {
+      const projectId = `project-${generateId()}`;
+      const skill1Id = `skill-${generateId()}`;
+      const skill2Id = `skill-${generateId()}`;
+
+      const projectWithSkills: FullProjectDefinition = {
+        ...createTestProjectDefinition(projectId),
+        skills: {
+          [skill1Id]: {
+            name: skill1Id,
+            description: 'Skill 1 description',
+            content: 'Skill 1 content',
+            metadata: null,
+            files: [
+              {
+                filePath: 'SKILL.md',
+                content: `---\nname: ${skill1Id}\ndescription: Skill 1 description\n---\nSkill 1 content`,
+              },
+            ],
+          },
+          [skill2Id]: {
+            name: skill2Id,
+            description: 'Skill 2 description',
+            content: 'Skill 2 content',
+            metadata: null,
+            files: [
+              {
+                filePath: 'SKILL.md',
+                content: `---\nname: ${skill2Id}\ndescription: Skill 2 description\n---\nSkill 2 content`,
+              },
+            ],
+          },
+        },
+      };
+
+      await createFullProjectServerSide(db)({
+        scopes: { tenantId, projectId },
+        projectData: projectWithSkills,
+      });
+
+      let skillsResult = await listSkills(db)({
+        scopes: { tenantId, projectId },
+      });
+      expect(skillsResult.data).toHaveLength(2);
+
+      const updatedProjectWithOneSkill: FullProjectDefinition = {
+        ...projectWithSkills,
+        skills: {
+          // biome-ignore lint/style/noNonNullAssertion: ignore in test
+          [skill1Id]: projectWithSkills.skills![skill1Id],
+        },
+      };
+
+      await updateFullProjectServerSide(db)({
+        scopes: { tenantId, projectId },
+        projectData: updatedProjectWithOneSkill,
+      });
+
+      skillsResult = await listSkills(db)({
+        scopes: { tenantId, projectId },
+      });
+      expect(skillsResult.data).toHaveLength(1);
+      expect(skillsResult.data[0]?.name).toBe(skill1Id);
     });
 
     it('should delete orphaned agents when removed from project', async () => {

--- a/packages/agents-core/src/data-access/manage/agentFull.ts
+++ b/packages/agents-core/src/data-access/manage/agentFull.ts
@@ -164,23 +164,19 @@ async function applyExecutionLimitsInheritance(
       );
 
       for (const [subAgentId, subAgentData] of Object.entries(agentData.subAgents)) {
-        if (subAgentData.canTransferTo && Array.isArray(subAgentData.canTransferTo)) {
-          const agent = agentData as any;
+        if (!subAgentData.stopWhen) {
+          subAgentData.stopWhen = {};
+        }
 
-          if (!agent.stopWhen) {
-            agent.stopWhen = {};
-          }
-
-          if (agent.stopWhen.stepCountIs === undefined) {
-            agent.stopWhen.stepCountIs = projectStopWhen.stepCountIs;
-            logger.info(
-              {
-                subAgentId,
-                inheritedValue: projectStopWhen.stepCountIs,
-              },
-              'Agent inherited stepCountIs from project'
-            );
-          }
+        if (subAgentData.stopWhen.stepCountIs === undefined) {
+          subAgentData.stopWhen.stepCountIs = projectStopWhen.stepCountIs;
+          logger.info(
+            {
+              subAgentId,
+              inheritedValue: projectStopWhen.stepCountIs,
+            },
+            'SubAgent inherited stepCountIs from project'
+          );
         }
       }
     }

--- a/packages/agents-core/src/data-access/manage/projectFull.ts
+++ b/packages/agents-core/src/data-access/manage/projectFull.ts
@@ -41,7 +41,7 @@ import { deleteDataComponent, listDataComponents, upsertDataComponent } from './
 import { deleteExternalAgent, listExternalAgents, upsertExternalAgent } from './externalAgents';
 import { deleteFunction, listFunctions, upsertFunction } from './functions';
 import { createProject, deleteProject, getProject, updateProject } from './projects';
-import { listSkillsWithFiles, upsertSkill } from './skills';
+import { deleteSkill, listSkills, listSkillsWithFiles, upsertSkill } from './skills';
 import { deleteTool, listTools, upsertTool } from './tools';
 
 const logger = getLogger('projectFull');
@@ -1097,6 +1097,39 @@ export const updateFullProjectServerSide =
             projectId: typed.id,
           },
           'Deleted orphaned artifactComponents from project'
+        );
+      }
+
+      const incomingSkillIds = new Set(Object.keys(typed.skills || {}));
+      const existingSkillsResult = await listSkills(db)({
+        scopes: { tenantId, projectId: typed.id },
+        pagination: { page: 1, limit: 1000 },
+      });
+      const existingSkills = existingSkillsResult.data;
+
+      let deletedSkillCount = 0;
+      for (const skill of existingSkills) {
+        if (!incomingSkillIds.has(skill.id)) {
+          try {
+            await deleteSkill(db)({
+              skillId: skill.id,
+              scopes: { tenantId, projectId: typed.id },
+            });
+            deletedSkillCount++;
+            logger.info({ skillId: skill.id }, 'Deleted orphaned skill from project');
+          } catch (error) {
+            logger.error({ skillId: skill.id, error }, 'Failed to delete orphaned skill from project');
+          }
+        }
+      }
+
+      if (deletedSkillCount > 0) {
+        logger.info(
+          {
+            deletedSkillCount,
+            projectId: typed.id,
+          },
+          'Deleted orphaned skills from project'
         );
       }
 


### PR DESCRIPTION
## Summary
This PR fixes two critical data-access issues in \@inkeep/agents-core\:
1. **Subagent \stepCountIs\ Inheritance**: In \pplyExecutionLimitsInheritance\ (\gentFull.ts\), \projectStopWhen.stepCountIs\ was incorrectly mutating the parent \gentData.stopWhen\ instead of the sub-agent's \subAgentData.stopWhen\, and required an unnecessary \canTransferTo\ condition. Fixed to properly propagate \stepCountIs\ onto each \subAgentData.stopWhen\.
2. **Orphaned Skills Cleanup**: In \updateFullProjectServerSide\ (\projectFull.ts\), while orphaned tools, functions, external agents, components, and agents were cleaned up during full project updates, skills were omitted. Added orphaned skill detection and cleanup with \deleteSkill\.

## Verification
- \pnpm --filter @inkeep/agents-core test src/__tests__/data-access/agentFull.test.ts src/__tests__/data-access/projectFull.test.ts\ passes (35/35 tests pass).
- \pnpm --filter @inkeep/agents-core typecheck\ passes with zero errors.