### PR TITLE
docs: add inkeep status command to CLI reference

### DIFF
--- a/agents-docs/content/typescript-sdk/cli-reference.mdx
+++ b/agents-docs/content/typescript-sdk/cli-reference.mdx
@@ -855,6 +855,37 @@ inkeep logout
 </SkillRule>
 
 <SkillRule
+  id="cli-status-command"
+  skills="typescript-sdk"
+  title="CLI inkeep status Command"
+  description="Check the status of the CLI and authentication state"
+>
+
+### `inkeep status`
+
+Check the status of your CLI connection to the Inkeep API, including authentication state and active profile.
+
+```bash
+inkeep status
+```
+
+**Options:**
+
+- `--profile <name>` - Use a specific CLI profile (overrides the active profile)
+
+**Examples:**
+
+```bash
+# Check status with active profile
+inkeep status
+
+# Check status with specific profile
+inkeep status --profile staging
+```
+
+</SkillRule>
+
+<SkillRule
   id="cli-add-command"
   skills="typescript-sdk"
   title="CLI inkeep add Command"


### PR DESCRIPTION
## Summary

Document the `inkeep status` CLI command in the CLI Reference.

## Background

The `status` command is referenced in the profile section as an API command (`push`, `pull`, `status`, `login`, `logout`), but lacks its own documentation section.

## Changes

Adds a complete `inkeep status` section with:
- Command description
- `--profile` option
- Usage examples

## Impact

Closes a documentation gap and improves CLI reference completeness for users.