### PR TITLE
fix(agents-sdk): remove obsolete /crud/ segment from SubAgent function and tool URLs

### DIFF
--- a/.changeset/sure-turquoise-macaw.md
+++ b/.changeset/sure-turquoise-macaw.md
@@ -1,0 +1,5 @@
+---
+"@inkeep/agents-sdk": patch
+---
+
+Remove obsolete /crud/ segment from function and tool URLs in SubAgent

--- a/packages/agents-sdk/src/__tests__/builder/subagent.test.ts
+++ b/packages/agents-sdk/src/__tests__/builder/subagent.test.ts
@@ -1,5 +1,6 @@
 import type { JsonSchemaForLlmSchemaType } from '@inkeep/agents-core';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { FunctionTool } from '../../function-tool';
 import { SubAgent } from '../../subAgent';
 import { Tool } from '../../tool';
 import type { SubAgentConfig } from '../../types';
@@ -349,6 +350,39 @@ describe('Agent Builder', () => {
             call[0]?.toString().includes('/agent-data-components')
         );
       expect(dataComponentCalls.length).toBeGreaterThan(0);
+    });
+
+    it('should create function tools without /crud/ in URL', async () => {
+      const funcTool = new FunctionTool({
+        name: 'testFunction',
+        description: 'Test function description',
+        inputSchema: { type: 'object', properties: {} },
+        dependencies: {},
+        execute: async () => ({ ok: true }),
+      });
+
+      const agentWithFunc = new SubAgent({
+        id: 'func-agent',
+        name: 'Func Agent',
+        prompt: 'Instructions',
+        canUse: () => [funcTool],
+      });
+      agentWithFunc.setContext('test-tenant', 'test-project');
+
+      await agentWithFunc.init();
+
+      const fetchUrls = vi.mocked(fetch).mock.calls.map((call) => call[0]?.toString());
+      expect(
+        fetchUrls.some((url) =>
+          url?.includes('/manage/tenants/test-tenant/projects/test-project/functions')
+        )
+      ).toBe(true);
+      expect(
+        fetchUrls.some((url) =>
+          url?.includes('/manage/tenants/test-tenant/projects/test-project/tools')
+        )
+      ).toBe(true);
+      expect(fetchUrls.some((url) => url?.includes('/crud/'))).toBe(false);
     });
   });
 

--- a/packages/agents-sdk/src/subAgent.ts
+++ b/packages/agents-sdk/src/subAgent.ts
@@ -752,7 +752,7 @@ export class SubAgent implements SubAgentInterface {
       const functionData = functionTool.serializeFunction();
       const toolData = functionTool.serializeTool();
 
-      const functionUrl = `${this.baseURL}/manage/tenants/${this.tenantId}/crud/projects/${this.projectId}/functions`;
+      const functionUrl = `${this.baseURL}/manage/tenants/${this.tenantId}/projects/${this.projectId}/functions`;
       logger.info(
         {
           agentId: this.getId(),
@@ -801,7 +801,7 @@ export class SubAgent implements SubAgentInterface {
       }
 
       // Create a tool with type 'function' at project level
-      const toolUrl = `${this.baseURL}/manage/tenants/${this.tenantId}/crud/projects/${this.projectId}/tools`;
+      const toolUrl = `${this.baseURL}/manage/tenants/${this.tenantId}/projects/${this.projectId}/tools`;
       logger.info(
         {
           agentId: this.getId(),


### PR DESCRIPTION
## Summary
This PR fixes broken API endpoints when creating function tools via \SubAgent.prototype.createFunctionTool\ in \@inkeep/agents-sdk\:
- When the \/crud/\ path segment was removed from manage API routes, \subAgent.ts\ still contained hardcoded \/crud/projects/:projectId/functions\ and \/crud/projects/:projectId/tools\ URLs, causing 404 Not Found responses when registering function tools.
- Updated \unctionUrl\ and \	oolUrl\ to use \/manage/tenants/:tenantId/projects/:projectId/functions\ and \/manage/tenants/:tenantId/projects/:projectId/tools\.
- Added unit test coverage in \subagent.test.ts\ verifying that functions and tools are registered with valid project endpoints without \/crud/\.

## Verification
- \pnpm --filter @inkeep/agents-sdk exec vitest --run\ passes (255/255 tests pass across 25 suites).
- \pnpm --filter @inkeep/agents-sdk typecheck\ passes with zero errors.