### PR TITLE
fix(agents-core): prevent metadata header pollution and preserve base headers in CredentialStuffer

### DIFF
--- a/.changeset/civic-turquoise-constrictor.md
+++ b/.changeset/civic-turquoise-constrictor.md
@@ -1,0 +1,5 @@
+---
+"@inkeep/agents-core": patch
+---
+
+Fix credential headers merging and prevent non-string metadata spreading in CredentialStuffer

--- a/packages/agents-core/src/__tests__/credentials/credentialStuffer.test.ts
+++ b/packages/agents-core/src/__tests__/credentials/credentialStuffer.test.ts
@@ -271,6 +271,49 @@ describe('CredentialStuffer', () => {
 
       expect(result).toEqual({});
     });
+
+    test('should preserve tool base headers and not spread arbitrary metadata into headers', async () => {
+      const storeReference: CredentialStoreReference = {
+        credentialStoreId: 'nango-default',
+        retrievalParams: {
+          connectionId: 'test-conn',
+          providerConfigKey: 'test-provider',
+        },
+      };
+
+      const nangoStorePayload = {
+        connectionId: 'test-conn',
+        providerConfigKey: 'test-provider',
+        secretKey: 'secret-key',
+        provider: 'test',
+        metadata: {
+          rawUserInfo: { id: 123, roles: ['admin'] },
+          retryCount: 3,
+          isActive: true,
+        },
+      };
+
+      vi.mocked(mockNangoStore.get).mockResolvedValue(JSON.stringify(nangoStorePayload));
+
+      const result = await credentialStuffer.getCredentialHeaders({
+        context: mockContext,
+        mcpType: MCPServerType.nango,
+        storeReference,
+        headers: {
+          'X-Custom-Header': 'custom-val',
+        },
+      });
+
+      expect(result).toEqual({
+        'X-Custom-Header': 'custom-val',
+        Authorization: 'Bearer secret-key',
+        'provider-config-key': 'test-provider',
+        'connection-id': 'test-conn',
+      });
+      expect(result).not.toHaveProperty('rawUserInfo');
+      expect(result).not.toHaveProperty('retryCount');
+      expect(result).not.toHaveProperty('isActive');
+    });
   });
 
   describe('buildMcpServerConfig', () => {

--- a/packages/agents-core/src/credential-stuffer/CredentialStuffer.ts
+++ b/packages/agents-core/src/credential-stuffer/CredentialStuffer.ts
@@ -244,14 +244,10 @@ export class CredentialStuffer {
       credentialStoreHeaders = await this.getCredentials(context, storeReference, mcpType);
     }
 
-    if (!credentialStoreHeaders) {
-      return credentialsFromHeaders ? credentialsFromHeaders.headers : { ...headers };
-    }
-
-    const combinedHeaders = {
-      ...credentialStoreHeaders.headers,
-      ...credentialStoreHeaders.metadata,
-      ...credentialsFromHeaders?.headers,
+    const combinedHeaders: Record<string, string> = {
+      ...(headers ?? {}),
+      ...(credentialStoreHeaders?.headers ?? {}),
+      ...(credentialsFromHeaders?.headers ?? {}),
     };
 
     return combinedHeaders;


### PR DESCRIPTION
## Summary
This PR fixes two critical issues in \CredentialStuffer.prototype.getCredentialHeaders\:
1. **Metadata Header Pollution**: In \CredentialStuffer.ts\, \credentialStoreHeaders.metadata\ (which contains arbitrary non-string data such as nested objects, arrays, booleans, and numbers) was being spread directly into HTTP headers. This causes runtime \TypeError\ / malformed header exceptions in HTTP/fetch/undici clients when calling MCP servers.
2. **Base Header Loss**: If a tool had custom base \headers\ defined alongside a \storeReference\, the base headers were lost in the merged output. Fixed to preserve base headers, credential store headers, and template headers cleanly.

## Verification
- \pnpm --filter @inkeep/agents-core test src/__tests__/credentials/credentialStuffer.test.ts\ passes (23/23 tests pass).
- \pnpm --filter @inkeep/agents-core typecheck\ passes with zero errors.