### PR TITLE
feat: add OrcaRouter as a named OpenAI-compatible model provider

### DIFF
--- a/.changeset/fine-gold-cougar.md
+++ b/.changeset/fine-gold-cougar.md
@@ -1,0 +1,6 @@
+---
+"@inkeep/agents-core": patch
+"@inkeep/agents-manage-ui": patch
+---
+
+Add OrcaRouter as a named OpenAI-compatible model provider

--- a/.env.example
+++ b/.env.example
@@ -44,6 +44,9 @@ TENANT_ID=default
 ANTHROPIC_API_KEY=
 OPENAI_API_KEY=
 GOOGLE_GENERATIVE_AI_API_KEY=
+# Optional: enable OrcaRouter as a model provider
+# https://www.orcarouter.ai
+ORCAROUTER_API_KEY=
 
 # ============ PROMPT CACHING ============
 # Deployment-level kill switch for Inkeep-attached Anthropic prompt caching at

--- a/agents-api/src/__tests__/run/agents/ModelFactory.test.ts
+++ b/agents-api/src/__tests__/run/agents/ModelFactory.test.ts
@@ -839,6 +839,14 @@ describe('ModelFactory', () => {
         });
       });
 
+      test('should support orcarouter provider', () => {
+        const result = ModelFactory.parseModelString('orcarouter/auto');
+        expect(result).toEqual({
+          provider: 'orcarouter',
+          modelName: 'auto',
+        });
+      });
+
       test('should support custom provider', () => {
         const result = ModelFactory.parseModelString('custom/my-custom-model');
         expect(result).toEqual({
@@ -890,6 +898,23 @@ describe('ModelFactory', () => {
         'nim/nvidia/llama-3.3-nemotron-super-49b-v1.5',
         'nim/nvidia/nemotron-4-340b-instruct',
         'nim/meta/llama-3.1-8b-instruct',
+      ];
+
+      for (const modelString of customModels) {
+        const config: ModelSettings = { model: modelString };
+        const model = ModelFactory.createModel(config);
+        expect(model).toBeDefined();
+        expect(model).toHaveProperty('modelId');
+      }
+    });
+
+    test('should create OrcaRouter models without provider options', () => {
+      // OrcaRouter can route to ANY model via its OpenAI-compatible gateway
+      const customModels = [
+        'orcarouter/auto',
+        'orcarouter/fusion',
+        'orcarouter/fusion-flash',
+        'orcarouter/fusion-mini',
       ];
 
       for (const modelString of customModels) {

--- a/agents-docs/content/typescript-sdk/models.mdx
+++ b/agents-docs/content/typescript-sdk/models.mdx
@@ -75,6 +75,7 @@ Each model type inherits independently through the project → agent → sub age
 | **OpenRouter** | `openrouter/anthropic/claude-sonnet-4-0`<br/>`openrouter/meta-llama/llama-3.1-405b` | `OPENROUTER_API_KEY` |
 | **Gateway** | `gateway/openai/gpt-4.1-mini` | `AI_GATEWAY_API_KEY` |
 | **NVIDIA NIM** | `nim/nvidia/llama-3.3-nemotron-super-49b-v1.5`<br/>`nim/nvidia/nemotron-4-340b-instruct` | `NIM_API_KEY` |
+| **OrcaRouter** | `orcarouter/auto`<br/>`orcarouter/fusion`<br/>`orcarouter/fusion-flash`<br/>`orcarouter/fusion-mini` | `ORCAROUTER_API_KEY` |
 | **Custom OpenAI-compatible** | `custom/my-custom-model`<br/>`custom/llama-3-custom` | `CUSTOM_LLM_API_KEY` |
 | **Mock** | `mock/default` | None required |
 

--- a/agents-manage-ui/src/components/agent/sidepane/nodes/model-selector.tsx
+++ b/agents-manage-ui/src/components/agent/sidepane/nodes/model-selector.tsx
@@ -57,7 +57,7 @@ export const ModelSelector: FC<ModelSelectorProps> = ({
   const [open, setOpen] = useState(defaultOpen);
 
   const [showCustomInput, setShowCustomInput] = useState<
-    'openrouter' | 'gateway' | 'nim' | 'custom' | 'azure' | null
+    'openrouter' | 'gateway' | 'nim' | 'orcarouter' | 'custom' | 'azure' | null
   >(null);
   const [azureDeploymentName, setAzureDeploymentName] = useState('');
   const [azureResourceName, setAzureResourceName] = useState('');
@@ -89,6 +89,10 @@ export const ModelSelector: FC<ModelSelectorProps> = ({
     if (value.startsWith('nim/')) {
       const modelName = value.replace('nim/', '');
       return { value, label: modelName, prefix: 'nim/' };
+    }
+    if (value.startsWith('orcarouter/')) {
+      const modelName = value.replace('orcarouter/', '');
+      return { value, label: modelName, prefix: 'orcarouter/' };
     }
     if (value.startsWith('custom/')) {
       const modelName = value.replace('custom/', '');
@@ -203,6 +207,7 @@ export const ModelSelector: FC<ModelSelectorProps> = ({
                               !modelValue.startsWith('openrouter/') &&
                               !modelValue.startsWith('gateway/') &&
                               !modelValue.startsWith('nim/') &&
+                              !modelValue.startsWith('orcarouter/') &&
                               !modelValue.startsWith('custom/')
                             ) {
                               // Could be openrouter format, let user decide or add logic here
@@ -312,6 +317,18 @@ export const ModelSelector: FC<ModelSelectorProps> = ({
                   </CommandItem>
                   <CommandItem
                     className="flex items-center justify-between cursor-pointer text-foreground"
+                    value="__orcarouter__"
+                    onSelect={() => {
+                      setShowCustomInput('orcarouter');
+                      setOpen(false);
+                      setCustomModelInput('');
+                      onValueChange('orcarouter/...');
+                    }}
+                  >
+                    OrcaRouter ...
+                  </CommandItem>
+                  <CommandItem
+                    className="flex items-center justify-between cursor-pointer text-foreground"
                     value="__azure__"
                     onSelect={() => {
                       setShowCustomInput('azure');
@@ -338,6 +355,7 @@ export const ModelSelector: FC<ModelSelectorProps> = ({
               openrouter: 'OpenRouter Model ID',
               gateway: 'Vercel AI Gateway Model ID',
               nim: 'NVIDIA NIM Model ID',
+              orcarouter: 'OrcaRouter Model ID',
               custom: '',
             }[showCustomInput] || 'Custom Model ID'}
           </div>
@@ -347,6 +365,7 @@ export const ModelSelector: FC<ModelSelectorProps> = ({
                 'Examples: anthropic/claude-3-5-sonnet, meta-llama/llama-3.1-405b-instruct',
               gateway: 'Examples: openai/gpt-4o, anthropic/claude-3-5-sonnet',
               nim: 'Examples: nvidia/llama-3.3-nemotron-super-49b-v1.5, nvidia/nemotron-4-340b-instruct',
+              orcarouter: 'Examples: auto, fusion, fusion-flash, fusion-mini',
               custom: '',
             }[showCustomInput] || 'Examples: my-custom-model, llama-3-custom, custom-finetuned'}
           </div>
@@ -357,6 +376,7 @@ export const ModelSelector: FC<ModelSelectorProps> = ({
                   openrouter: 'anthropic/claude-3-5-sonnet',
                   gateway: 'openai/gpt-4o',
                   nim: 'nvidia/llama-3.3-nemotron-super-49b-v1.5',
+                  orcarouter: 'auto',
                   custom: '',
                 }[showCustomInput] || 'my-custom-model'
               }
@@ -371,7 +391,9 @@ export const ModelSelector: FC<ModelSelectorProps> = ({
                         ? 'gateway/'
                         : showCustomInput === 'nim'
                           ? 'nim/'
-                          : 'custom/';
+                          : showCustomInput === 'orcarouter'
+                            ? 'orcarouter/'
+                            : 'custom/';
                   onValueChange(`${prefix}${customModelInput.trim()}`);
                   setShowCustomInput(null);
                   setCustomModelInput('');
@@ -394,7 +416,9 @@ export const ModelSelector: FC<ModelSelectorProps> = ({
                         ? 'gateway/'
                         : showCustomInput === 'nim'
                           ? 'nim/'
-                          : 'custom/';
+                          : showCustomInput === 'orcarouter'
+                            ? 'orcarouter/'
+                            : 'custom/';
                   onValueChange(`${prefix}${customModelInput.trim()}`);
                   setShowCustomInput(null);
                   setCustomModelInput('');

--- a/packages/agents-core/src/__tests__/utils/model-factory.test.ts
+++ b/packages/agents-core/src/__tests__/utils/model-factory.test.ts
@@ -16,6 +16,7 @@ describe('ModelFactory', () => {
     delete process.env.AZURE_OPENAI_API_KEY;
     delete process.env.CUSTOM_LLM_API_KEY;
     delete process.env.NIM_API_KEY;
+    delete process.env.ORCAROUTER_API_KEY;
   });
 
   describe('parseModelString', () => {
@@ -72,6 +73,14 @@ describe('ModelFactory', () => {
       expect(result).toEqual({
         provider: 'nim',
         modelName: 'nvidia/llama-3.3-nemotron',
+      });
+    });
+
+    test('should parse orcarouter model string', () => {
+      const result = ModelFactory.parseModelString('orcarouter/auto');
+      expect(result).toEqual({
+        provider: 'orcarouter',
+        modelName: 'auto',
       });
     });
 

--- a/packages/agents-core/src/utils/model-factory.ts
+++ b/packages/agents-core/src/utils/model-factory.ts
@@ -27,6 +27,15 @@ const nimDefault = createOpenAICompatible({
   },
 });
 
+// OrcaRouter default provider instance
+const orcarouterDefault = createOpenAICompatible({
+  name: 'orcarouter',
+  baseURL: 'https://api.orcarouter.ai/v1',
+  headers: {
+    Authorization: `Bearer ${process.env.ORCAROUTER_API_KEY}`,
+  },
+});
+
 /**
  * Factory for creating AI SDK language models from configuration
  * Supports multiple providers and AI Gateway integration
@@ -77,6 +86,17 @@ export class ModelFactory {
           ...config,
         };
         return createOpenAICompatible(nimConfig);
+      }
+      case 'orcarouter': {
+        const orcarouterConfig = {
+          name: 'orcarouter',
+          baseURL: 'https://api.orcarouter.ai/v1',
+          headers: {
+            Authorization: `Bearer ${process.env.ORCAROUTER_API_KEY}`,
+          },
+          ...config,
+        };
+        return createOpenAICompatible(orcarouterConfig);
       }
       case 'custom': {
         if (!config.baseURL && !config.baseUrl) {
@@ -261,6 +281,9 @@ export class ModelFactory {
         case 'nim':
           model = nimDefault(modelName);
           break;
+        case 'orcarouter':
+          model = orcarouterDefault(`orcarouter/${modelName}`);
+          break;
         case 'mock':
           return createMockModel(modelName) as unknown as LanguageModel;
         case 'custom':
@@ -271,7 +294,7 @@ export class ModelFactory {
           throw new Error(
             `Unsupported provider: ${provider}. ` +
               `Supported providers are: ${ModelFactory.BUILT_IN_PROVIDERS.join(', ')}. ` +
-              `To access other models, use OpenRouter (openrouter/model-id), Vercel AI Gateway (gateway/model-id), NVIDIA NIM (nim/model-id), or Custom OpenAI-compatible (custom/model-id).`
+              `To access other models, use OpenRouter (openrouter/model-id), Vercel AI Gateway (gateway/model-id), NVIDIA NIM (nim/model-id), OrcaRouter (orcarouter/model-id), or Custom OpenAI-compatible (custom/model-id).`
           );
       }
     }
@@ -293,6 +316,7 @@ export class ModelFactory {
     'openrouter',
     'gateway',
     'nim',
+    'orcarouter',
     'custom',
     'mock',
   ] as const;
@@ -312,7 +336,7 @@ export class ModelFactory {
         throw new Error(
           `Unsupported provider: ${normalizedProvider}. ` +
             `Supported providers are: ${ModelFactory.BUILT_IN_PROVIDERS.join(', ')}. ` +
-            `To access other models, use OpenRouter (openrouter/model-id), Vercel AI Gateway (gateway/model-id), NVIDIA NIM (nim/model-id), or Custom OpenAI-compatible (custom/model-id).`
+            `To access other models, use OpenRouter (openrouter/model-id), Vercel AI Gateway (gateway/model-id), NVIDIA NIM (nim/model-id), OrcaRouter (orcarouter/model-id), or Custom OpenAI-compatible (custom/model-id).`
         );
       }
 


### PR DESCRIPTION
## Summary

Adds **[OrcaRouter](https://www.orcarouter.ai)** as a first-class named model provider, alongside the existing `nim`, `openrouter`, and `custom` OpenAI-compatible providers.

Use the `orcarouter/` prefix (e.g. `orcarouter/auto`, `orcarouter/fusion`) to route through the OrcaRouter gateway — a smart routing gateway that fronts many upstream model providers behind one OpenAI-compatible endpoint. Implemented by mirroring the existing `nim` provider pattern exactly (a named `createOpenAICompatible` default instance + a configurable case), so it is additive and low-risk.

It also runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.

## Changes

- `packages/agents-core/src/utils/model-factory.ts` — new `orcarouterDefault` provider instance (`https://api.orcarouter.ai/v1`); `orcarouter` case in `createProvider` and in the default-instance switch; `orcarouter` added to `BUILT_IN_PROVIDERS`; provider-enumeration error messages updated.
- `packages/agents-core/src/__tests__/utils/model-factory.test.ts` — `parseModelString` coverage for `orcarouter/`.
- `agents-api/src/__tests__/run/agents/ModelFactory.test.ts` — parse + create coverage for OrcaRouter gateway models.
- `agents-manage-ui/src/components/agent/sidepane/nodes/model-selector.tsx` — OrcaRouter entry in the model picker (prefix display, selector item, labels/placeholder, prefix handling).
- `agents-docs/content/typescript-sdk/models.mdx` — provider table row.
- `.env.example` — `ORCAROUTER_API_KEY`.
- `.changeset/fine-gold-cougar.md` — patch changeset for `@inkeep/agents-core` and `@inkeep/agents-manage-ui`.

## Tests

**1. Unit tests**

`agents-core`:
```
 ✓ packages/agents-core/src/__tests__/utils/model-factory.test.ts (49 tests)
 ✓ src/utils/__tests__/usage-cost-middleware.test.ts (60 tests)
```

`agents-api`:
```
 ✓ src/__tests__/run/agents/ModelFactory.test.ts (69 tests)
```

**2. Format + lint (Biome)** — clean on all changed files, root `format:check` (2655 files) clean.

**3. Typecheck** — `@inkeep/agents-core` and `@inkeep/agents-manage-ui` both pass `tsc --noEmit`.

**4. Live end-to-end against OrcaRouter**

Driven through `ModelFactory.createModel('orcarouter/...')` using the AI SDK's `generateText` with a live gateway key:

```
OK  orcarouter/auto -> modelId=orcarouter/auto provider=orcarouter.chat text="ORCA-LIVE-OK"
OK  orcarouter/fusion -> modelId=orcarouter/fusion provider=orcarouter.chat text="ORCA-LIVE-OK"
OK  orcarouter/fusion-flash -> modelId=orcarouter/fusion-flash provider=orcarouter.chat text="ORCA-LIVE-OK"
```

## Risk / compatibility

- Additive only. No existing provider behavior changes.
- Same shape as the existing `nim` named OpenAI-compatible provider.
- No new dependencies (`@ai-sdk/openai-compatible` is already used by `nim`/`custom`).

Disclosure: I'm an engineer on the OrcaRouter team.
